### PR TITLE
Ensure bump-version script pulls all remote tags.

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -56,6 +56,10 @@ fi
 
 # Ensure that the local git repo is up to date
 git fetch --tags --prune
+if [ $? -ne 0 ]; then
+  echo -e "${RED}Error: Failed to fetch tags from the remote repository.${NC}"
+  exit 1
+fi
 
 # Get the latest version tag
 LATEST_TAG=$(git tag -l "v*" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -54,6 +54,9 @@ if ! command -v git &> /dev/null; then
   exit 1
 fi
 
+# Ensure that the local git repo is up to date
+git fetch --tags --prune
+
 # Get the latest version tag
 LATEST_TAG=$(git tag -l "v*" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
 


### PR DESCRIPTION
Ensure a developers local clone of the repo has all related tags for the project prior to updating the version.