### PR TITLE
Add Spaces to Scheduled Commands

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -31,7 +31,7 @@ export const parseMissionCommand = (name: string) => {
   const info = name
     .split(' ')
     .filter((s) => !['run', 'sched', 'asap'].includes(s))
-    .join('')
+    .join(' ')
     .split(';')
   return {
     name: info[0],
@@ -207,6 +207,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     const mission = results[index + indexOffset]
     const { name: missionName, parameters: missionParams } =
       parseMissionCommand(mission?.event.data ?? '')
+    console.log(missionName, missionParams)
     return mission ? (
       <ScheduleCell
         label={missionName ?? 'Unknown'}


### PR DESCRIPTION
Fix typo that prevented spaces from appearing in mission / commands in the schedule.