### PR TITLE
Add Size Support to `IconButton`

### DIFF
--- a/packages/react-ui/src/Navigation/IconButton.stories.tsx
+++ b/packages/react-ui/src/Navigation/IconButton.stories.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+// also exported from '@storybook/react' if you can deal with breaking changes in 6.1
+import { Story, Meta } from '@storybook/react/types-6-0'
+import { IconButton, IconButtonProps } from './IconButton'
+import { faHomeLgAlt } from '@fortawesome/pro-duotone-svg-icons'
+
+export default {
+  title: 'IconButton',
+  component: IconButton,
+} as Meta
+
+const Template: Story<IconButtonProps> = (args) => <IconButton {...args} />
+
+const args: IconButtonProps = {
+  className: '',
+  icon: faHomeLgAlt,
+  ariaLabel: 'Home',
+}
+
+export const Standard = Template.bind({})
+Standard.args = args
+
+export const ExtraSmall = Template.bind({})
+ExtraSmall.args = { ...args, size: 'text-xs' }
+
+export const Small = Template.bind({})
+Small.args = { ...args, size: 'text-sm' }
+
+export const Medium = Template.bind({})
+Medium.args = { ...args, size: 'text-md' }
+
+export const Large = Template.bind({})
+Large.args = { ...args, size: 'text-lg' }
+
+export const XL = Template.bind({})
+XL.args = { ...args, size: 'text-xl' }
+
+export const TwoXL = Template.bind({})
+TwoXL.args = { ...args, size: 'text-2xl' }

--- a/packages/react-ui/src/Navigation/IconButton.test.tsx
+++ b/packages/react-ui/src/Navigation/IconButton.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { IconButton } from './IconButton'
+import { faHome } from '@fortawesome/pro-regular-svg-icons'
+
+test('should support disabled state', async () => {
+  render(<IconButton ariaLabel="home" icon={faHome} disabled />)
+  expect(screen.getByLabelText(/home/i)).toHaveClass('pointer-events-none')
+})
+
+test('should be large by default', async () => {
+  render(<IconButton ariaLabel="home" icon={faHome} />)
+  expect(screen.getByLabelText(/home/i)).toHaveClass('text-lg')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('h-10')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('w-10')
+})
+
+test('should adjust for text-xs', async () => {
+  render(<IconButton ariaLabel="home" icon={faHome} size="text-xs" />)
+  expect(screen.getByLabelText(/home/i)).toHaveClass('text-xs')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('h-7')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('w-7')
+})
+
+test('should adjust for text-sm', async () => {
+  render(<IconButton ariaLabel="home" icon={faHome} size="text-sm" />)
+  expect(screen.getByLabelText(/home/i)).toHaveClass('text-sm')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('h-8')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('w-8')
+})
+
+test('should adjust for text-md', async () => {
+  render(<IconButton ariaLabel="home" icon={faHome} size="text-md" />)
+  expect(screen.getByLabelText(/home/i)).toHaveClass('text-md')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('h-9')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('w-9')
+})
+
+test('should adjust for text-xl', async () => {
+  render(<IconButton ariaLabel="home" icon={faHome} size="text-xl" />)
+  expect(screen.getByLabelText(/home/i)).toHaveClass('text-xl')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('h-11')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('w-11')
+})
+
+test('should adjust for text-2xl', async () => {
+  render(<IconButton ariaLabel="home" icon={faHome} size="text-2xl" />)
+  expect(screen.getByLabelText(/home/i)).toHaveClass('text-2xl')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('h-12')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('w-12')
+})
+
+test('should adjust for text-3xl', async () => {
+  render(<IconButton ariaLabel="home" icon={faHome} size="text-3xl" />)
+  expect(screen.getByLabelText(/home/i)).toHaveClass('text-3xl')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('h-14')
+  expect(screen.getByLabelText(/home/i)).toHaveClass('w-14')
+})

--- a/packages/react-ui/src/Navigation/IconButton.tsx
+++ b/packages/react-ui/src/Navigation/IconButton.tsx
@@ -33,7 +33,7 @@ export interface IconButtonProps {
 }
 
 const style = {
-  button: 'rounded-full w-10 h-10 flex-shrink-0 leading-none',
+  button: 'rounded-full flex-shrink-0 leading-none',
   buttonHover: 'hover:bg-primary-600 hover:bg-opacity-10',
   inactive: 'opacity-50',
   disabled: 'opacity-25 pointer-events-none',
@@ -82,6 +82,13 @@ export const IconButton: React.FC<IconButtonProps> = ({
         (className ?? '').indexOf('hover:bg') < 0 && style.buttonHover,
         !noPadding && 'p-2',
         size,
+        size === 'text-xs' && 'h-7 w-7',
+        size === 'text-sm' && 'h-8 w-8',
+        size === 'text-md' && 'h-9 w-9',
+        size === 'text-lg' && 'h-10 w-10',
+        size === 'text-xl' && 'h-11 w-11',
+        size === 'text-2xl' && 'h-12 w-12',
+        size === 'text-3xl' && 'h-14 w-14',
         className,
         disabled && !inactive && style.disabled,
         inactive && style.inactive,


### PR DESCRIPTION
The `IconButton` size can now be adjusted by setting the `size` attribute to any tailwind text size class i.e. `text-xl` or `text-md`. Defaults to `text-lg`.