### PR TITLE
Incorrect PIC / OnCall displayed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ yarn-error.log*
 .DS_Store
 
 # local env files
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/apps/lrauv-dash2/components/Reassignment.tsx
+++ b/apps/lrauv-dash2/components/Reassignment.tsx
@@ -6,10 +6,12 @@ import {
 import { ReassignmentModal, ReassignmentModalProps } from '@mbari/react-ui'
 import useGlobalModalId from '../lib/useGlobalModalId'
 import { capitalize } from '@mbari/utils'
+import { useQueryClient } from 'react-query'
 
 const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
   vehicleNames,
 }) => {
+  const queryClient = useQueryClient()
   const { data, isLoading } = usePicAndOnCall({
     vehicleName: vehicleNames,
   })
@@ -42,6 +44,8 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
         })
       })
     )
+    queryClient.invalidateQueries(['users', 'picAndOnCall'])
+    queryClient.invalidateQueries(['users', 'role'])
     handleClose()
     return undefined
   }

--- a/apps/lrauv-dash2/components/Reassignment.tsx
+++ b/apps/lrauv-dash2/components/Reassignment.tsx
@@ -22,12 +22,12 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
   const { mutate: assignPicAndOnCall, isLoading: loadingAssignPicAndOnCall } =
     useAssignPicAndOnCall()
   const handleReassignmentSubmit: ReassignmentModalProps['onSubmit'] = async ({
-    vehicleName: selectedVehicles,
+    vehicleNames: selectedVehicles,
     pic,
     onCall,
   }) => {
     await Promise.all(
-      selectedVehicles.map(async (vehicleName) => {
+      selectedVehicles.map(async (vehicleName: string) => {
         await assignPicAndOnCall({
           vehicleName,
           sign: 'in',

--- a/packages/react-ui/src/Forms/ReassignmentForm.tsx
+++ b/packages/react-ui/src/Forms/ReassignmentForm.tsx
@@ -38,13 +38,20 @@ interface Vehicle {
 export type Vehicles = Vehicle[]
 
 export type ReassignmentFormValues = {
-  vehicleName: string[]
+  vehicleNames: string[]
   pic: string
   onCall: string
 }
 
+// checkbox inputs return a string if only one is selected, and an array if multiple are selected, so we need to transform the value to an array
 const schema = yup.object({
-  vehicleName: yup.array().of(yup.string()).required('cannot be blank'),
+  vehicleNames: yup
+    .array()
+    .transform((value, originalValue) => {
+      if (!originalValue) return []
+      return typeof originalValue === 'string' ? [originalValue] : originalValue
+    })
+    .min(1, 'A vehicle must be selected'),
   pic: yup.string().required('cannot be blank'),
   onCall: yup.string().required('cannot be blank'),
 })
@@ -82,7 +89,7 @@ const VehicleField: React.FC<VehicleProps> = ({
           id={`${vehicleName}_${vehicleId}`}
           value={vehicleId}
           data-testid={`input_${vehicleId}`}
-          {...register('vehicleName')}
+          {...register('vehicleNames')}
         />{' '}
         <span className="ml-1 text-lg font-medium">{vehicleName}</span>
       </label>


### PR DESCRIPTION
References #312 

This issue was likely due to a type error caused by native checkbox behavior, where a string is output instead of an array when only one checkbox is selected. This was causing the PIC/OnCall not to be updated properly in some cases. Additionally, the PIC / OnCall was not updating in the UI without refreshing. Both of these issues have been updated.
.env was also added to the gitignore list.