### PR TITLE
Codex/update GitHub workflow for automatic version bump

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,4 +67,4 @@ jobs:
           fi
 
       - name: Bump version and tag
-        run: ./scripts/bump-version.sh --${{ steps.bump.outputs.type }}
+        run: ./scripts/bump-version.sh "--${{ steps.bump.outputs.type }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,10 @@ jobs:
         run: |
           git fetch --tags --prune
           commit_msg="$(git show -s --format=%B ${{ github.event.pull_request.head.sha }})"
+          if [ $? -ne 0 ] || [ -z "$commit_msg" ]; then
+            echo "Error: Failed to retrieve commit message." >&2
+            exit 1
+          fi
           if echo "$commit_msg" | grep -iq "#major"; then
             echo "type=major" >> "$GITHUB_OUTPUT"
           elif echo "$commit_msg" | grep -iq "#minor"; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,3 +37,34 @@ jobs:
         
       - name: Run API Client Tests
         run: yarn workspace @mbari/api-client test
+
+  bump-version:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'develop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+      - name: Determine bump type
+        id: bump
+        run: |
+          git fetch --tags --prune
+          commit_msg="$(git show -s --format=%B ${{ github.event.pull_request.head.sha }})"
+          if echo "$commit_msg" | grep -iq "#major"; then
+            echo "type=major" >> "$GITHUB_OUTPUT"
+          elif echo "$commit_msg" | grep -iq "#minor"; then
+            echo "type=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version and tag
+        run: ./scripts/bump-version.sh --${{ steps.bump.outputs.type }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
   push:
     tags:
       - 'v*'  # Run when a version tag is pushed
+  # Tags are created automatically when PRs merge into develop
   release:
     types: [created]
 


### PR DESCRIPTION
This PR should automate version bump script when merging into develop branch via GitHub workflows. Patch level bump by default unless a developer includes a minor or major tag in their PR. This may require a few revisions as it's difficult to test this behavior locally.