### PR TITLE
Update release workflow to handle Next.js config for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,10 @@ jobs:
           echo "NEXT_PUBLIC_WEBSOCKET_URL: $NEXT_PUBLIC_WEBSOCKET_URL"
           echo "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: [REDACTED]"
           
+          # Uncomment the assetPrefix and output lines for production build
+          sed -i 's/\/\/ assetPrefix: '\''\.'\''/'assetPrefix: '\''\.'\''/' apps/lrauv-dash2/next.config.js
+          sed -i 's/\/\/ output: '\''export'\''/'output: '\''export'\''/' apps/lrauv-dash2/next.config.js
+          
           yarn build
       
       - name: Pack output directory


### PR DESCRIPTION
## Summary
- Adds sed commands to CI workflow that automatically uncomment the assetPrefix and output settings in next.config.js before building for production
- Allows the config file to remain in development mode for local builds while ensuring proper static exports in CI

## Test plan
- The current workflow works in development mode with the commented settings
- When this PR is merged, the CI build should uncomment the settings during the release process

🤖 Generated with [Claude Code](https://claude.ai/code)