### PR TITLE
Resolve Issue 246 - Command Not Constructed

### DIFF
--- a/packages/react-ui/src/Modals/CommandModal.sampleProps.tsx
+++ b/packages/react-ui/src/Modals/CommandModal.sampleProps.tsx
@@ -1,0 +1,139 @@
+import { CommandModalProps } from './CommandModal'
+
+export const syntaxVariations: CommandModalProps['syntaxVariations'] = [
+  { argList: [], help: 'List all failed components' },
+  {
+    argList: [
+      { argType: 'ARG_KEYWORD', keyword: 'show', required: 'REQUIRED' },
+      { argType: 'ARG_COMPONENT', required: 'REQUIRED' },
+    ],
+    help: 'Show failure state of one component',
+  },
+  {
+    argList: [
+      { argType: 'ARG_KEYWORD', keyword: 'none', required: 'REQUIRED' },
+      { argType: 'ARG_COMPONENT', required: 'REQUIRED' },
+    ],
+    help: 'Clear failure state of one component',
+  },
+  {
+    argList: [
+      { argType: 'ARG_KEYWORD', keyword: 'hardware', required: 'REQUIRED' },
+      { argType: 'ARG_COMPONENT', required: 'REQUIRED' },
+    ],
+    help: "Set failure state of one component to 'Hardware Failure'",
+  },
+  {
+    argList: [
+      { argType: 'ARG_KEYWORD', keyword: 'software', required: 'REQUIRED' },
+      { argType: 'ARG_COMPONENT', required: 'REQUIRED' },
+    ],
+    help: "Set failure state of one component to 'Software Failure'",
+  },
+  {
+    argList: [
+      { argType: 'ARG_KEYWORD', keyword: 'segfault', required: 'REQUIRED' },
+      { argType: 'ARG_COMPONENT', required: 'REQUIRED' },
+    ],
+    help: 'Create component software failure via an actual segfault',
+  },
+]
+
+export const commands: CommandModalProps['commands'] = [
+  { id: '?', name: '?', description: 'Show help' },
+  {
+    id: '!',
+    name: '!',
+    description:
+      'Bash command with no stdin, stdout routed to syslog IMPORTANT',
+  },
+  {
+    id: 'burn',
+    name: 'burn',
+    description: 'Burn (or stop burning) the burnwire',
+  },
+  {
+    id: 'strobe',
+    name: 'strobe',
+    description: 'Enable (or disable) the strobe',
+  },
+  {
+    id: 'configSet',
+    name: 'configSet',
+    description: 'Set configuration variable value',
+  },
+  {
+    id: 'conversation',
+    name: 'conversation',
+    description: 'Show, start and stop satellite conversations',
+  },
+  {
+    id: 'DDM',
+    name: 'DDM',
+    description: 'Set the docking module state to standby, arm, or detach',
+  },
+  {
+    id: 'DockingServo',
+    name: 'DockingServo',
+    description: 'Set the docking servo state to standby, arm, or detach',
+  },
+  {
+    id: 'failComponent',
+    name: 'failComponent',
+    description: 'Show, set, or clear failed state of components',
+  },
+  {
+    id: 'failVariable',
+    name: 'failVariable',
+    description: 'Show, set, or clear failed state of values',
+  },
+  {
+    id: 'fileExec',
+    name: 'fileExec',
+    description:
+      'Execute contents of file that follows (.sbd or plain text) as if it were sent remotely',
+  },
+  { id: 'get', name: 'get', description: 'Get variable value' },
+  {
+    id: 'gfscan',
+    name: 'gfscan',
+    description: 'Allow CBIT to scan for ground faults',
+  },
+  {
+    id: 'help',
+    name: 'help',
+    description: 'Show help, optionally for a specific command',
+  },
+  { id: 'ibit', name: 'ibit', description: 'Run Initiated Built In Test' },
+  { id: 'load', name: 'load', description: 'Load, but do not run mission' },
+  { id: 'maintain', name: 'maintain', description: 'Maintain variable value' },
+  {
+    id: 'quick',
+    name: 'quick',
+    description: 'Toggle state of quicker than realtime execution',
+  },
+  {
+    id: 'quit',
+    name: 'quit',
+    description: 'Stop any running mission and exit LRAUV program',
+  },
+  { id: 'report', name: 'report', description: 'Report variable value' },
+  {
+    id: 'restart',
+    name: 'restart',
+    description: 'Restart, from least impact (logs) to most impact (system)',
+  },
+  { id: 'resume', name: 'resume', description: 'Resume loaded mission' },
+  { id: 'retransmit', name: 'retransmit', description: 'Retransmit data' },
+  { id: 'run', name: 'run', description: 'Run mission' },
+  {
+    id: 'schedule',
+    name: 'schedule',
+    description: 'Schedule commands for later execution',
+  },
+  { id: 'send', name: 'send', description: 'Send variable value or command' },
+  { id: 'set', name: 'set', description: 'Set variable value' },
+  { id: 'show', name: 'show', description: 'Show information' },
+  { id: 'stop', name: 'stop', description: 'Stop currently running mission' },
+  { id: 'ubat', name: 'ubat', description: 'Enable (or disable) the UBAT' },
+]

