### PR TITLE
Schedule commands using UTC time

### DIFF
--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -164,7 +164,7 @@ export const CommandModal: React.FC<CommandModalProps> = ({
     const { schedDate } = makeCommand({
       commandText,
       scheduleMethod,
-      specifiedTime,
+      specifiedLocalTime: specifiedTime,
     })
     createCommand({
       vehicle: confirmedVehicle?.toLowerCase() ?? '',

--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -347,7 +347,7 @@ const MissionModal: React.FC<MissionModalProps> = ({
       mission: selectedMissionId as string,
       parameterOverrides,
       scheduleMethod: scheduleMethod as ScheduleOption,
-      specifiedTime: specifiedTime ?? undefined,
+      specifiedLocalTime: specifiedTime ?? undefined,
     })
     setCommandText(previewSbd)
     if (!preview) {

--- a/apps/lrauv-dash2/lib/makeCommand.test.ts
+++ b/apps/lrauv-dash2/lib/makeCommand.test.ts
@@ -69,4 +69,18 @@ describe('makeMissionCommand', () => {
     )
     expect(schedDate).toBe('asap')
   })
+
+  it('should convert local time to UTC in the correct format', () => {
+    const { commandText, schedDate, previewSbd } = makeMissionCommand({
+      mission: 'Science/test.xml',
+      parameterOverrides: [],
+      scheduleMethod: 'time',
+      specifiedLocalTime: '2024-03-20T14:00:00-07:00', // Pacific time
+    })
+
+    // This time should be 21:00 UTC (14:00 PDT + 7 hours)
+    expect(schedDate).toBe('20240320T2100')
+    expect(previewSbd).toBe('sched 20240320T2100 "load Science/test.xml;run"')
+    expect(commandText).toBe('load Science/test.xml;run')
+  })
 })

--- a/apps/lrauv-dash2/lib/makeCommand.ts
+++ b/apps/lrauv-dash2/lib/makeCommand.ts
@@ -13,14 +13,15 @@ const printUnit = (p: ParameterProps) => {
   return `${p.overrideValue} ${p.overrideUnit ?? p.unit}`
 }
 
+// Accepts a local time string and returns a formatted UTC time string
 export const makeCommand = ({
   commandText,
   scheduleMethod = 'end',
-  specifiedTime,
+  specifiedLocalTime,
 }: {
   commandText: string
   scheduleMethod?: ScheduleOption
-  specifiedTime?: string | null
+  specifiedLocalTime?: string | null
 }) => {
   switch (scheduleMethod) {
     case 'ASAP':
@@ -30,14 +31,14 @@ export const makeCommand = ({
         previewSbd: `sched asap "${commandText}"`,
       }
     case 'time':
-      if (!specifiedTime) {
+      if (!specifiedLocalTime) {
         return {
           commandText,
           schedDate: '',
           previewSbd: `sched "${commandText}"`,
         }
       }
-      const t = DateTime.fromISO(specifiedTime)
+      const t = DateTime.fromISO(specifiedLocalTime).toUTC()
       const schedDate = `${t.toFormat('yyyyMMdd')}}T${t.toFormat('HHmm')}`
       return {
         commandText,
@@ -53,16 +54,17 @@ export const makeCommand = ({
   }
 }
 
+// Accepts a local time string and returns a formatted UTC time string
 export const makeMissionCommand = ({
   mission,
   parameterOverrides,
   scheduleMethod,
-  specifiedTime,
+  specifiedLocalTime,
 }: {
   parameterOverrides: ParameterProps[]
   mission: string
   scheduleMethod: ScheduleOption
-  specifiedTime?: string
+  specifiedLocalTime?: string
 }) => {
   const missionName = mission.split('/').pop()?.split('.')[0]
   const commands: string[] = [`load ${mission}`]
@@ -77,6 +79,6 @@ export const makeMissionCommand = ({
   return makeCommand({
     commandText: commands.join('; '),
     scheduleMethod,
-    specifiedTime,
+    specifiedLocalTime,
   })
 }


### PR DESCRIPTION
- Update makeCommand and by extension, makeMissionCommand, to use UTC time instead of local time when scheduling commands with a user selected time.
- Rename the specifiedTime prop to specifiedLocalTime to clarify that the provided time should be in local time for makeCommand and makeMissionCommand, so that these functions can convert to UTC.
- Add test to verify correct UTC conversion.