### PR TITLE
Report depth as a positive value when using map mouseover

### DIFF
--- a/apps/lrauv-dash2/lib/elevationService.ts
+++ b/apps/lrauv-dash2/lib/elevationService.ts
@@ -119,7 +119,7 @@ export const getCachedElevation = async (
     })
 
     if (response.results?.[0]) {
-      const elevation = response.results[0].elevation
+      const elevation = Math.abs(response.results[0].elevation)
       // Cache the result
       elevationCache.set(key, elevation)
       return elevation

--- a/apps/lrauv-dash2/lib/useGoogleElevator.ts
+++ b/apps/lrauv-dash2/lib/useGoogleElevator.ts
@@ -57,7 +57,7 @@ export function useElevator() {
           )
 
           // Process result
-          const elevation = result?.results?.[0]?.elevation ?? null
+          const elevation = Math.abs(result?.results?.[0]?.elevation) ?? null
           lastKnownDepth.current = elevation
 
           return {


### PR DESCRIPTION
- Update `useGoogleElevator` to report depth as its absolute value
- Update `elevationService` to report cached depth as its absolute value

<img width="323" height="289" alt="Screenshot 2025-08-04 at 12 32 58 PM" src="https://github.com/user-attachments/assets/cc00c741-2c5a-4202-b85d-e243707271ab" />
