### PR TITLE
GH-281: Allow Pilots to Toggle Realtime vs Historic Logs

### DIFF
--- a/apps/lrauv-dash2/components/CommsSection.tsx
+++ b/apps/lrauv-dash2/components/CommsSection.tsx
@@ -94,7 +94,6 @@ const CommsSection: React.FC<CommsSectionProps> = ({
           icon={!allLogs ? faFilter : faPersonRunning}
           ariaLabel="download"
           tooltipAlignment="right"
-          tooltipPosition="left"
           tooltip={!allLogs ? 'Historic Logs' : 'Realtime'}
           className="my-auto"
           onClick={toggleAllLogs}

--- a/apps/lrauv-dash2/components/CommsSection.tsx
+++ b/apps/lrauv-dash2/components/CommsSection.tsx
@@ -1,6 +1,16 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useEvents } from '@mbari/api-client'
-import { AccordionCells, Virtualizer, CommsCell } from '@mbari/react-ui'
+import {
+  AccordionCells,
+  Virtualizer,
+  CommsCell,
+  IconButton,
+} from '@mbari/react-ui'
+import {
+  faFilter,
+  faPersonRunning,
+  faSync,
+} from '@fortawesome/pro-regular-svg-icons'
 import { DateTime } from 'luxon'
 import { useLastCommsTime } from '../lib/useLastCommsTime'
 
@@ -17,11 +27,16 @@ const CommsSection: React.FC<CommsSectionProps> = ({
   from,
   to,
 }) => {
-  const { data, isLoading, isFetching } = useEvents({
+  const [allLogs, setAllLogs] = useState(false)
+  const toggleAllLogs = () => {
+    setAllLogs((prev) => !prev)
+  }
+
+  const { data, isLoading, isFetching, refetch } = useEvents({
     vehicles: [vehicleName],
     eventTypes: ['command', 'run'],
-    from: '',
-    to: '',
+    from: allLogs ? DateTime.now().minus({ years: 2 }).toISODate() : from,
+    to: allLogs ? undefined : to,
   })
   const lastCommsMillis = useLastCommsTime(
     vehicleName,
@@ -59,12 +74,38 @@ const CommsSection: React.FC<CommsSectionProps> = ({
     )
   }
 
+  const handleRefresh = () => {
+    refetch()
+  }
+
   return (
-    <AccordionCells
-      cellAtIndex={cellAtIndex}
-      count={data?.length}
-      loading={isLoading || isFetching}
-    />
+    <>
+      <header className="flex justify-end p-2">
+        <IconButton
+          icon={faSync}
+          ariaLabel="reload"
+          tooltipAlignment="right"
+          tooltip="Reload"
+          className="my-auto"
+          disabled={isLoading || isFetching}
+          onClick={handleRefresh}
+        />
+        <IconButton
+          icon={!allLogs ? faFilter : faPersonRunning}
+          ariaLabel="download"
+          tooltipAlignment="right"
+          tooltipPosition="left"
+          tooltip={!allLogs ? 'Historic Logs' : 'Realtime'}
+          className="my-auto"
+          onClick={toggleAllLogs}
+        />
+      </header>
+      <AccordionCells
+        cellAtIndex={cellAtIndex}
+        count={data?.length}
+        loading={isLoading || isFetching}
+      />
+    </>
   )
 }
 

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -14,7 +14,11 @@ import formatEvent, {
   eventFilters,
   isUploadEvent,
 } from '../lib/formatEvent'
-import { faSync } from '@fortawesome/pro-regular-svg-icons'
+import {
+  faSync,
+  faFilter,
+  faPersonRunning,
+} from '@fortawesome/pro-regular-svg-icons'
 import { SelectOption } from '@mbari/react-ui/dist/Fields/Select'
 
 export interface LogsSectionProps {
@@ -26,6 +30,11 @@ export interface LogsSectionProps {
 }
 
 const LogsSection: React.FC<LogsSectionProps> = ({ vehicleName, from, to }) => {
+  const [allLogs, setAllLogs] = useState(false)
+  const toggleAllLogs = () => {
+    setAllLogs((prev) => !prev)
+  }
+
   const { siteConfig } = useTethysApiContext()
   const [filters, setFilters] = useState<MultiValue<SelectOption>>([])
   const eventTypes = filters.length
@@ -37,8 +46,8 @@ const LogsSection: React.FC<LogsSectionProps> = ({ vehicleName, from, to }) => {
 
   const { data, isLoading, isFetching, refetch } = useEvents({
     vehicles: [vehicleName],
-    from,
-    to,
+    from: allLogs ? DateTime.now().minus({ years: 2 }).toISODate() : from,
+    to: allLogs ? undefined : to,
     eventTypes,
   })
 
@@ -95,6 +104,15 @@ const LogsSection: React.FC<LogsSectionProps> = ({ vehicleName, from, to }) => {
           className="my-auto"
           disabled={isLoading || isFetching}
           onClick={handleRefresh}
+        />
+        <IconButton
+          icon={!allLogs ? faFilter : faPersonRunning}
+          ariaLabel="download"
+          tooltipAlignment="right"
+          tooltipPosition="left"
+          tooltip={!allLogs ? 'Historic Logs' : 'Realtime'}
+          className="my-auto"
+          onClick={toggleAllLogs}
         />
       </header>
       <AccordionCells

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -109,7 +109,6 @@ const LogsSection: React.FC<LogsSectionProps> = ({ vehicleName, from, to }) => {
           icon={!allLogs ? faFilter : faPersonRunning}
           ariaLabel="download"
           tooltipAlignment="right"
-          tooltipPosition="left"
           tooltip={!allLogs ? 'Historic Logs' : 'Realtime'}
           className="my-auto"
           onClick={toggleAllLogs}


### PR DESCRIPTION
@ksalamy this PR will introduce a new UI element to toggle between realtime and filtered logs per the selected deployment. This should retain the existing dash behavior where a pilot can review a historic deployment and see pertinent data whilst allowing pilots to review logs to vehicles that are not currently deployed. This should close #281 
 
![CleanShot 2023-06-02 at 13 28 05](https://github.com/mbari-org/dash5/assets/9150/5fd296e6-004d-4df0-83af-920ccd8c59a3)
