### PR TITLE
Change selected state to selectedIndex prop on Table component

### DIFF
--- a/packages/react-ui/src/Data/Table.stories.tsx
+++ b/packages/react-ui/src/Data/Table.stories.tsx
@@ -223,6 +223,7 @@ export const Sortable = Template.bind({})
 Sortable.args = {
   ...args,
   scrollable: true,
+  selectedIndex: 0,
   onSelectRow: (index) => {
     console.log(index)
   },

--- a/packages/react-ui/src/Data/Table.test.tsx
+++ b/packages/react-ui/src/Data/Table.test.tsx
@@ -214,3 +214,21 @@ test('should display sort up icon in header cell when sort direction is descendi
 
   expect(screen.queryByLabelText('sort down icon')).toBeInTheDocument()
 })
+
+test('should style selected row with blue background', async () => {
+  render(
+    <Table
+      {...props}
+      onSelectRow={() => {
+        console.log('selected')
+      }}
+      selectedIndex={0}
+    />
+  )
+
+  const selectedRow = screen.queryAllByLabelText(/table row/i)[0]
+  const unselectedRow = screen.queryAllByLabelText(/table row/i)[1]
+
+  expect(selectedRow).toHaveClass('bg-sky-200/70')
+  expect(unselectedRow).not.toHaveClass('bg-sky-200/70')
+})

--- a/packages/react-ui/src/Data/Table.tsx
+++ b/packages/react-ui/src/Data/Table.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import clsx from 'clsx'
 import { TableHeader, TableHeaderProps } from './TableHeader'
 import { TableRow, TableRowProps } from './TableRow'
@@ -11,6 +11,7 @@ export interface TableProps {
   highlightedStyle?: string
   stackable?: boolean
   scrollable?: boolean
+  selectedIndex?: number | null
   onSelectRow?: (index: number) => void
 }
 
@@ -42,14 +43,12 @@ export const Table: React.FC<TableProps> = ({
   stackable,
   scrollable,
   onSelectRow,
+  selectedIndex,
 }) => {
   // dynamically calculate grid columns
   const colsInRow = rows[0]?.cells.length | 0
 
-  const [selected, setSelected] = useState<number | null>(null)
-
   const handleSelectRow = (index: number) => {
-    setSelected(index)
     onSelectRow?.(index)
   }
 
@@ -85,13 +84,14 @@ export const Table: React.FC<TableProps> = ({
                 gridClassNames[colsInRow],
                 !onSelectRow && 'gap-4',
                 onSelectRow &&
-                  (selected === index ? 'bg-sky-200/70' : 'hover:bg-sky-50'),
+                  (selectedIndex === index
+                    ? 'bg-sky-200/70'
+                    : 'hover:bg-sky-50'),
                 index !== 0 && styles.borderTop
               )}
               {...row}
               scrollable={scrollable}
               highlightedStyle={highlightedStyle}
-              aria-label="table row"
               onSelect={onSelectRow ? () => handleSelectRow(index) : null}
             />
           ))}

--- a/packages/react-ui/src/Data/TableRow.tsx
+++ b/packages/react-ui/src/Data/TableRow.tsx
@@ -34,7 +34,7 @@ export const TableRow: React.FC<TableRowProps> = ({
   onSelect,
 }) => {
   return (
-    <tr className={clsx(styles.container, className)}>
+    <tr className={clsx(styles.container, className)} aria-label={'table row'}>
       {cells.map((cell, index) => (
         <td className={styles.cell} key={`${cell.label}${index}`}>
           {onSelect ? (


### PR DESCRIPTION
Closes #80 
Changing selected row indicator from component level state to a prop for Table to simplify persistence during content sorting.