### PR TITLE
Feature: Add Platforms Modal

### DIFF
--- a/apps/lrauv-dash2/components/PlatformSection.tsx
+++ b/apps/lrauv-dash2/components/PlatformSection.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react'
+
+// TODO: Use proper type for items prop.
+export const PlatformSection: React.FC<{ name: string; items: any[] }> = ({
+  name,
+  items,
+}) => {
+  const [open, setOpen] = useState(false)
+  const handleToggle = () => setOpen(!open)
+
+  // TODO: Implement a context provider to track all selected platforms similar to how we do this for paths: in SharedPathContextProvider.tsx
+  const [selectedPlatforms, setSelectedPlatforms] = useState([] as string[])
+
+  return (
+    <>
+      <button className="py-2 text-left font-bold" onClick={handleToggle}>
+        {name}
+      </button>
+      {open && (
+        <ul>
+          {items.map((p) => (
+            <li key={p.name} className="flex items-center py-1">
+              <input
+                type="checkbox"
+                id={p.name}
+                name={p.name}
+                className="mr-2"
+                onChange={() =>
+                  setSelectedPlatforms((prev) => [...prev, p.name])
+                }
+                checked={selectedPlatforms.includes(p.name)}
+              />
+              <label htmlFor={p.name}>
+                {p.name}{' '}
+                <span className="text-sm text-stone-400">
+                  ({p.abbreviation})
+                </span>
+              </label>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  )
+}

--- a/apps/lrauv-dash2/components/PlatformsListModal.tsx
+++ b/apps/lrauv-dash2/components/PlatformsListModal.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { usePlatforms } from '@mbari/api-client'
+import { Modal } from '@mbari/react-ui'
+import { PlatformSection } from './PlatformSection'
+
+export const PlatformsListModal: React.FC<{ onClose: () => void }> = ({
+  onClose,
+}) => {
+  const { data: platforms } = usePlatforms(
+    { refresh: 'true' as any },
+    { baseUrl: process.env.NEXT_PUBLIC_ODSS2BASE_URL }
+  )
+
+  const groups =
+    platforms?.reduce((acc, p) => {
+      const group = acc[p.typeName] ?? []
+      group.push(p)
+      return { ...acc, [p.typeName]: group }
+    }, {} as Record<string, any>) ?? {}
+
+  return (
+    <Modal
+      title={<div className={'text-lg font-bold'}>Platforms</div>}
+      onClose={onClose}
+      draggable
+      open
+    >
+      <ul
+        className="flex flex-col overflow-auto"
+        style={{ height: 300, overflowY: 'auto' }}
+      >
+        {Object.keys(groups)?.map((groupName) => (
+          <li key={groupName}>
+            <PlatformSection name={groupName} items={groups[groupName]} />
+          </li>
+        ))}
+      </ul>
+    </Modal>
+  )
+}

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -50,6 +50,7 @@ export interface MapProps {
   dmsCoord?: string
   mapCoord?: string
   children?: React.ReactNode
+  onRequestPlatforms?: () => React.ReactNode
 }
 
 export type MeasureMode = 'open' | 'measuring' | 'closed' | 'cancelled'
@@ -77,6 +78,7 @@ const Map: React.FC<MapProps> = ({
   children,
   onRequestDepth,
   onRequestCoordinate,
+  onRequestPlatforms,
 }) => {
   const { baseLayer, setBaseLayer } = useMapBaseLayer()
   const addBaseLayerHandler = useCallback(
@@ -475,6 +477,46 @@ const Map: React.FC<MapProps> = ({
             </p>
           </div>
         ) : null}
+
+        <Control position="topleft">
+          <button
+            id="vehicle-center"
+            className="vehicle-center rounded"
+            onMouseOver={handleMouseOver}
+            style={{
+              position: 'relative',
+              zIndex: isHovering ? 900 : 10,
+              border: '0px solid rgba(0,0,0,0.2)',
+              backgroundClip: 'padding-box',
+              width: 42,
+              height: 42,
+            }}
+            onClick={onRequestPlatforms}
+          >
+            <a
+              data-tooltip-id="trackdb"
+              data-tooltip-content="Track Database"
+              data-tooltip-place="bottom-end"
+            >
+              <FontAwesomeIcon icon={faLayerGroup} size="2xl" />
+            </a>
+            <Tooltip
+              id="trackdb"
+              style={{
+                paddingLeft: 4,
+                paddingRight: 4,
+                paddingTop: 2,
+                paddingBottom: 2,
+                backgroundColor: '#D3D3D3',
+                color: '#312e2b',
+                fontWeight: 'normal',
+                fontSize: '14px',
+                width: '240px',
+                height: 'max-content',
+              }}
+            />
+          </button>
+        </Control>
         {measureMode === 'measuring' ? (
           <div
             id="measModeMeasuring"


### PR DESCRIPTION
@ksalamy this is the modal and workflow we started to implement during our meeting today. I added some todos regarding tracking the state of the selected layers which you can simply do via maintaining a state as `string[]` and storing the name of any selected platform layer. However, we should move this state into a context provider as noted in the comments in the newly created component. That way, you can reference the state on the deployment map where you'd need to render the paths related to the selected platforms. Remember -- in this case you'll need to create a new type of path component that is a simplified versions of the `VehiclePath` component we already use. This component would not need any of the special interactivity but would need to be able to request the positions for the selected platform and render the poly line associated to the lat/lngs returned from the API.