### PR TITLE
Update Docker Compose Configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,17 +5,6 @@ node_modules
 .pnp
 .pnp.js
 
-# next.js
-.next/
-out/
-
-# production
-build
-dist
-build/**
-dist/**
-.next/**
-
 # misc
 .DS_Store
 *.pem
@@ -25,9 +14,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
-
-# Mac OS
-.DS_Store
 
 # local env files
 .env

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+.pnp
+.pnp.js
+
+# next.js
+.next/
+out/
+
+# production
+build
+dist
+build/**
+dist/**
+.next/**
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Mac OS
+.DS_Store
+
+# local env files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+
+# testing
+coverage
+.jest-test-results.json
+
+# turborepo cache
+.turbo

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -174,14 +174,16 @@ const ConnectedVehicleCell: React.FC<{
             vehiclePosition?.gpsFixes?.[0]?.longitude
           )}
           lastSatellite={
-            vehicle?.text_gpsago.length
+            vehicle?.text_gpsago?.length
               ? `${vehicle.text_gpsago}${
                   pingEvent?.reachable ? ', likely on surface' : ''
                 }`
               : undefined
           }
           lastCell={
-            vehicle?.text_cellago.length ? `${vehicle.text_cellago}` : undefined
+            vehicle?.text_cellago?.length
+              ? `${vehicle.text_cellago}`
+              : undefined
           }
           vehicle={
             vehicle && {

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,8 +1,10 @@
 services:
-  dash4:
+  dash5:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
     ports:
-      - '80:80'
-    image: index.docker.io/mbari/lrauv-dash:5
+      - '8082:80'
     command:
       - '-g'
       - 'info'


### PR DESCRIPTION
## Summary
- Updated Docker Compose configuration to use build parameters instead of direct image reference
- Changed default port mapping to 8082:80 for local development to avoid port conflicts
- Added .dockerignore file to optimize Docker builds while keeping build outputs
- Fixed context path to properly reference parent directory from the docker folder

## Test plan
1. From the project root, run: `docker-compose -f docker/compose.yml up`
2. Access the application at http://localhost:8082
3. Verify the application loads correctly including dynamic routes

🤖 Generated with [Claude Code](https://claude.ai/code)