### PR TITLE
Fix subpath asset loading for staging deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,8 +41,9 @@ jobs:
           echo "NEXT_PUBLIC_WEBSOCKET_URL: $NEXT_PUBLIC_WEBSOCKET_URL"
           echo "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: [REDACTED]"
           
-          # Uncomment the assetPrefix and output lines for production build
-          sed -i 's/\/\/ assetPrefix: '\''\.'\''/assetPrefix: '\''\.'\''/' apps/lrauv-dash2/next.config.js
+          # Configure basePath, assetPrefix and output for production build
+          sed -i 's/\/\/ basePath: '\''\/dash5'\''/basePath: '\''\/staging\/dash5'\''/' apps/lrauv-dash2/next.config.js
+          sed -i 's/\/\/ assetPrefix: '\''\.'\''/assetPrefix: '\''\/staging\/dash5'\''/' apps/lrauv-dash2/next.config.js
           sed -i 's/\/\/ output: '\''export'\''/output: '\''export'\''/' apps/lrauv-dash2/next.config.js
           
           yarn build

--- a/apps/lrauv-dash2/next.config.js
+++ b/apps/lrauv-dash2/next.config.js
@@ -1,8 +1,8 @@
 // This is a workaround for Next.js 15 to handle TypeScript files in workspace packages
 const nextConfig = {
-  // basePath: '/dash5',
-  // assetPrefix: '.',
-  // output: 'export',
+  basePath: '/staging/dash5',
+  assetPrefix: '/staging/dash5',
+  output: 'export',
   reactStrictMode: true,
   // Fix for Next.js 15 image optimization with static export
   images: {


### PR DESCRIPTION
## Summary
- Updates Next.js configuration to correctly handle subpath deployment
- Sets basePath and assetPrefix to '/staging/dash5' for proper asset loading on deep links
- Updates GitHub workflow to configure paths during build process

## Test plan
- Deploy to staging environment
- Verify that deep links like `/staging/dash5/vehicle/pontus/` correctly load all assets
- Confirm that all JavaScript chunks are loaded with absolute paths

🤖 Generated with [Claude Code](https://claude.ai/code)