### PR TITLE
Fix missing or partially displayed mission names

### DIFF
--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -146,13 +146,10 @@ const MissionModal: React.FC<MissionModalProps> = ({
     { enabled: !!vehicleName }
   )
 
-  const { data: recentRunsData } = useRecentRuns(
-    {
-      vehicles: vehicles ?? [],
-      from: LAST_60_DAYS,
-    },
-    { enabled: !!vehicles }
-  )
+  const { data: recentRunsData, isLoading: recentRunsLoading } = useRecentRuns({
+    vehicles: [], // All vehicles by default
+    from: LAST_60_DAYS,
+  })
   const {
     mutate: createCommand,
     isLoading: sendingCommand,
@@ -207,6 +204,7 @@ const MissionModal: React.FC<MissionModalProps> = ({
       ?.map(
         (
           {
+            data,
             mission,
             vehicleName: vehicle,
             isoTime,
@@ -222,7 +220,7 @@ const MissionModal: React.FC<MissionModalProps> = ({
             id: mission,
             category,
             name,
-            description: mission,
+            description: data,
             vehicle,
             ranOn: capitalize(
               DateTime.fromISO(isoTime).toFormat('MMM. d yyyy')
@@ -418,6 +416,7 @@ const MissionModal: React.FC<MissionModalProps> = ({
       onFocusWaypoint={onFocusWaypoint}
       vehicles={vehicles}
       loading={sendingCommand}
+      missionsLoading={recentRunsLoading}
       commandText={commandText}
       unitOptions={unitsData}
       selectedId={selectedMission}

--- a/packages/api-client/src/react-query/Command/useRecentRuns.test.tsx
+++ b/packages/api-client/src/react-query/Command/useRecentRuns.test.tsx
@@ -7,35 +7,54 @@ import { rest } from 'msw'
 import { setupServer } from 'msw/node'
 import { MockProviders } from '../queryTestHelpers'
 
+// Mock events containing various mission names (including ones with digits and underscores) to
+// ensure the regex in `useRecentRuns` properly extracts them.
 const mockResponse = {
   result: [
     {
-      eventId: 17097188,
+      eventId: 1,
       vehicleName: 'brizo',
-      unixTime: 1660056630848,
-      isoTime: '2022-08-09T14:50:30.848Z',
+      unixTime: 1718512400000,
+      isoTime: '2024-06-16T04:00:00.000Z',
       eventType: 'run',
       user: 'Brian Kieft',
-      data: 'sched asap "load Science/profile_station.xml;set profile_station.MissionTimeout 4 h;set profile_station.NeedCommsTime 30 min;set profile_station.Lat 43.9375 degree;set profile_station.Lon -86.499304 degree;set profile_station.YoYoMaxDepth 4 m" p7w6 1 2\nsched asap "set profile_station.YoYoPitch 12 degree;set profile_station.Speed 0.8 m/s;set profile_station.MaxDepth 9 m;set profile_station.MinOffshore 0.5 km;run" p7w6 2 2',
+      data: 'load Science/sci2.tl;set sci2.MissionTimeout 4 h;set sci2.Lat1 36.903 degree;set sci2.Lon1 -122.11055 degree;set sci2.YoYoMinDepth 5 m;set sci2.YoYoMaxDepth 30 m;run',
     },
     {
-      eventId: 17097032,
+      eventId: 2,
       vehicleName: 'brizo',
-      unixTime: 1660013627155,
-      isoTime: '2022-08-09T02:53:47.155Z',
+      unixTime: 1718512300000,
+      isoTime: '2024-06-16T03:58:20.000Z',
       eventType: 'run',
       user: 'Brian Kieft',
-      data: 'sched asap "load Science/profile_station.tl;set profile_station.MissionTimeout 10 h;set profile_station.NeedCommsTime 60 min;set profile_station.Lat 43.92975 degree;set profile_station.Lon -86.5052 degree;set profile_station.YoYoMaxDepth 4 m" oapn 1 2\nsched asap "set profile_station.YoYoPitch 12 degree;set profile_station.Speed 0.8 m/s;set profile_station.MaxDepth 9 m;set profile_station.MinOffshore 0.5 km;run" oapn 2 2',
+      data: 'sched asap "load Science/profile_station.tl;set profile_station.MissionTimeout 6 h;set profile_station.NeedCommsTime 60 min;set profile_station.Lat 36.9057 degree;set profile_station.Lon -122.1161 degree;set profile_station.YoYoMinDepth 5 m" 2v4l8 1 2\nsched asap "set profile_station.YoYoMaxDepth 30 m;set profile_station.Speed 1.0 m/s;run" 2v4l8 2 2',
     },
     {
-      eventId: 17096967,
+      eventId: 3,
       vehicleName: 'brizo',
-      unixTime: 1660001471824,
-      isoTime: '2022-08-08T23:31:11.824Z',
+      unixTime: 1718512200000,
+      isoTime: '2024-06-16T03:56:40.000Z',
       eventType: 'run',
       user: 'Chris Preston',
-      note: 'Increased mission timout.  Still going to NN1-E',
-      data: 'sched asap "load Science/profile_station.xml;set profile_station.MissionTimeout 16 h;set profile_station.NeedCommsTime 60 min;set profile_station.Lat 43.907447 degree;set profile_station.Lon -86.52055 degree" o1bz 1 2\nsched asap "set profile_station.YoYoMaxDepth 20 m;run" o1bz 2 2',
+      data: 'load Maintenance/ballast_and_trim.tl;set ballast_and_trim.Depth1 15 m;run',
+    },
+    {
+      eventId: 4,
+      vehicleName: 'brizo',
+      unixTime: 1718512100000,
+      isoTime: '2024-06-16T03:55:00.000Z',
+      eventType: 'run',
+      user: 'Test User',
+      data: 'sched 20250616T0415 "load Science/nested_dir/profile_station_12.tl;set profile_station_12.MissionTimeout 14 h;set profile_station_12.NeedCommsTime 60 min;set profile_station_12.Lat 36.797 degree;set profile_station_12.Lon -121.847 degree" 2t7vk 1 2\nsched 20250616T0415 "set profile_station_12.YoYoMaxDepth 35 m;set profile_station_12.Speed 0.9 m/s;run" 2t7vk 2 2',
+    },
+    {
+      eventId: 5,
+      vehicleName: 'brizo',
+      unixTime: 1718512000000,
+      isoTime: '2024-06-16T03:53:20.000Z',
+      eventType: 'run',
+      user: 'Test User',
+      data: 'load Engineering/sink.tl;set sink.SinkDuration 1.5 h;set sink.Depth 15 m;set sink.DepthDeadband 5 m;run',
     },
   ],
 }
@@ -75,15 +94,20 @@ describe('useRecentRuns', () => {
       </MockProviders>
     )
 
-    await waitFor(() => {
-      return screen.getByTestId('command0')
-    })
+    await waitFor(() => screen.getByTestId('command4'))
 
-    expect(screen.getByTestId('command0')).toHaveTextContent(
-      'Science/profile_station.xml'
-    )
+    expect(screen.getByTestId('command0')).toHaveTextContent('Science/sci2.tl')
     expect(screen.getByTestId('command1')).toHaveTextContent(
       'Science/profile_station.tl'
+    )
+    expect(screen.getByTestId('command2')).toHaveTextContent(
+      'Maintenance/ballast_and_trim.tl'
+    )
+    expect(screen.getByTestId('command3')).toHaveTextContent(
+      'Science/nested_dir/profile_station_12.tl'
+    )
+    expect(screen.getByTestId('command4')).toHaveTextContent(
+      'Engineering/sink.tl'
     )
   })
 })

--- a/packages/api-client/src/react-query/Command/useRecentRuns.ts
+++ b/packages/api-client/src/react-query/Command/useRecentRuns.ts
@@ -23,6 +23,10 @@ export const useRecentRuns = (
   )
 
   const formattedData = query.data?.map((event) => {
+    // Regex: /[a-zA-Z0-9_/]+(\.xml|\.tl)/
+    //   • [a-zA-Z0-9_/]+  → one or more letters, digits, “_”, or “/” (captures a simple path or filename)
+    //   • (\.xml|\.tl)    → that sequence must end with “.xml” **or** “.tl” (the dot is escaped to mean a literal dot)
+    // Summary → Pulls out the first path-like token in event.data that ends in one of those extensions
     const mission = event.data?.match(/[a-zA-Z0-9_/]+(\.xml|\.tl)/)?.[0] ?? ''
     const { waypointOverrides, parameterOverrides } = extractOverrides(
       event.data ?? ''

--- a/packages/api-client/src/react-query/Command/useRecentRuns.ts
+++ b/packages/api-client/src/react-query/Command/useRecentRuns.ts
@@ -23,7 +23,7 @@ export const useRecentRuns = (
   )
 
   const formattedData = query.data?.map((event) => {
-    const mission = event.data?.match(/[a-zA-Z_/]+(\.xml|\.tl)/)?.[0] ?? ''
+    const mission = event.data?.match(/[a-zA-Z0-9_/]+(\.xml|\.tl)/)?.[0] ?? ''
     const { waypointOverrides, parameterOverrides } = extractOverrides(
       event.data ?? ''
     )

--- a/packages/react-ui/src/Data/Table.tsx
+++ b/packages/react-ui/src/Data/Table.tsx
@@ -16,6 +16,7 @@ export interface TableProps {
   selectedIndex?: number | null
   onSelectRow?: (index: number) => void
   colInRow?: number
+  loading?: boolean
 }
 
 const gridClassNames = [
@@ -50,6 +51,7 @@ export const Table: React.FC<TableProps> = ({
   onSelectRow,
   selectedIndex,
   colInRow,
+  loading,
 }) => {
   // dynamically calculate grid columns unless defined through associated prop
   const colsInRow = colInRow ? colInRow : rows[0]?.cells.length | 0
@@ -85,25 +87,32 @@ export const Table: React.FC<TableProps> = ({
           </thead>
         )}
         <tbody>
-          {rows.map((row, index) => (
+          {(loading && !rows.length) || !rows.length ? (
             <TableRow
-              key={`${row?.cells[0]}${index}`}
-              className={clsx(
-                'grid',
-                gridClassNames[colsInRow],
-                !onSelectRow && 'gap-4',
-                onSelectRow &&
-                  (selectedIndex === index
-                    ? 'bg-sky-200/70'
-                    : 'hover:bg-sky-50'),
-                index !== 0 && styles.borderTop
-              )}
-              {...row}
-              scrollable={scrollable}
-              highlightedStyle={highlightedStyle}
-              onSelect={onSelectRow ? () => handleSelectRow(index) : null}
+              cells={[{ label: loading ? 'Loading...' : 'No Results' }]}
+              className="grid-cols-1"
             />
-          ))}
+          ) : (
+            rows.map((row, index) => (
+              <TableRow
+                key={`${row?.cells[0]}${index}`}
+                className={clsx(
+                  'grid',
+                  gridClassNames[colsInRow],
+                  !onSelectRow && 'gap-4',
+                  onSelectRow &&
+                    (selectedIndex === index
+                      ? 'bg-sky-200/70'
+                      : 'hover:bg-sky-50'),
+                  index !== 0 && styles.borderTop
+                )}
+                {...row}
+                scrollable={scrollable}
+                highlightedStyle={highlightedStyle}
+                onSelect={onSelectRow ? () => handleSelectRow(index) : null}
+              />
+            ))
+          )}
         </tbody>
       </table>
     </article>

--- a/packages/react-ui/src/Modals/MissionModalSteps/MissionStep.tsx
+++ b/packages/react-ui/src/Modals/MissionModalSteps/MissionStep.tsx
@@ -14,6 +14,7 @@ export interface MissionStepProps {
   selectedCategory?: string
   onSelectCategory?: (id?: string) => void
   defaultSearchText?: string
+  loading?: boolean
 }
 
 export const MissionStep: React.FC<MissionStepProps> = ({
@@ -25,6 +26,7 @@ export const MissionStep: React.FC<MissionStepProps> = ({
   onSelectCategory: handleSelectCategory,
   selectedCategory = 'Recent Runs',
   defaultSearchText = '',
+  loading,
 }) => {
   const [searchTerm, setSearchTerm] = useState(defaultSearchText)
   const [filteredMissions, setFilteredMissions] = useState<Mission[]>(missions)
@@ -129,6 +131,7 @@ export const MissionStep: React.FC<MissionStepProps> = ({
         onSortColumn={handleSort}
         sortColumn={sortColumn}
         sortDirection={sortDirection}
+        loading={loading}
       />
     </article>
   )

--- a/packages/react-ui/src/Modals/MissionModalView.tsx
+++ b/packages/react-ui/src/Modals/MissionModalView.tsx
@@ -78,6 +78,7 @@ export interface MissionModalViewProps
   onStepIndexChange?: (step: number) => void
   selectedMissionCategory?: string
   defaultSearchText?: string
+  missionsLoading?: boolean
 }
 
 export const MissionModalView: React.FC<MissionModalViewProps> = (props) => (
@@ -122,6 +123,7 @@ const MissionModalBody: React.FC<MissionModalViewProps> = ({
   selectedMissionCategory: defaultMissionCategory,
   defaultOverrides,
   defaultSearchText,
+  missionsLoading,
 }) => {
   const [selectedMissionCategory, setSelectedMissionCategory] = useState<
     string | undefined
@@ -281,6 +283,7 @@ const MissionModalBody: React.FC<MissionModalViewProps> = ({
             onSelectCategory={handleSelectCategory}
             selectedCategory={selectedMissionCategory}
             defaultSearchText={defaultSearchText}
+            loading={missionsLoading}
           />
         )
 

--- a/packages/react-ui/src/Tables/MissionTable.tsx
+++ b/packages/react-ui/src/Tables/MissionTable.tsx
@@ -13,6 +13,7 @@ export interface MissionTableProps {
   onSortColumn?: (column: number, ascending?: boolean) => void
   sortColumn?: number | null
   sortDirection?: SortDirection
+  loading?: boolean
 }
 
 export interface Mission {
@@ -40,6 +41,7 @@ export const MissionTable: React.FC<MissionTableProps> = ({
   onSortColumn,
   sortColumn,
   sortDirection,
+  loading,
 }) => {
   const shouldShowVehicleColumn = missions.some((p) => p.recentRun)
   const missionRows = missions.map(
@@ -137,6 +139,7 @@ export const MissionTable: React.FC<MissionTableProps> = ({
         selectedId ? missions.findIndex(({ id }) => id === selectedId) : null
       }
       colInRow={6}
+      loading={loading}
     />
   )
 }

--- a/packages/react-ui/src/Tables/MissionTable.tsx
+++ b/packages/react-ui/src/Tables/MissionTable.tsx
@@ -71,7 +71,21 @@ export const MissionTable: React.FC<MissionTableProps> = ({
             }
           : null,
         {
-          label: description ? description : 'No description',
+          label: description ? (
+            <span
+              className="block overflow-hidden text-indigo-600 transition-all duration-200"
+              style={{
+                display: '-webkit-box',
+                WebkitLineClamp: 2, // tailwind line clamp doesn't work here since parent has flex
+                WebkitBoxOrient: 'vertical',
+              }}
+              title={description}
+            >
+              {description}
+            </span>
+          ) : (
+            'No description'
+          ),
           span: 3,
           secondary: (
             <ul className="">


### PR DESCRIPTION
- Fix regex to extract mission names in useRecentRuns
- Add simple loading and no results states to Table and by extension, MissionTable
- Display truncated mission command string for mission description instead of repeating mission name; hover to view full mission command string
- In MissionModal, useRecentCommands was waiting for useVehicleNames to load all the vehicle names before fetching, but supplying an empty array to useRecentCommands yields the same result without waiting; fixed

### Staging with missing or partial mission names
<img width="1020" alt="Screenshot 2025-06-12 at 6 04 18 PM" src="https://github.com/user-attachments/assets/0b504b49-eb64-4069-a00e-31b2b826a13e" />

### Mission names made whole
<img width="1012" alt="Screenshot 2025-06-12 at 6 05 18 PM" src="https://github.com/user-attachments/assets/41b5f02c-cbd2-49d1-88ce-5b0eb179bec2" />

