### PR TITLE
Use Tethys Provided API Key in favor of ENV Var.

### DIFF
--- a/apps/lrauv-dash2/lib/useGoogleMaps.ts
+++ b/apps/lrauv-dash2/lib/useGoogleMaps.ts
@@ -4,9 +4,7 @@ import { Loader } from '@googlemaps/js-api-loader'
 
 export const useGoogleMaps = () => {
   const { siteConfig } = useTethysApiContext()
-  const googleMapsApiKey =
-    process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ??
-    siteConfig?.appConfig.googleApiKey
+  const googleMapsApiKey = siteConfig?.appConfig.googleApiKey
 
   const [mapsLoaded, setMapsLoaded] = useState(false)
   useEffect(() => {


### PR DESCRIPTION
Remove the hardcoded env var that was taking precedence over the Google Maps API Key supplied by the Tethys API to resolve the issue preventing google maps and the elevation service from returning maps tiles and depth info:

![CleanShot 2025-05-01 at 22 15 17@2x](https://github.com/user-attachments/assets/d22b79f6-d3ba-4cec-b453-5b184bbcb0a5)
