### PR TITLE
Fix command scheduling issues

### DIFF
--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -116,20 +116,25 @@ export const CommandModal: React.FC<CommandModalProps> = ({
     { name: 'Module', options: moduleInfoData?.moduleNames ?? [] },
     {
       name: 'Component',
-      options: configVariable.Module
-        ? Object.keys(moduleInfoData?.outputUris[config.Module ?? ''] ?? {})
+      options: config?.Module
+        ? moduleInfoData?.sensors?.[config?.Module ?? '']
+            ?.map((s) => s.string)
+            ?.sort() ?? []
         : [],
     },
     {
       name: 'Element',
-      options: config.Component
-        ? moduleInfoData?.outputUris[config.Module ?? '']?.[
-            config.Component
-          ]?.map((e) => e.string) ?? []
-        : [],
+      options:
+        config?.Module && config?.Component
+          ? moduleInfoData?.uris?.[config?.Module ?? '']?.[
+              config?.Component ?? ''
+            ]
+              ?.map((e) => e.string)
+              ?.sort() ?? []
+          : [],
     },
   ]
-  const moduleNames = makeModuleNames(configVariable)
+  const moduleNames = makeModuleNames(variable)
 
   const units = unitsData?.map((u) => u.name) ?? []
 

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -219,6 +219,8 @@ export const CommandModal: React.FC<CommandModalProps> = ({
       break
   }
 
+  const missionOptions = missionData?.list?.map((m) => m.path)?.sort() ?? []
+
   return (
     <CommandModalView
       className={className}
@@ -238,7 +240,7 @@ export const CommandModal: React.FC<CommandModalProps> = ({
       missions={[
         {
           name: 'Mission',
-          options: missionData?.list?.map((m) => m.path) ?? [],
+          options: missionOptions,
         },
       ]}
       decimationTypes={[{ name: 'Decimation Type', options: decimationTypes }]}

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -39,11 +39,7 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   const [currentCommandId, setCurrentCommand] = useState<
     string | null | undefined
   >(defaultCommand)
-  const [configVariable, setConfigVariable] = useState<Record<string, string>>({
-    Module: '',
-    Component: '',
-    Element: '',
-  })
+
   const [variable, setVariable] = useState<Record<string, string>>({
     Variable: '',
     Mission: '',
@@ -104,10 +100,12 @@ export const CommandModal: React.FC<CommandModalProps> = ({
     argType,
     value
   ) => {
-    if (argType === 'ARG_CONFIG_VARIABLE') {
-      setConfigVariable(mapValues(value))
-    }
-    if (argType === 'ARG_VARIABLE') {
+    if (
+      argType === 'ARG_VARIABLE' ||
+      argType === 'ARG_COMPONENT' ||
+      argType === 'ARG_CONFIG_VARIABLE' ||
+      argType === 'ARG_MISSION'
+    ) {
       setVariable(mapValues(value))
     }
   }
@@ -237,6 +235,12 @@ export const CommandModal: React.FC<CommandModalProps> = ({
       syntaxVariations={syntaxVariations ?? []}
       units={[{ name: 'Units', options: units }]}
       universals={[{ name: 'Universal', options: universalData ?? [] }]}
+      missions={[
+        {
+          name: 'Mission',
+          options: missionData?.list?.map((m) => m.path) ?? [],
+        },
+      ]}
       decimationTypes={[{ name: 'Decimation Type', options: decimationTypes }]}
       serviceTypes={[{ name: 'Service Type', options: serviceTypes }]}
       variableTypes={variableTypes}

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -208,7 +208,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     const mission = results[index + indexOffset]
     const { name: missionName, parameters: missionParams } =
       parseMissionCommand(mission?.event.data ?? '')
-    console.log(missionName, missionParams)
+
     return mission ? (
       <ScheduleCell
         label={missionName ?? 'Unknown'}

--- a/packages/api-client/src/react-query/Command/useCreateCommand.ts
+++ b/packages/api-client/src/react-query/Command/useCreateCommand.ts
@@ -17,6 +17,11 @@ export const useCreateCommand = (config?: RequestConfig) => {
     {
       onSuccess: () => {
         queryClient.invalidateQueries(['event', 'events'])
+        queryClient.invalidateQueries([
+          'deployment',
+          'deployments',
+          'commandStatus',
+        ])
       },
     }
   )

--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
@@ -52,7 +52,7 @@ const argumentAsParameter = (
     case 'ARG_INT':
       return {
         argType: arg.argType,
-        name: 'int',
+        name: arg?.altName ?? 'int',
         description: 'An integer value',
         inputType: 'number',
         value,
@@ -78,7 +78,7 @@ const argumentAsParameter = (
     case 'ARG_STRING':
       return {
         argType: arg.argType,
-        name: 'string',
+        name: arg?.altName ?? 'string',
         description: 'A string value',
         inputType: 'string',
         value,
@@ -104,8 +104,8 @@ const argumentAsParameter = (
     case 'ARG_TOKEN':
       return {
         argType: arg.argType,
-        name: 'token',
-        description: 'A token value',
+        name: arg?.altName ?? 'token',
+        description: `A ${arg?.altName ?? 'token'} value`,
         inputType: 'string',
         required: arg.required === 'REQUIRED',
         value,
@@ -230,6 +230,7 @@ const argumentAsParameter = (
 export interface Argument {
   argType: ArgumentType
   keyword?: string
+  altName?: string
   required?: string
 }
 

--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
@@ -336,6 +336,8 @@ export const BuildTemplatedCommandStep: React.FC<
         return value ? values[1] : value
       case 'ARG_COMMAND':
         return value ? values[0] : value
+      case 'ARG_QUOTED_STRING':
+        return value ? `"${value}"` : value
       default:
         return value
     }

--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
@@ -332,6 +332,8 @@ export const BuildTemplatedCommandStep: React.FC<
               ?.slice(-2)
               .join('.')
           : undefined
+      case 'ARG_UNIVERSAL':
+        return values?.slice(-1)[0] ?? undefined
       case 'ARG_COMPONENT':
         return value ? values[1] : value
       case 'ARG_COMMAND':

--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
@@ -338,6 +338,8 @@ export const BuildTemplatedCommandStep: React.FC<
         return value ? values[1] : value
       case 'ARG_COMMAND':
         return value ? values[0] : value
+      case 'ARG_MISSION':
+        return value ? values[0] : value
       case 'ARG_QUOTED_STRING':
         return value ? `"${value}"` : value
       default:


### PR DESCRIPTION
Resolved the following issues with scheduling commands:

- There are now mission name, component and element options for commands that use them.
- Commands that are scheduled should quickly appear in the scheduling log.
- Fields previously marked token, int or string will now use the appropriate label to describe what they represent.
- Quoted string fields now resolve to quoted strings in the command string.
- Command strings are now assembled without extra characters. 

#### Correctly assembles command text without extra characters
<img width="1018" alt="Screenshot 2025-06-09 at 5 40 53 PM" src="https://github.com/user-attachments/assets/fbf298bc-01b1-457e-b548-c3f660715755" />

#### Quoted strings are quoted in command text
<img width="1027" alt="Screenshot 2025-06-09 at 5 40 04 PM" src="https://github.com/user-attachments/assets/7b46fee1-9dce-4a1c-bcad-426a4ae7f33f" />

#### Component and element options are loaded correctly
<img width="1017" alt="Screenshot 2025-06-09 at 5 39 05 PM" src="https://github.com/user-attachments/assets/b256463f-21a9-4bd7-9711-a674cea52b20" />

#### Generic fields have appropriate labels to describe what they represent
<img width="1018" alt="Screenshot 2025-06-09 at 5 37 58 PM" src="https://github.com/user-attachments/assets/a3aecf26-414d-47b4-9343-96ad4263544b" />

#### Mission options are loaded correctly
<img width="1020" alt="Screenshot 2025-06-09 at 5 53 31 PM" src="https://github.com/user-attachments/assets/36305432-cef5-4d55-8c37-9f2bd83ce46d" />

