### PR TITLE
Deduplicate recent runs by both mission name and override details

### DIFF
--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -205,19 +205,37 @@ const MissionModal: React.FC<MissionModalProps> = ({
 
   const recentRuns: MissionTableProps['missions'] =
     recentRunsData
-      ?.map(({ mission, vehicleName: vehicle, isoTime, user }) => {
-        const { category, name } = parseMissionPath(mission)
-        return {
-          id: mission,
-          category,
-          name,
-          description: mission,
-          vehicle,
-          ranOn: capitalize(DateTime.fromISO(isoTime).toFormat('MMM. d yyyy')),
-          ranBy: capitalizeEach(user ?? ''),
-          recentRun: true,
+      ?.map(
+        (
+          {
+            mission,
+            vehicleName: vehicle,
+            isoTime,
+            user,
+            note,
+            parameterOverrides,
+            waypointOverrides,
+          },
+          i
+        ) => {
+          const { category, name } = parseMissionPath(mission)
+          return {
+            id: mission,
+            category,
+            name,
+            description: mission,
+            vehicle,
+            ranOn: capitalize(
+              DateTime.fromISO(isoTime).toFormat('MMM. d yyyy')
+            ),
+            ranBy: capitalizeEach(user ?? ''),
+            recentRun: true,
+            note,
+            parameterCount: parameterOverrides.length,
+            waypointCount: waypointOverrides.length,
+          }
         }
-      })
+      )
       .filter(
         (mission, index, s) => s.findIndex((m) => m.id === mission.id) === index
       ) ?? []

--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -50,6 +50,11 @@ const insertForParameter = (
   return null
 }
 
+const LAST_60_DAYS = getAdjustedUnixTime({
+  unixTime: DateTime.now().toMillis(),
+  offsetDays: -60,
+})
+
 export interface MissionModalProps {
   onClose: () => void
   className?: string
@@ -141,14 +146,11 @@ const MissionModal: React.FC<MissionModalProps> = ({
     },
     { enabled: !!vehicleName }
   )
-  const last60Days = getAdjustedUnixTime({
-    unixTime: DateTime.now().toMillis(),
-    offsetDays: -60,
-  })
+
   const { data: recentRunsData } = useRecentRuns(
     {
       vehicles: vehicles ?? [],
-      from: last60Days,
+      from: LAST_60_DAYS,
     },
     { enabled: !!vehicles }
   )

--- a/packages/api-client/src/axios/Util/extractOverrides.test.ts
+++ b/packages/api-client/src/axios/Util/extractOverrides.test.ts
@@ -1,0 +1,87 @@
+import { extractOverrides } from './extractOverrides'
+
+describe('extractOverrides', () => {
+  const baseMissionData = `sched asap "load Science/sci2_noyo_optim.tl;set sci2_noyo_optim.MissionTimeout 13 h;set sci2_noyo_optim.NeedCommsTime 90 min;set sci2_noyo_optim.Depth1 250 m;set sci2_noyo_optim.Depth2 250 m;set sci2_noyo_optim.Depth3 NaN m" 33c01 1 4
+sched asap "set sci2_noyo_optim.Repeat 12 count;set sci2_noyo_optim.Lat1 36.79279 degree;set sci2_noyo_optim.Lon1 -121.88919 degree;set sci2_noyo_optim.Lat2 36.78427 degree;set sci2_noyo_optim.Lon2 -121.91339 degree" 33c01 2 4
+sched asap "set sci2_noyo_optim.ApproachDepth 10 m;set sci2_noyo_optim.ApproachSpeed 1.0 m/s;set sci2_noyo_optim.SlowSpeed 0.4 m/s;set sci2_noyo_optim.MinAltitude 10 m;set sci2_noyo_optim.MaxDepth 270 m" 33c01 3 4
+sched asap "set sci2_noyo_optim:PowerOnly.SampleLoad1 1 bool;run" 33c01 4 4`
+
+  it('should correctly parse waypoint and parameter overrides from mission data', () => {
+    const result = extractOverrides(baseMissionData)
+
+    // Check waypoint overrides (coordinates)
+    expect(result.waypointOverrides).toEqual([
+      { name: 'Lat1', value: '36.79279 degree' },
+      { name: 'Lon1', value: '-121.88919 degree' },
+      { name: 'Lat2', value: '36.78427 degree' },
+      { name: 'Lon2', value: '-121.91339 degree' },
+    ])
+
+    // Check parameter overrides (depths, timeouts, and other parameters)
+    expect(result.parameterOverrides).toEqual([
+      { name: 'MissionTimeout', value: '13 h' },
+      { name: 'NeedCommsTime', value: '90 min' },
+      { name: 'Depth1', value: '250 m' },
+      { name: 'Depth2', value: '250 m' },
+      { name: 'Depth3', value: 'NaN m' },
+      { name: 'Repeat', value: '12 count' },
+      { name: 'ApproachDepth', value: '10 m' },
+      { name: 'ApproachSpeed', value: '1.0 m/s' },
+      { name: 'SlowSpeed', value: '0.4 m/s' },
+      { name: 'MinAltitude', value: '10 m' },
+      { name: 'MaxDepth', value: '270 m' },
+      { name: 'PowerOnly.SampleLoad1', value: '1 bool' },
+    ])
+  })
+
+  it('should handle empty input', () => {
+    const result = extractOverrides('')
+    expect(result.waypointOverrides).toHaveLength(0)
+    expect(result.parameterOverrides).toHaveLength(0)
+  })
+
+  it('should handle input with no valid commands', () => {
+    const missionData = 'invalid command; another invalid command'
+    const result = extractOverrides(missionData)
+    expect(result.waypointOverrides).toHaveLength(0)
+    expect(result.parameterOverrides).toHaveLength(0)
+  })
+
+  it('should handle commands with both dot and colon separators', () => {
+    const missionData = `${baseMissionData} set sci2_noyo_optim.Lat3 36.79279 degree; set sci2_noyo_optim:Param1 value1`
+    const result = extractOverrides(missionData)
+
+    // Check that original overrides are preserved
+    expect(result.waypointOverrides.length).toBeGreaterThan(0)
+    expect(result.parameterOverrides.length).toBeGreaterThan(0)
+
+    // Check that new overrides are added
+    expect(result.waypointOverrides).toContainEqual({
+      name: 'Lat3',
+      value: '36.79279 degree',
+    })
+    expect(result.parameterOverrides).toContainEqual({
+      name: 'Param1',
+      value: 'value1',
+    })
+  })
+
+  it('should handle malformed commands in the input', () => {
+    const missionData = `${baseMissionData} set h; set sci2_noyo_optim.Depth1 m; set set sci2_noyo_optim.Depth2 50 m`
+    const result = extractOverrides(missionData)
+
+    // Check that original overrides are preserved
+    expect(result.waypointOverrides.length).toBeGreaterThan(0)
+    expect(result.parameterOverrides.length).toBeGreaterThan(0)
+
+    // Check that malformed commands don't break the parsing
+    expect(result.parameterOverrides).toContainEqual({
+      name: 'Depth1',
+      value: 'm',
+    })
+    expect(result.parameterOverrides).toContainEqual({
+      name: 'Depth2',
+      value: '50 m',
+    })
+  })
+})

--- a/packages/api-client/src/axios/Util/extractOverrides.test.ts
+++ b/packages/api-client/src/axios/Util/extractOverrides.test.ts
@@ -2,7 +2,7 @@ import { extractOverrides } from './extractOverrides'
 
 describe('extractOverrides', () => {
   const baseMissionData = `sched asap "load Science/sci2_noyo_optim.tl;set sci2_noyo_optim.MissionTimeout 13 h;set sci2_noyo_optim.NeedCommsTime 90 min;set sci2_noyo_optim.Depth1 250 m;set sci2_noyo_optim.Depth2 250 m;set sci2_noyo_optim.Depth3 NaN m" 33c01 1 4
-sched asap "set sci2_noyo_optim.Repeat 12 count;set sci2_noyo_optim.Lat1 36.79279 degree;set sci2_noyo_optim.Lon1 -121.88919 degree;set sci2_noyo_optim.Lat2 36.78427 degree;set sci2_noyo_optim.Lon2 -121.91339 degree" 33c01 2 4
+sched asap "set sci2_noyo_optim.Repeat 12 count;set sci2_noyo_optim.Lat1 36.79279 degree;set sci2_noyo_optim.Lon1 -121.88919 degree;set sci2_noyo_optim.Lat2 36.78427 degree;set sci2_noyo_optim.Lon2 NaN degree" 33c01 2 4
 sched asap "set sci2_noyo_optim.ApproachDepth 10 m;set sci2_noyo_optim.ApproachSpeed 1.0 m/s;set sci2_noyo_optim.SlowSpeed 0.4 m/s;set sci2_noyo_optim.MinAltitude 10 m;set sci2_noyo_optim.MaxDepth 270 m" 33c01 3 4
 sched asap "set sci2_noyo_optim:PowerOnly.SampleLoad1 1 bool;run" 33c01 4 4`
 
@@ -14,7 +14,7 @@ sched asap "set sci2_noyo_optim:PowerOnly.SampleLoad1 1 bool;run" 33c01 4 4`
       { name: 'Lat1', value: '36.79279 degree' },
       { name: 'Lon1', value: '-121.88919 degree' },
       { name: 'Lat2', value: '36.78427 degree' },
-      { name: 'Lon2', value: '-121.91339 degree' },
+      { name: 'Lon2', value: 'NaN degree' },
     ])
 
     // Check parameter overrides (depths, timeouts, and other parameters)

--- a/packages/api-client/src/axios/Util/extractOverrides.ts
+++ b/packages/api-client/src/axios/Util/extractOverrides.ts
@@ -1,0 +1,46 @@
+/**
+ * Extracts waypoint and parameter overrides from mission command data.
+ *
+ * This function parses command strings that follow these patterns:
+ * - `set [prefix].[name] [value]`
+ * - `[prefix]:[name.name] [value]`
+ *
+ * It splits the commands into two categories:
+ * - waypointOverrides: commands where the value includes 'degree' as a unit
+ * - parameterOverrides: all other commands
+ *
+ * @param missionData - The raw command data string containing set commands
+ * @returns An object containing arrays of waypoint and parameter overrides
+ *
+ * @example
+ * const data = "set PAM.Lat1 -121.847 degree; PAM:BackseatDriver.EnableBackseat 1 bool"
+ * const { waypointOverrides, parameterOverrides } = extractOverrides(data)
+ * // waypointOverrides: [{ name: "Lat1", value: "-121.847 degree" }]
+ * // parameterOverrides: [{ name: "BackseatDriver.EnableBackseat", value: "1 bool" }]
+ */
+export type Override = {
+  name: string
+  value: string
+}
+
+export type Overrides = {
+  waypointOverrides: Override[]
+  parameterOverrides: Override[]
+}
+
+export const extractOverrides = (missionData: string): Overrides => {
+  const regex = /(?:set\s+)?([\w]+)[.:]([\w.]+)\s+([^;"]+)/g
+  const commands: Override[] = []
+  let match: RegExpExecArray | null
+
+  while ((match = regex.exec(missionData)) !== null) {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_, _prefix, name, value] = match
+    commands.push({ name, value: value.trim() })
+  }
+
+  return {
+    waypointOverrides: commands.filter((cmd) => cmd.value.includes('degree')),
+    parameterOverrides: commands.filter((cmd) => !cmd.value.includes('degree')),
+  }
+}

--- a/packages/api-client/src/axios/Util/generateMissionKey.test.ts
+++ b/packages/api-client/src/axios/Util/generateMissionKey.test.ts
@@ -1,0 +1,97 @@
+import { generateMissionKey } from './generateMissionKey'
+import type { MissionRun } from './generateMissionKey'
+
+describe('generateMissionKey', () => {
+  it('should generate the same key for identical mission runs', () => {
+    const missionRun: MissionRun = {
+      missionName: 'test_mission',
+      waypointOverrides: [
+        { name: 'wp1', value: '10' },
+        { name: 'wp2', value: '20' },
+      ],
+      parameterOverrides: [
+        { name: 'speed', value: '2' },
+        { name: 'depth', value: '100' },
+      ],
+    }
+
+    const key1 = generateMissionKey(missionRun)
+    const key2 = generateMissionKey(missionRun)
+
+    expect(key1).toBe(key2)
+  })
+
+  it('should generate different keys for different mission names', () => {
+    const run1: MissionRun = {
+      missionName: 'mission1',
+      waypointOverrides: [],
+      parameterOverrides: [],
+    }
+
+    const run2: MissionRun = {
+      missionName: 'mission2',
+      waypointOverrides: [],
+      parameterOverrides: [],
+    }
+
+    const key1 = generateMissionKey(run1)
+    const key2 = generateMissionKey(run2)
+
+    expect(key1).not.toBe(key2)
+  })
+
+  it('should generate the same key regardless of override order', () => {
+    const run1: MissionRun = {
+      missionName: 'test_mission',
+      waypointOverrides: [
+        { name: 'wp1', value: '10' },
+        { name: 'wp2', value: '20' },
+      ],
+      parameterOverrides: [{ name: 'speed', value: '2' }],
+    }
+
+    const run2: MissionRun = {
+      missionName: 'test_mission',
+      waypointOverrides: [
+        { name: 'wp2', value: '20' },
+        { name: 'wp1', value: '10' },
+      ],
+      parameterOverrides: [{ name: 'speed', value: '2' }],
+    }
+
+    const key1 = generateMissionKey(run1)
+    const key2 = generateMissionKey(run2)
+
+    expect(key1).toBe(key2)
+  })
+
+  it('should handle empty overrides', () => {
+    const run: MissionRun = {
+      missionName: 'test_mission',
+      waypointOverrides: [],
+      parameterOverrides: [],
+    }
+
+    const key = generateMissionKey(run)
+    expect(key).toBe('test_mission||')
+  })
+
+  it('should generate different keys for different override values', () => {
+    const run1: MissionRun = {
+      missionName: 'test_mission',
+      waypointOverrides: [{ name: 'wp1', value: '10' }],
+      parameterOverrides: [],
+    }
+
+    const run2: MissionRun = {
+      missionName: 'test_mission',
+      waypointOverrides: [{ name: 'wp1', value: '20' }],
+      parameterOverrides: [],
+    }
+
+    const key1 = generateMissionKey(run1)
+    const key2 = generateMissionKey(run2)
+
+    expect(key1).not.toBe(key2)
+  })
+})

--- a/packages/api-client/src/axios/Util/generateMissionKey.ts
+++ b/packages/api-client/src/axios/Util/generateMissionKey.ts
@@ -1,0 +1,42 @@
+import { Override } from './extractOverrides'
+
+/**
+ * Represents a mission run configuration including the mission name
+ * and any overrides applied to waypoints and parameters.
+ */
+export interface MissionRun {
+  missionName: string
+  waypointOverrides: Override[]
+  parameterOverrides: Override[]
+}
+
+/**
+ * Generates a unique key for a mission run based on its configuration.
+ * The key is created by combining the mission name and all overrides in a deterministic order.
+ * This ensures that identical mission configurations will generate the same key,
+ * allowing for deduplication of mission runs.
+ *
+ * @param run - The mission run configuration to generate a key for
+ * @returns A string key that uniquely identifies the mission configuration
+ */
+export const generateMissionKey = (run: MissionRun): string => {
+  // Sort overrides to ensure consistent ordering
+  const sortedWaypointOverrides = [...run.waypointOverrides].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  )
+  const sortedParameterOverrides = [...run.parameterOverrides].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  )
+
+  // Create a string representation of all overrides
+  const waypointOverrideString = sortedWaypointOverrides
+    .map((override) => `${override.name}:${override.value}`)
+    .join('|')
+
+  const parameterOverrideString = sortedParameterOverrides
+    .map((override) => `${override.name}:${override.value}`)
+    .join('|')
+
+  // Combine all fields into a single string
+  return `${run.missionName}|${waypointOverrideString}|${parameterOverrideString}`
+}

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./axios"
-export * from "./react-query"
+export * from './axios'
+export * from './react-query'

--- a/packages/api-client/src/react-query/Command/useRecentRuns.ts
+++ b/packages/api-client/src/react-query/Command/useRecentRuns.ts
@@ -1,8 +1,16 @@
 import { useEvents } from '../Event/useEvents'
 import { SupportedQueryOptions } from '../types'
+import { extractOverrides } from '../../axios/Util/extractOverrides'
+import { generateMissionKey } from '../../axios/Util/generateMissionKey'
 
 export const useRecentRuns = (
-  params: { vehicles: string[]; from: number; to?: number; limit?: number },
+  params: {
+    vehicles: string[]
+    from: number
+    to?: number
+    limit?: number
+    unique?: boolean
+  },
   options?: SupportedQueryOptions
 ) => {
   const query = useEvents(
@@ -14,12 +22,32 @@ export const useRecentRuns = (
     options
   )
 
-  const data = query.data?.map((event) => {
+  const formattedData = query.data?.map((event) => {
+    const mission = event.data?.match(/[a-zA-Z_/]+(\.xml|\.tl)/)?.[0] ?? ''
+    const { waypointOverrides, parameterOverrides } = extractOverrides(
+      event.data ?? ''
+    )
+    const missionKey = generateMissionKey({
+      missionName: mission,
+      waypointOverrides,
+      parameterOverrides,
+    })
     return {
       ...event,
-      mission: event.data?.match(/[a-zA-Z_/]+(\.xml|\.tl)/)?.[0] ?? '',
+      mission,
+      waypointOverrides,
+      parameterOverrides,
+      missionKey,
     }
   })
+
+  // Provide unique missions (unique mission name and waypoint and parameter overrides) if requested
+  const data = params.unique
+    ? formattedData?.filter(
+        (event, index, self) =>
+          self.findIndex((e) => e.missionKey === event.missionKey) === index
+      )
+    : formattedData
 
   return { ...query, data }
 }

--- a/packages/react-ui/src/Modals/MissionModal.stories.tsx
+++ b/packages/react-ui/src/Modals/MissionModal.stories.tsx
@@ -22,7 +22,7 @@ const missionTableArgs: MissionTableProps = {
       id: '1',
       category: 'Science',
       name: 'sci2',
-      task: 'Test mission',
+      note: 'Test mission',
       description:
         "Vehicle yo-yo's to the specified waypoints, with science turned on.",
       vehicle: 'Brizo',
@@ -35,7 +35,7 @@ const missionTableArgs: MissionTableProps = {
       category: 'Science',
       name: 'sci2',
 
-      task: 'Test mission',
+      note: 'Test mission',
       description:
         "Vehicle yo-yo's to the specified waypoints, with science turned on.",
       vehicle: 'Tethys',
@@ -47,7 +47,7 @@ const missionTableArgs: MissionTableProps = {
       id: '3',
       category: 'Science',
       name: 'profile_station',
-      task: 'Profile station at C1 for the night',
+      note: 'Profile station at C1 for the night',
       description:
         'This mission yoyos in a circle around a specified location.',
       vehicle: 'Tethys',
@@ -59,7 +59,7 @@ const missionTableArgs: MissionTableProps = {
       id: '4',
       category: 'Science',
       name: 'sci2',
-      task: 'more okeanids testing',
+      note: 'more okeanids testing',
       description:
         "Vehicle yo-yo's to the specified waypoints, with science turned on.",
       vehicle: 'Tethys',
@@ -71,7 +71,7 @@ const missionTableArgs: MissionTableProps = {
       id: '5',
       category: 'Science',
       name: 'esp_sample_at_depth',
-      task: 'sending final doublet sampling mission',
+      note: 'sending final doublet sampling mission',
       description: 'This mission takes ESP samples at the designated depth.',
       vehicle: 'Brizo',
       ranBy: 'Greg Doucette',
@@ -81,7 +81,7 @@ const missionTableArgs: MissionTableProps = {
       id: '6',
       category: 'Maintenance',
       name: 'ballast_and_trim',
-      task: 'running B&T until next sampling',
+      note: 'running B&T until next sampling',
       vehicle: 'Brizo',
       ranBy: 'Greg Doucette',
       ranOn: 'Aug. 16, 2021',

--- a/packages/react-ui/src/Modals/MissionModal.test.tsx
+++ b/packages/react-ui/src/Modals/MissionModal.test.tsx
@@ -44,7 +44,7 @@ const props: MissionModalProps = {
       id: '1',
       category: 'Science',
       name: 'sci2',
-      task: 'Test mission',
+      note: 'Test mission',
       description:
         "Vehicle yo-yo's to the specified waypoints, with science turned on.",
       vehicle: 'Brizo',
@@ -57,7 +57,7 @@ const props: MissionModalProps = {
       id: '2',
       category: 'Maintenance',
       name: 'sci2',
-      task: 'Mission 2',
+      note: 'Mission 2',
       description:
         "Another mission where a vehicle yo-yo's to the specified waypoints, with science turned on.",
       vehicle: 'Tethys',
@@ -70,7 +70,7 @@ const props: MissionModalProps = {
       id: '3',
       category: 'Science',
       name: 'profile_station',
-      task: 'Profile station at C1 for the night',
+      note: 'Profile station at C1 for the night',
       description:
         'This mission yoyos in a circle around a specified location.',
       vehicle: 'Tethys',
@@ -180,7 +180,7 @@ test('should display mission tasks', async () => {
       <MissionModal {...props} />
     </RecoilRoot>
   )
-  expect(screen.queryByText(props.missions[0].task ?? '')).toBeInTheDocument()
+  expect(screen.queryByText(props.missions[0].note ?? '')).toBeInTheDocument()
 })
 
 test('should display mission category and name labels', async () => {

--- a/packages/react-ui/src/Tables/MissionTable.stories.tsx
+++ b/packages/react-ui/src/Tables/MissionTable.stories.tsx
@@ -37,7 +37,7 @@ const args: MissionTableProps = {
       id: '1',
       category: 'Science',
       name: 'sci2',
-      task: 'Test mission',
+      note: 'Test mission',
       description:
         "Vehicle yo-yo's to the specified waypoints, with science turned on.",
       vehicle: 'Brizo',
@@ -50,7 +50,7 @@ const args: MissionTableProps = {
       category: 'Science',
       name: 'sci2',
 
-      task: 'Test mission',
+      note: 'Test mission',
       description:
         "Vehicle yo-yo's to the specified waypoints, with science turned on.",
       vehicle: 'Tethys',
@@ -62,7 +62,7 @@ const args: MissionTableProps = {
       id: '3',
       category: 'Science',
       name: 'profile_station',
-      task: 'Profile station at C1 for the night',
+      note: 'Profile station at C1 for the night',
       description:
         'This mission yoyos in a circle around a specified location.',
       vehicle: 'Tethys',
@@ -74,7 +74,7 @@ const args: MissionTableProps = {
       id: '4',
       category: 'Science',
       name: 'sci2',
-      task: 'more okeanids testing',
+      note: 'more okeanids testing',
       description:
         "Vehicle yo-yo's to the specified waypoints, with science turned on.",
       vehicle: 'Tethys',
@@ -86,7 +86,7 @@ const args: MissionTableProps = {
       id: '5',
       category: 'Science',
       name: 'esp_sample_at_depth',
-      task: 'sending final doublet sampling mission',
+      note: 'sending final doublet sampling mission',
       description: 'This mission takes ESP samples at the designated depth.',
       vehicle: 'Brizo',
       ranBy: 'Greg Doucette',
@@ -96,7 +96,7 @@ const args: MissionTableProps = {
       id: '6',
       category: 'Maintenance',
       name: 'ballast_and_trim',
-      task: 'running B&T until next sampling',
+      note: 'running B&T until next sampling',
       vehicle: 'Brizo',
       ranBy: 'Greg Doucette',
       ranOn: 'Aug. 16, 2021',

--- a/packages/react-ui/src/Tables/MissionTable.stories.tsx
+++ b/packages/react-ui/src/Tables/MissionTable.stories.tsx
@@ -44,6 +44,7 @@ const args: MissionTableProps = {
       ranBy: 'Jordan Caress',
       ranOn: 'Dec. 10, 2021',
       waypointCount: 2,
+      parameterCount: 3,
     },
     {
       id: '2',

--- a/packages/react-ui/src/Tables/MissionTable.test.tsx
+++ b/packages/react-ui/src/Tables/MissionTable.test.tsx
@@ -9,7 +9,7 @@ const props: MissionTableProps = {
       id: '1',
       category: 'Science',
       name: 'sci2',
-      task: 'Test mission',
+      note: 'Test mission',
       vehicle: 'Brizo',
       ranBy: 'Jordan Caress',
       ranOn: 'Dec. 10, 2021',

--- a/packages/react-ui/src/Tables/MissionTable.test.tsx
+++ b/packages/react-ui/src/Tables/MissionTable.test.tsx
@@ -74,8 +74,9 @@ test('should display description label when description is provided', async () =
 
 test('should display run details including pilot and run date', async () => {
   render(<MissionTable {...props} />)
-  expect(screen.getByText(/Jordan Caress./i)).toBeInTheDocument()
-  expect(screen.getByText(/on Dec. 10, 2021./i)).toBeInTheDocument()
+  expect(
+    screen.getByText(/Last ran by Jordan Caress on Dec. 10, 2021/i)
+  ).toBeInTheDocument()
 })
 
 test('should display run details including number of waypoints when provided', async () => {
@@ -85,15 +86,45 @@ test('should display run details including number of waypoints when provided', a
       missions={[{ ...props.missions[0], waypointCount: 2 }]}
     />
   )
-  expect(screen.getByText(/This mission has 2 waypoints/i)).toBeInTheDocument()
+  expect(
+    screen.getByText(/This mission has 2 waypoint overrides/i)
+  ).toBeInTheDocument()
 })
 
-test('should display run details including number run location when provided', async () => {
+test('should display run details including number of parameters when provided', async () => {
+  render(
+    <MissionTable
+      {...props}
+      missions={[{ ...props.missions[0], parameterCount: 3 }]}
+    />
+  )
+  expect(
+    screen.getByText(/This mission has 3 parameter overrides/i)
+  ).toBeInTheDocument()
+})
+
+test('should display run details including number of waypoints and parameters when both are provided', async () => {
+  render(
+    <MissionTable
+      {...props}
+      missions={[{ ...props.missions[0], waypointCount: 2, parameterCount: 3 }]}
+    />
+  )
+  expect(
+    screen.getByText(
+      /This mission has 2 waypoint overrides and 3 parameter overrides/i
+    )
+  ).toBeInTheDocument()
+})
+
+test('should display run details including run location when provided', async () => {
   render(
     <MissionTable
       {...props}
       missions={[{ ...props.missions[0], ranAt: 'test location' }]}
     />
   )
-  expect(screen.getByText(/Last ran by Jordan Caress/i)).toBeInTheDocument()
+  expect(
+    screen.getByText(/Location ran at: test location/i)
+  ).toBeInTheDocument()
 })

--- a/packages/react-ui/src/Tables/MissionTable.tsx
+++ b/packages/react-ui/src/Tables/MissionTable.tsx
@@ -19,7 +19,7 @@ export interface Mission {
   id: string
   category: string
   name: string
-  task?: string
+  note?: string
   description?: string
   vehicle?: string
   ranBy?: string
@@ -45,7 +45,7 @@ export const MissionTable: React.FC<MissionTableProps> = ({
     ({
       category,
       name,
-      task,
+      note,
       description,
       ranBy,
       ranOn,
@@ -56,7 +56,8 @@ export const MissionTable: React.FC<MissionTableProps> = ({
       cells: [
         {
           label: category ? `${category}: ${name}` : `${name}`,
-          secondary: task,
+          secondary: note,
+          span: 2,
         },
         shouldShowVehicleColumn
           ? {
@@ -83,6 +84,7 @@ export const MissionTable: React.FC<MissionTableProps> = ({
       {
         label: 'MISSION NAME',
         onSort: onSortColumn,
+        span: 2,
       },
       shouldShowVehicleColumn
         ? {
@@ -90,7 +92,7 @@ export const MissionTable: React.FC<MissionTableProps> = ({
             onSort: onSortColumn,
           }
         : null,
-      { label: 'DESCRIPTION', onSort: onSortColumn },
+      { label: 'DESCRIPTION', onSort: onSortColumn, span: 3 },
     ].filter((i) => i),
     activeSortColumn: sortColumn,
     activeSortDirection: sortDirection,
@@ -111,6 +113,7 @@ export const MissionTable: React.FC<MissionTableProps> = ({
       selectedIndex={
         selectedId ? missions.findIndex(({ id }) => id === selectedId) : null
       }
+      colInRow={6}
     />
   )
 }

--- a/packages/react-ui/src/Tables/MissionTable.tsx
+++ b/packages/react-ui/src/Tables/MissionTable.tsx
@@ -26,6 +26,7 @@ export interface Mission {
   ranOn?: string
   ranAt?: string
   waypointCount?: number
+  parameterCount?: number
   recentRun?: boolean
   frequentRun?: boolean
 }
@@ -51,12 +52,15 @@ export const MissionTable: React.FC<MissionTableProps> = ({
       ranOn,
       ranAt,
       waypointCount,
+      parameterCount,
       vehicle,
     }) => ({
       cells: [
         {
-          label: category ? `${category}: ${name}` : `${name}`,
-          secondary: note,
+          label: category
+            ? `${category}: ${name}`
+            : `${name !== '' && name ? name : 'Unnamed mission'}`,
+          secondary: note ? <span className="italic">{note}</span> : null,
           span: 2,
         },
         shouldShowVehicleColumn
@@ -66,14 +70,33 @@ export const MissionTable: React.FC<MissionTableProps> = ({
           : null,
         {
           label: description ? description : 'No description',
-          secondary: `${(ranBy && `Last ran by ${ranBy}`) ?? ''} 
-            ${(ranOn && `on ${ranOn}.`) ?? ''} 
-            ${(ranAt && `Location ran at: ${ranAt}.`) ?? ''}
-            ${
-              (waypointCount &&
-                `This mission has ${waypointCount} waypoints`) ??
-              ''
-            }`,
+          span: 3,
+          secondary: (
+            <ul className="">
+              <li className="flex">
+                {ranBy && `Last ran by ${ranBy}`}
+                {ranOn && ` on ${ranOn}`}
+              </li>
+              <li className="flex">{ranAt && `Location ran at: ${ranAt}`}</li>
+              {waypointCount || parameterCount ? (
+                <li className="flex">
+                  {`This mission has${
+                    waypointCount
+                      ? ` ${waypointCount} waypoint override${
+                          waypointCount !== 1 ? 's' : ''
+                        }`
+                      : ''
+                  }${waypointCount && parameterCount ? ' and' : ''}${
+                    parameterCount
+                      ? ` ${parameterCount} parameter override${
+                          parameterCount !== 1 ? 's' : ''
+                        }`
+                      : ''
+                  }`}
+                </li>
+              ) : null}
+            </ul>
+          ),
         },
       ].filter((i) => i),
     })


### PR DESCRIPTION
- Provide unique recent run options for mission scheduling based on both mission name and all override details.
- Create util function to extract waypoint and parameter overrides from data string provided by event endpoint. Ensure NaN waypoints are correctly parsed.
- Create util function to create a unique mission key based on mission name and override details to aid in deduplicating missions.
- Show any note attached to mission in italics below mission name in scheduling table.
- Create sane structure and extra wide column for mission details in scheduling table.
- Move calculated timespan argument for fetching recent runs out of component body to avoid constant recalculation / endpoint calls.
- Update tests accordingly.

#### Updated scheduling table
<img width="1022" alt="Screenshot 2025-03-31 at 11 47 19 AM" src="https://github.com/user-attachments/assets/acab624f-1dd8-45af-aa43-9c9f84409f74" />


