### PR TITLE
Remove Unused Listener Hook

### DIFF
--- a/apps/lrauv-dash2/lib/useWebSocketListeners.ts
+++ b/apps/lrauv-dash2/lib/useWebSocketListeners.ts
@@ -14,28 +14,6 @@ export const SUPPORTED_EVENT_TYPES: SubscriptionEventType[] = [
   'presence',
 ]
 
-export const useWebsocketListeners = () => {
-  const { token, profile } = useTethysApiContext()
-  const webSocketUrl = process.env.NEXT_PUBLIC_WEBSOCKET_URL as string
-
-  const [data, setData] = useState({})
-  const [ws, setWS] = useState<WebSocket | null>(null)
-  useEffect(() => {
-    if (webSocketUrl.length === 0 || ws || !token || !profile) {
-      return
-    }
-    const url = `${webSocketUrl}/${token}?tduiv=4.30.1&aem=${profile?.email}`
-    console.log('Opening websocket url at: ', url)
-    const newWS = new WebSocket(url)
-    newWS.onerror = (err) => console.error(err)
-    newWS.onopen = () => setWS(newWS)
-    newWS.onmessage = (msg) => setData(JSON.parse(msg.data))
-  }, [webSocketUrl, ws, setWS, setData, token, profile])
-
-  console.log('data', data)
-  return data
-}
-
 export interface TethysSubscriptionEvent {
   eventName?: string
   vehicleName?: string


### PR DESCRIPTION
Removed unused hook to register websocket listeners which simply stored output in local state as opposed to updating the react-query cache.