### PR TITLE
Update release workflow to support branch-based deployments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,8 +192,8 @@ jobs:
         if: needs.determine-environment.outputs.is_production == 'false'
         shell: bash
         run: |
-          if [ -n "${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}" ] && [ -n "${{ secrets.TETHYSDASH2_STAGING_WATCHTOWER_ENDPOINT }}" ]; then
-            curl -H "Authorization: Bearer ${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}" ${{ secrets.TETHYSDASH2_STAGING_WATCHTOWER_ENDPOINT }}
+          if [ -n "${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}" ] && [ -n "${{ secrets.TETHYSDASH2_WATCHTOWER_ENDPOINT }}" ]; then
+            curl -H "Authorization: Bearer ${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}" ${{ secrets.TETHYSDASH2_WATCHTOWER_ENDPOINT }}
             echo "Watchtower update triggered successfully for STAGING"
           else
             echo "Skipping Watchtower update - required secrets not configured"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,52 @@ env:
   NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY || 'placeholder-api-key' }}
 
 jobs:
+  determine-environment:
+    runs-on: ubuntu-latest
+    outputs:
+      env_name: ${{ steps.set-env.outputs.env_name }}
+      is_production: ${{ steps.set-env.outputs.is_production }}
+    steps:
+      - name: Checkout code to determine branch for tag
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Need full history to determine branch for tag
+
+      - name: Determine environment based on tag branch
+        id: set-env
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]]; then
+            # Get the branch where the tag was created
+            TAG_NAME="${{ github.ref_name }}"
+            COMMIT_SHA=$(git rev-list -n 1 $TAG_NAME)
+            
+            # Check if tag is on main branch (production) or develop branch (staging)
+            if git branch --contains $COMMIT_SHA | grep "main"; then
+              echo "Tag is on main branch - PRODUCTION environment"
+              echo "env_name=production" >> $GITHUB_OUTPUT
+              echo "is_production=true" >> $GITHUB_OUTPUT
+            elif git branch --contains $COMMIT_SHA | grep "develop"; then
+              echo "Tag is on develop branch - STAGING environment"
+              echo "env_name=staging" >> $GITHUB_OUTPUT
+              echo "is_production=false" >> $GITHUB_OUTPUT
+            else
+              echo "Tag is on an unknown branch - defaulting to STAGING"
+              echo "env_name=staging" >> $GITHUB_OUTPUT
+              echo "is_production=false" >> $GITHUB_OUTPUT
+            fi
+          elif [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "Release event - PRODUCTION environment"
+            echo "env_name=production" >> $GITHUB_OUTPUT
+            echo "is_production=true" >> $GITHUB_OUTPUT
+          else
+            echo "Manual workflow dispatch - STAGING environment"
+            echo "env_name=staging" >> $GITHUB_OUTPUT
+            echo "is_production=false" >> $GITHUB_OUTPUT
+          fi
+
   build-static:
     runs-on: ubuntu-latest
+    needs: determine-environment
     
     steps:
       - name: Checkout code
@@ -40,6 +84,7 @@ jobs:
           echo "NEXT_PUBLIC_ODSS2BASE_URL: $NEXT_PUBLIC_ODSS2BASE_URL"
           echo "NEXT_PUBLIC_WEBSOCKET_URL: $NEXT_PUBLIC_WEBSOCKET_URL"
           echo "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: [REDACTED]"
+          echo "Building for environment: ${{ needs.determine-environment.outputs.env_name }}"
           
           # Uncomment the assetPrefix and output lines for production build
           sed -i 's/\/\/ assetPrefix: '\''\.'\''/'assetPrefix: '\''\.'\''/' apps/lrauv-dash2/next.config.js
@@ -67,7 +112,7 @@ jobs:
           
   build-docker:
     runs-on: ubuntu-latest
-    needs: build-static
+    needs: [determine-environment, build-static]
     if: success() && (github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v'))
     
     steps:
@@ -115,7 +160,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ needs.determine-environment.outputs.is_production == 'true' }}
+            type=raw,value=${{ needs.determine-environment.outputs.env_name }}
       
       # Build and push Docker image
       - name: Build and push Docker image
@@ -126,14 +172,29 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ENVIRONMENT=${{ needs.determine-environment.outputs.env_name }}
       
-      # Trigger Watchtower to update container
-      - name: Trigger Watchtower to update container
+      # Trigger Watchtower to update container (for production environment)
+      - name: Trigger Watchtower to update production container
+        if: needs.determine-environment.outputs.is_production == 'true'
         shell: bash
         run: |
           if [ -n "${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}" ] && [ -n "${{ secrets.TETHYSDASH2_WATCHTOWER_ENDPOINT }}" ]; then
             curl -H "Authorization: Bearer ${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}" ${{ secrets.TETHYSDASH2_WATCHTOWER_ENDPOINT }}
-            echo "Watchtower update triggered successfully"
+            echo "Watchtower update triggered successfully for PRODUCTION"
+          else
+            echo "Skipping Watchtower update - required secrets not configured"
+          fi
+
+      # Trigger Watchtower to update container (for staging environment)
+      - name: Trigger Watchtower to update staging container
+        if: needs.determine-environment.outputs.is_production == 'false'
+        shell: bash
+        run: |
+          if [ -n "${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}" ] && [ -n "${{ secrets.TETHYSDASH2_STAGING_WATCHTOWER_ENDPOINT }}" ]; then
+            curl -H "Authorization: Bearer ${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}" ${{ secrets.TETHYSDASH2_STAGING_WATCHTOWER_ENDPOINT }}
+            echo "Watchtower update triggered successfully for STAGING"
           else
             echo "Skipping Watchtower update - required secrets not configured"
           fi
@@ -144,7 +205,7 @@ jobs:
         with:
           status: ${{ job.status }}
           channel: '#deployments'
-          message: "Static site deployment for LRAUV Dashboard ${{ github.ref_name }} completed"
+          message: "Static site deployment for LRAUV Dashboard ${{ github.ref_name }} completed for ${{ needs.determine-environment.outputs.env_name }} environment"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: always() # Pick up events even if the job fails or is canceled

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,20 @@
 # Use the official Nginx Alpine image
 FROM nginx:alpine
 
+# Define build argument for environment (defaults to staging)
+ARG ENVIRONMENT=staging
+
+# Set environment label
+LABEL environment=${ENVIRONMENT}
+
 # Copy the static files from the Next.js build
 COPY apps/lrauv-dash2/out /usr/share/nginx/html
 
 # Copy our custom Nginx configuration
 COPY docker/nginx.conf /etc/nginx/conf.d/default.conf
+
+# Create environment indicator file that can be used for health checks or debugging
+RUN echo "DASH5 ${ENVIRONMENT} environment" > /usr/share/nginx/html/env.txt
 
 # Expose port 80
 EXPOSE 80


### PR DESCRIPTION
## Summary
- Added a new determine-environment job that detects if a tag is on main or develop branch
- Tags on main branch now trigger production builds
- Tags on develop branch trigger staging builds
- Updated Dockerfile to accept ENVIRONMENT build argument
- Added separate Watchtower triggers for staging and production environments
- Added environment indicators in image labels and build logs

## Test plan
- Tag a commit on develop branch (e.g., v1.2.3-dev) and verify it builds and deploys to staging
- Tag a commit on main branch (e.g., v1.2.3) and verify it builds and deploys to production
- Verify that the Docker image gets appropriately tagged with the environment name

🤖 Generated with [Claude Code](https://claude.ai/code)