### PR TITLE
Fix sed command syntax in GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
           echo "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: [REDACTED]"
           
           # Uncomment the assetPrefix and output lines for production build
-          sed -i 's/\/\/ assetPrefix: '\''\.'\''/'assetPrefix: '\''\.'\''/' apps/lrauv-dash2/next.config.js
-          sed -i 's/\/\/ output: '\''export'\''/'output: '\''export'\''/' apps/lrauv-dash2/next.config.js
+          sed -i 's/\/\/ assetPrefix: '\''\.'\''/assetPrefix: '\''\.'\''/' apps/lrauv-dash2/next.config.js
+          sed -i 's/\/\/ output: '\''export'\''/output: '\''export'\''/' apps/lrauv-dash2/next.config.js
           
           yarn build
       


### PR DESCRIPTION
## Summary
- Fixed the sed command in the release workflow that was causing the 'unterminated `s` command' error
- Properly balanced quotes in the string pattern to ensure correct syntax
- This allows the GitHub workflow to run successfully when releasing

🤖 Generated with [Claude Code](https://claude.ai/code)