### PR TITLE
Correct inconsistencies in vehicle summary

### DIFF
--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -23,7 +23,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCheck, faSync } from '@fortawesome/free-solid-svg-icons'
 import { useCookies } from 'react-cookie'
 import useGlobalModalId from '../lib/useGlobalModalId'
-
+import { useTethysSubscriptionEvent } from '../lib/useWebSocketListeners'
 const parsePos = (pos: string | number) => parseFloat(`${pos}`).toFixed(3)
 const calcPosition = (lat?: number | string, long?: number | string) =>
   lat && long ? [parsePos(lat), parsePos(long)].join(', ') : undefined
@@ -78,6 +78,7 @@ const ConnectedVehicleCell: React.FC<{
       enabled: !!name && !!lastDeployment?.lastEvent,
     }
   )
+  const pingEvent = useTethysSubscriptionEvent('VehiclePingResult', name)
 
   // TODO: Remove this demonstations of 'usePlatforms'
   // const { data: platforms } = usePlatforms(
@@ -175,7 +176,9 @@ const ConnectedVehicleCell: React.FC<{
           )}
           lastSatellite={
             vehicle?.text_gpsago.length
-              ? `${vehicle.text_gpsago}, likely on surface`
+              ? `${vehicle.text_gpsago}${
+                  pingEvent?.reachable ? ', likely on surface' : ''
+                }`
               : undefined
           }
           lastCell={

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -121,7 +121,13 @@ const ConnectedVehicleCell: React.FC<{
       missionStartedEvent?.[0]?.unixTime ??
         lastDeployment?.startEvent?.unixTime ??
         0
-    ).toRelative() ?? undefined
+    ).toRelative() ?? ''
+
+  const timeSpanSinceRecovery =
+    DateTime.fromMillis(
+      lastDeployment?.recoverEvent?.unixTime ?? 0
+    ).toRelative() ?? ''
+
   const { setGlobalModalId } = useGlobalModalId()
   const onColorChange = (_: string, _v: string) => {
     setGlobalModalId({ id: 'color', meta: { vehicleName: name, color } })
@@ -143,9 +149,7 @@ const ConnectedVehicleCell: React.FC<{
           headline={
             <div>
               <span className="font-semibold text-purple-600">{status}</span>{' '}
-              {lastDeployment?.lastEvent
-                ? DateTime.fromMillis(lastDeployment.lastEvent).toRelative()
-                : ''}
+              {recovered ? timeSpanSinceRecovery : timeSpanSinceDeployment}
             </div>
           }
           headline2={

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -116,6 +116,12 @@ const ConnectedVehicleCell: React.FC<{
   const recovered = lastDeployment?.recoverEvent?.eventId && true
   const active = lastDeployment?.active
 
+  const timeSpanSinceDeployment =
+    DateTime.fromMillis(
+      missionStartedEvent?.[0]?.unixTime ??
+        lastDeployment?.startEvent?.unixTime ??
+        0
+    ).toRelative() ?? undefined
   const { setGlobalModalId } = useGlobalModalId()
   const onColorChange = (_: string, _v: string) => {
     setGlobalModalId({ id: 'color', meta: { vehicleName: name, color } })
@@ -126,15 +132,7 @@ const ConnectedVehicleCell: React.FC<{
         name={capitalize(name)}
         deployment={active ? lastDeployment?.name ?? 'loading' : 'Not Deployed'}
         color={color}
-        deployedAt={
-          active
-            ? Math.round(
-                (missionStartedEvent?.[0]?.unixTime ??
-                  lastDeployment?.startEvent?.unixTime ??
-                  0) / 1000
-              )
-            : undefined
-        }
+        timeSpanSinceDeployment={active ? timeSpanSinceDeployment : undefined}
         onToggle={handleToggle}
         open={isOpen}
         onChangeColor={onColorChange}

--- a/packages/react-ui/src/Navigation/VehicleHeader.stories.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.stories.tsx
@@ -13,13 +13,16 @@ const Template: Story<VehicleHeaderProps> = (args) => (
   <VehicleHeader {...args} />
 )
 
+const timeSpanSinceDeployment =
+  DateTime.now().minus({ days: 3, hours: 4 }).toRelative() ?? undefined
+
 const args: VehicleHeaderProps = {
   name: 'Brizo',
   deployment: 'Brizo 7 Ecohab',
   color: '#00ff00',
   onToggle: () => undefined,
   open: false,
-  deployedAt: DateTime.now().minus({ days: 3, hours: 4 }).toSeconds(),
+  timeSpanSinceDeployment,
 }
 
 export const Standard = Template.bind({})

--- a/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
@@ -10,7 +10,8 @@ const props: VehicleHeaderProps = {
   color: '#00ff00',
   onToggle: () => undefined,
   open: true,
-  deployedAt: DateTime.now().minus({ days: 3, hours: 4 }).toSeconds(),
+  timeSpanSinceDeployment:
+    DateTime.now().minus({ days: 3, hours: 4 }).toRelative() ?? undefined,
 }
 
 test('should render the component', async () => {

--- a/packages/react-ui/src/Navigation/VehicleHeader.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.tsx
@@ -15,7 +15,7 @@ export interface VehicleHeaderProps {
   color: string
   onToggle: () => void
   open?: boolean
-  deployedAt?: number
+  timeSpanSinceDeployment?: string
   onChangeColor?: (color: string, vehicle: string) => void
 }
 
@@ -36,7 +36,7 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
   deployment,
   onToggle,
   open,
-  deployedAt,
+  timeSpanSinceDeployment,
   onChangeColor,
 }) => {
   const handleChangeColor = useCallback(
@@ -82,9 +82,10 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
         <span className={styles.label}>
           {name}: {deployment}
         </span>
-        {deployedAt ? (
+        {timeSpanSinceDeployment ? (
           <span className={styles.secondary}>
-            began {DateTime.fromSeconds(deployedAt).toRelative()}
+            {/* began {DateTime.fromSeconds(deployedAt).toRelative()} */}
+            began {timeSpanSinceDeployment}
           </span>
         ) : null}
         <FontAwesomeIcon

--- a/packages/react-ui/src/Navigation/VehicleHeader.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.tsx
@@ -84,7 +84,6 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
         </span>
         {timeSpanSinceDeployment ? (
           <span className={styles.secondary}>
-            {/* began {DateTime.fromSeconds(deployedAt).toRelative()} */}
             began {timeSpanSinceDeployment}
           </span>
         ) : null}


### PR DESCRIPTION
Updated `likely on surface` indicator to only appear when ping is reachable (best known indicator AFAIK).
Corrected relative time span indicator related to be explicitly tied to current status instead of last event (ie Running for 6 days displays how long it has been running, not time since last event).
Reused that logic to display relative time span since deployment for the `VehicleHeader` component.