### PR TITLE
Automatically redirect root page to dash page

### DIFF
--- a/apps/lrauv-dash2/next.config.js
+++ b/apps/lrauv-dash2/next.config.js
@@ -7,4 +7,14 @@ const withTM = require('next-transpile-modules')([
 module.exports = withTM({
   basePath: '/dash5',
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/dash5',
+        basePath: false,
+        permanent: true,
+      },
+    ]
+  },
 })

--- a/apps/lrauv-dash2/next.config.js
+++ b/apps/lrauv-dash2/next.config.js
@@ -14,6 +14,13 @@ module.exports = withTM({
         destination: '/dash5',
         basePath: false,
         permanent: true,
+        has: [
+          {
+            type: 'header',
+            key: 'host',
+            value: '^(localhost:3000|localhost:3001)$',
+          },
+        ],
       },
     ]
   },


### PR DESCRIPTION
Going to the root page now redirects to the dash page when working locally instead of giving a 404.

Redirect applied to localhost ports 3000 and 3001.