### PR TITLE
Add Jest tests for truncate utility

### DIFF
--- a/packages/utils/jest.config.js
+++ b/packages/utils/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts?(x)'],
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+}

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,7 +21,10 @@
     "prebuild": "yarn clean",
     "build": "yarn build:modern",
     "build:modern": "rollup -c ./scripts/rollup/rollup.config.js",
-    "build:esm": "rollup -c ./scripts/rollup/rollup.esm.config.js"
+    "build:esm": "rollup -c ./scripts/rollup/rollup.esm.config.js",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "eslintConfig": {
     "extends": "react-app"
@@ -42,6 +45,7 @@
     "@rollup/plugin-commonjs": "^21.0.2",
     "@rollup/plugin-node-resolve": "^13.1.3",
     "@types/humps": "^2.0.0",
+    "@types/jest": "^27.4.1",
     "@types/node": "12.6.8",
     "@types/react": "^18.0.17",
     "jest": "27.5.1",
@@ -52,6 +56,7 @@
     "rollup-plugin-sourcemaps": "^0.6.2",
     "rollup-plugin-terser": "^7.0.2",
     "rollup-plugin-typescript2": "^0.31.1",
+    "ts-jest": "^27.1.3",
     "typescript": "^4.0.5"
   },
   "dependencies": {

--- a/packages/utils/src/truncate.test.ts
+++ b/packages/utils/src/truncate.test.ts
@@ -1,0 +1,52 @@
+import { truncate } from './truncate'
+
+describe('truncate', () => {
+  it('should return the original string if it is shorter than the max length', () => {
+    const str = 'Hello World'
+    expect(truncate(str, 20)).toBe(str)
+  })
+
+  it('should truncate a string to the specified length', () => {
+    const str = 'This is a very long string that should be truncated'
+    expect(truncate(str, 10)).toBe('This is...')
+  })
+
+  it('should use the default length of 100 if not specified', () => {
+    const str = 'A'.repeat(99)
+    expect(truncate(str)).toBe(str)
+
+    const longStr = 'A'.repeat(110)
+    expect(truncate(longStr)).toBe('A'.repeat(97) + '...')
+  })
+
+  it('should use a custom separator', () => {
+    const str = 'This should be truncated with a custom separator'
+    expect(truncate(str, 15, '***')).toBe('This should ***')
+  })
+
+  it('should handle tail parameter correctly', () => {
+    const str = 'Keep the beginning and the end of this long string'
+    expect(truncate(str, 20, '...', 3)).toBe('Keep the begin...ing')
+  })
+
+  it('should handle null length by returning the original string', () => {
+    const str = 'Original string'
+    // @ts-ignore - Testing the null case mentioned in the function
+    expect(truncate(str, null)).toBe(str)
+  })
+
+  it('should handle edge cases with very short strings and lengths', () => {
+    expect(truncate('abc', 2, '.')).toBe('a.')
+    // When length is 3 and separator is '.', it can still fit the entire string "abc"
+    expect(truncate('abc', 3, '.')).toBe('abc')
+    expect(truncate('abc', 4, '.')).toBe('abc')
+  })
+
+  it('should handle edge cases with tail parameter', () => {
+    const str = 'Beginning and end'
+    // Based on implementation, with tail=10, we'll get "...ng and end"
+    expect(truncate(str, 10, '...', 10)).toBe('...ng and end')
+    expect(truncate(str, 12, '...', 3)).toBe('Beginn...end')
+    expect(truncate(str, 12, '...', 0)).toBe('Beginning...')
+  })
+})


### PR DESCRIPTION
## Summary
- Configure Jest for the utils package
- Add comprehensive test suite for truncate utility function
- Add test scripts to package.json
- Add necessary dependencies (ts-jest, @types/jest)

## Test plan
- Run `yarn workspace @mbari/utils test` to verify all tests pass
- Tests cover various edge cases of the truncate function

🤖 Generated with [Claude Code](https://claude.ai/code)