### PR TITLE
Add Session Based Vehicle Tracking

### DIFF
--- a/apps/lrauv-dash2/components/VehicleDeploymentDropdown.tsx
+++ b/apps/lrauv-dash2/components/VehicleDeploymentDropdown.tsx
@@ -5,6 +5,7 @@ import {
   DropdownProps,
 } from '@mbari/react-ui'
 import { useSortedVehicleNames, useLastDeployment } from '@mbari/api-client'
+import useTrackedVehicles from '../lib/useTrackedVehicles'
 
 const LastDeploymentOption: React.FC<{ vehicleName: string }> = ({
   vehicleName,
@@ -28,17 +29,20 @@ const LastDeploymentOption: React.FC<{ vehicleName: string }> = ({
 const VehicleDeploymentDropdown: React.FC<Omit<DropdownProps, 'options'>> = (
   props
 ) => {
+  const { setTrackedVehicles, trackedVehicles } = useTrackedVehicles()
   const vehicleNamesQuery = useSortedVehicleNames({ refresh: 'y' })
   const vehicleNames = vehicleNamesQuery.data ?? []
   return (
     <VehicleDropdown
       {...props}
-      options={vehicleNames.map((name: string) => ({
-        label: <LastDeploymentOption vehicleName={name} key={name} />,
-        onSelect: () => {
-          console.log(name)
-        },
-      }))}
+      options={vehicleNames
+        .filter((n: string) => trackedVehicles.indexOf(n) < 0)
+        .map((name: string) => ({
+          label: <LastDeploymentOption vehicleName={name} key={name} />,
+          onSelect: () => {
+            setTrackedVehicles([...trackedVehicles, name])
+          },
+        }))}
     />
   )
 }

--- a/apps/lrauv-dash2/pages/dashboard.tsx
+++ b/apps/lrauv-dash2/pages/dashboard.tsx
@@ -5,11 +5,14 @@ import useAuthenticatedRedirect from '../lib/useAuthenticatedRedirect'
 import { useAuthContext } from '@mbari/api-client'
 import { useState } from 'react'
 import VehicleDeploymentDropdown from '../components/VehicleDeploymentDropdown'
+import useTrackedVehicles from '../lib/useTrackedVehicles'
 
 const Dashboard: NextPage = () => {
+  const [currentOption, setCurrentOption] = useState<string | null>('Overview')
   useAuthenticatedRedirect({
     redirectTo: '/',
   })
+  const { trackedVehicles } = useTrackedVehicles()
 
   const { logout, profile } = useAuthContext()
   const profileName = `${profile?.firstName} ${profile?.lastName}`
@@ -37,8 +40,9 @@ const Dashboard: NextPage = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <PrimaryToolbar
-        options={['Overview']}
-        currentOption="Overview"
+        options={['Overview', ...trackedVehicles]}
+        currentOption={currentOption ?? ''}
+        onSelectOption={setCurrentOption}
         avatarName={profileName}
         onAvatarClick={handleDropdown('profile')}
         onAddClick={handleDropdown('vehicle')}


### PR DESCRIPTION
Adding vehicles to the primary navigation is now done via the vehicle select dropdown and tracked via browser cookies. closes #89