### PR TITLE
Resolve issues with displaying all logs

### DIFF
--- a/apps/lrauv-dash2/components/CommsSection.tsx
+++ b/apps/lrauv-dash2/components/CommsSection.tsx
@@ -23,6 +23,11 @@ export interface CommsSectionProps {
   to?: number // milliseconds since epoch
 }
 
+const TWO_YEARS_AGO = getAdjustedUnixTime({
+  unixTime: DateTime.now().toMillis(),
+  offsetYears: -2,
+})
+
 const CommsSection: React.FC<CommsSectionProps> = ({
   vehicleName,
   from,
@@ -33,15 +38,10 @@ const CommsSection: React.FC<CommsSectionProps> = ({
     setAllLogs((prev) => !prev)
   }
 
-  const twoYearsAgo = getAdjustedUnixTime({
-    unixTime: DateTime.now().toMillis(),
-    offsetYears: -2,
-  })
-
   const { data, isLoading, isFetching, refetch } = useEvents({
     vehicles: [vehicleName],
     eventTypes: ['command', 'run'],
-    from: allLogs ? twoYearsAgo : from,
+    from: allLogs ? TWO_YEARS_AGO : from, // TODO: implement pagination to get all logs
     to: allLogs ? undefined : to,
   })
   const lastCommsMillis = useLastCommsTime(vehicleName, from)

--- a/apps/lrauv-dash2/components/DeploymentDetails.tsx
+++ b/apps/lrauv-dash2/components/DeploymentDetails.tsx
@@ -7,7 +7,7 @@ import {
 import {
   DeploymentDetailsPopUp,
   EventType,
-  DeploymentDetails,
+  DeploymentDetails as DeploymentDetailsType,
 } from '@mbari/react-ui'
 import { DateTime } from 'luxon'
 import useCurrentDeployment from '../lib/useCurrentDeployment'
@@ -69,7 +69,7 @@ const DeploymentDetails: React.FC<{
     endDate,
     launchDate,
     recoverDate,
-  }: DeploymentDetails) => {
+  }: DeploymentDetailsType) => {
     if (deployment?.deploymentId) {
       updateDeployment({
         deploymentId: deployment.deploymentId as number,

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -59,6 +59,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({ vehicleName, from, to }) => {
       eventTypes,
       from: allLogs ? TWO_YEARS_AGO : from, // TODO: implement pagination to get all logs
       to: allLogs ? undefined : to,
+      limit: 10000, // this limit affects chunk size, not the total number of logs returned
     }),
     [vehicleName, allLogs, from, to, eventTypes]
   )

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { useEvents, useTethysApiContext } from '@mbari/api-client'
 import {
   Virtualizer,
@@ -30,6 +30,11 @@ export interface LogsSectionProps {
   to?: number
 }
 
+const TWO_YEARS_AGO = getAdjustedUnixTime({
+  unixTime: DateTime.now().toMillis(),
+  offsetYears: -2,
+})
+
 const LogsSection: React.FC<LogsSectionProps> = ({ vehicleName, from, to }) => {
   const [allLogs, setAllLogs] = useState(false)
   const toggleAllLogs = () => {
@@ -38,24 +43,27 @@ const LogsSection: React.FC<LogsSectionProps> = ({ vehicleName, from, to }) => {
 
   const { siteConfig } = useTethysApiContext()
   const [filters, setFilters] = useState<MultiValue<SelectOption>>([])
-  const eventTypes = filters.length
-    ? filters
-        .map(({ id }) => eventFilters[id].eventTypes)
-        .flat()
-        .filter((k, i, a) => a.indexOf(k) === i)
-    : undefined
 
-  const twoYearsAgo = getAdjustedUnixTime({
-    unixTime: DateTime.now().toMillis(),
-    offsetYears: -2,
-  })
+  const eventTypes = useMemo(() => {
+    return filters.length
+      ? filters
+          .map(({ id }) => eventFilters[id].eventTypes)
+          .flat()
+          .filter((k, i, a) => a.indexOf(k) === i)
+      : undefined
+  }, [filters])
 
-  const { data, isLoading, isFetching, refetch } = useEvents({
-    vehicles: [vehicleName],
-    from: allLogs ? twoYearsAgo : from,
-    to: allLogs ? undefined : to,
-    eventTypes,
-  })
+  const queryParams = useMemo(
+    () => ({
+      vehicles: [vehicleName],
+      eventTypes,
+      from: allLogs ? TWO_YEARS_AGO : from, // TODO: implement pagination to get all logs
+      to: allLogs ? undefined : to,
+    }),
+    [vehicleName, allLogs, from, to, eventTypes]
+  )
+
+  const { data, isLoading, isFetching, refetch } = useEvents(queryParams)
 
   const cellAtIndex = (index: number, _virtualizer: Virtualizer) => {
     const item = data?.[index]

--- a/packages/api-client/src/react-query/Event/useEvents.ts
+++ b/packages/api-client/src/react-query/Event/useEvents.ts
@@ -1,5 +1,5 @@
 import { useQuery } from 'react-query'
-import { getEvents, GetEventsParams, GetEventsResponse } from '../../axios'
+import { getEvents, GetEventsParams } from '../../axios'
 import { useTethysApiContext } from '../TethysApiProvider'
 import { SupportedQueryOptions } from '../types'
 


### PR DESCRIPTION
Resolved issue where the beginning time range parameter when requesting logs was constantly recalculating in both the logs and comms sections.
Changed chunk size for requesting all logs with recursive calls to then endpoint to 10000 which resolved issues with loading all logs (within the past 2 years).

Note: when requesting events recursively with the 10,000 item chunk size, it was able to load ~170,000 logs in approximately  15 seconds.

References #343
There is more work to be done on this issue, including UI updates and implementing some form of pagination to load logs beyond 2 years ago