### PR TITLE
Fix build errors and React Hook warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'yarn'
+          
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+        
+      - name: Build
+        run: yarn build
+        
+      - name: Lint
+        run: yarn lint

--- a/apps/lrauv-dash2/lib/useGoogleElevator.ts
+++ b/apps/lrauv-dash2/lib/useGoogleElevator.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef, useMemo } from 'react'
 export const useGoogleElevator = () => {
   const elevator = useMemo(
     () => (!!google ? new google.maps.ElevationService() : null),
-    [google]
+    []
   )
 
   const depthLoading = useRef(false)

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -55,9 +55,9 @@ const CustomMarkerSet: React.FC = () => {
         ...markers,
         { lat, lng, label: `Marker ${markers.length + 1}` },
       ])
-      setMarkerIndex(markerIndex + 1)
+      setMarkerIndex((prevIndex) => prevIndex + 1)
     },
-    [setMarkerIndex, markers, setMarkers]
+    [markers, setMarkers]
   )
   return (
     <>

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -50,7 +50,7 @@ export interface MapProps {
   dmsCoord?: string
   mapCoord?: string
   children?: React.ReactNode
-  onRequestPlatforms?: () => React.ReactNode
+  onRequestPlatforms?: () => void
 }
 
 export type MeasureMode = 'open' | 'measuring' | 'closed' | 'cancelled'


### PR DESCRIPTION
## Summary
- Fix type mismatch in Map.tsx where onRequestPlatforms was returning ReactNode instead of void
- Fix useCallback dependency warning in index.tsx by using a functional update for setMarkerIndex
- Remove unnecessary 'google' dependency from useGoogleElevator.ts useMemo hook

## Test plan
- Verify the build succeeds without any type errors or warnings
- Verify the onRequestPlatforms functionality works correctly on the deployment map
- Verify marker indexing works correctly in the map component

🤖 Generated with [Claude Code](https://claude.ai/code)