--- a/packages/react-ui/src/Modals/CommandModal.stories.tsx
+++ b/packages/react-ui/src/Modals/CommandModal.stories.tsx
@@ -4,6 +4,7 @@ import { Story, Meta } from '@storybook/react/types-6-0'
 import { CommandModal, CommandModalProps } from './CommandModal'
 import { CommandTableProps } from '../Tables/CommandTable'
 import { wait } from '@mbari/utils'
+import { syntaxVariations, commands } from './CommandModal.sampleProps'
 
 export default {
   title: 'Modals/CommandModal',
@@ -21,80 +22,7 @@ const Template: Story<CommandModalProps> = (args) => {
 }
 
 const commandTableArgs: CommandTableProps = {
-  commands: [
-    {
-      id: '1',
-      name: 'restart logs',
-      vehicle: 'Brizo',
-      description: 'Restart, from least impact (logs) to most impact (system)',
-    },
-    {
-      id: '2',
-      name: 'stop',
-      vehicle: 'Tethys',
-      description: 'Stop currently running mission',
-    },
-    {
-      id: '3',
-      name: 'schedule clear; schedule resume',
-      vehicle: 'Tethys',
-      description: 'Schedule commands for later execution',
-    },
-    {
-      id: '4',
-      name: 'restart app',
-      vehicle: 'Tethys',
-      description: 'Restart, from least impact (logs) to most impact (system)',
-    },
-    {
-      id: '5',
-      name: 'configSet CTD_Seabird.loadAtStartup 1 bool persist;',
-      vehicle: 'Brizo',
-      description: 'Set configuration variable value',
-    },
-    {
-      id: '6',
-      name: 'configSet list',
-      vehicle: 'Brizo',
-      description: 'Set configuration variable value',
-    },
-    {
-      id: '7',
-      name: 'strobe off',
-      vehicle: 'Brizo',
-      description: 'Enable (or disable) the strobe',
-    },
-    {
-      id: '8',
-      name: 'ibit',
-      vehicle: 'Brizo',
-      description: 'Run initiated built in test',
-    },
-    {
-      id: '9',
-      name: 'configSet CTD_Seabird.loadAtStartup 1 bool persist;',
-      vehicle: 'Brizo',
-      description: 'Set configuration variable value',
-    },
-    {
-      id: '10',
-      name: 'configSet list',
-      vehicle: 'Brizo',
-      description: 'Set configuration variable value',
-    },
-    {
-      id: '11',
-      name: 'strobe off',
-      vehicle: 'Brizo',
-      description: 'Enable (or disable) the strobe',
-    },
-    {
-      id: '12',
-      name: 'ibit',
-      vehicle: 'Brizo',
-      description: 'Run initiated built in test',
-    },
-  ],
+  commands,
   onSortColumn: (col, isAsc) => {
     console.log(
       `Clicked column number ${col}, which is sorted ${
@@ -108,6 +36,7 @@ const commandTableArgs: CommandTableProps = {
 const args: Omit<CommandModalProps, 'onSubmit'> = {
   steps: ['Command', 'Build', 'Schedule'],
   currentStepIndex: 0,
+  syntaxVariations,
   vehicleName: 'Brizo',
   recentCommands: [
     {
@@ -123,7 +52,7 @@ const args: Omit<CommandModalProps, 'onSubmit'> = {
       name: 'schedule clear; schedule resume',
     },
   ],
-  onSchedule: () => console.log('schedule'),
+  onSchedule: () => undefined,
   onCancel: () => console.log('cancel'),
   ...commandTableArgs,
 }

--- a/packages/react-ui/src/Modals/CommandModal.tsx
+++ b/packages/react-ui/src/Modals/CommandModal.tsx
@@ -175,7 +175,9 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   const [commandText, setCommandText] = useState<string | null>(null)
 
   // Templated Command State
-  const [selectedSyntax, setSelectedSyntax] = useState<string | null>(null)
+  const [selectedSyntax, setSelectedSyntax] = useState<string | null>(
+    syntaxVariations?.[0]?.help ?? null
+  )
   const [selectedParameters, setSelectedParameters] = useState<{
     [key: string]: string
   }>({})

--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
@@ -359,7 +359,8 @@ export const BuildTemplatedCommandStep: React.FC<
     .replace(/\s+/g, ' ')
     .trim()
 
-  const persistedCommand = useRef(argumentAsCommand)
+  // Ensure this is blank on first render so that the side effect below runs.
+  const persistedCommand = useRef('')
   useEffect(() => {
     if (persistedCommand.current === argumentAsCommand) return
     persistedCommand.current = argumentAsCommand


### PR DESCRIPTION
@ksalamy please see this fork. I found that we were not assigning the default selected syntax in the primary component for the  `CommandModal`. Additionally when I initially implemented this component it seemed logical for our team to assign the generated argument for the selected syntax to the ref that tracks changes. This turned out to be the primary cause of this bug because the side effect that listens for changes to the generated command needs to run in order to trigger the necessary state update in the `CommandModal` component which tracks the state for every step of the wizard process.

Also added an additional unit test for the `CommandModal` which should hopefully prevent any regression from this happening in the future. This new complete test can be duplicated in case future edge case bugs are identified in the wizard workflow.