### PR TITLE
Apply comms filtering in Logs section

### DIFF
--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -17,6 +17,7 @@ import formatEvent, {
   eventFilters,
   isUploadEvent,
 } from '../lib/formatEvent'
+import { applyEventFilters } from '../lib/eventFilterUtils'
 import { createLogger } from '@mbari/utils'
 
 const logger = createLogger('components.LogsSection')
@@ -93,8 +94,13 @@ const LogsSection: React.FC<LogsSectionProps> = ({
 
   const flatData = useMemo(() => {
     if (!data?.pages) return []
-    return data.pages.flat()
-  }, [data?.pages])
+    let events = data.pages.flat()
+    if (filters.length) {
+      const selectedFilterNames = filters.map(({ id }) => id)
+      events = applyEventFilters(events, selectedFilterNames)
+    }
+    return events
+  }, [data?.pages, filters])
   const dataCount = flatData?.length ?? 0
   const totalCount = hasNextPage ? dataCount + 1 : dataCount
 

--- a/apps/lrauv-dash2/lib/eventFilterUtils.ts
+++ b/apps/lrauv-dash2/lib/eventFilterUtils.ts
@@ -1,0 +1,51 @@
+/**
+ * Generic helper utilities for client-side event filtering based on the
+ * `eventFilters` map exported from `formatEvent.ts`.
+ *
+ * Each entry in `eventFilters` contains:
+ *   • `eventTypes` – EventType[] that belong to that category
+ *   • `filter?`    – optional filtering for comms events
+ *
+ * The functions below combine both rules so that a consumer can simply supply
+ * the chosen filter names (as selected in the UI) and receive the subset of
+ * events that satisfy *any* of those filters.
+ */
+
+import { GetEventsResponse } from '@mbari/api-client'
+import { eventFilters } from './formatEvent'
+
+/**
+ * Returns true when the provided event satisfies the filter referenced by
+ * `filterName`.
+ */
+export function doesEventMatchFilter(
+  event: GetEventsResponse,
+  selectedEventType: string
+): boolean {
+  const matchingEventFilter = eventFilters[selectedEventType]
+  if (!matchingEventFilter) return false
+
+  // 1) Must match the allowed eventTypes for that filter.
+  if (!matchingEventFilter.eventTypes.includes(event.eventType)) return false
+
+  // 2) If it's a comms event, it must also pass the additional comms filters
+  return matchingEventFilter.filter ? matchingEventFilter.filter(event) : true
+}
+
+/**
+ * Filters `events`, keeping only those that satisfy at least one of the filter
+ * names in `selectedFilterNames`.
+ *
+ * If no filter names are provided, the original `events` array is returned
+ * unchanged.
+ */
+export function applyEventFilters(
+  events: GetEventsResponse[],
+  selectedEventTypes: string[]
+): GetEventsResponse[] {
+  if (!selectedEventTypes.length) return events
+
+  return events.filter((event) =>
+    selectedEventTypes.some((name) => doesEventMatchFilter(event, name))
+  )
+}


### PR DESCRIPTION
The Logs section filters were only filtering by event type, however comms events share event types such as `sbdSend` and `sbdReceive` and therefore, need additional filtering

- Created util functions to filter by event type with the additional comms filters included (this is set up so that if more filters are included in the future, it will still apply them correctly)
- Updated LogsSection with the additional filters



### Sat Comms
<img width="641" height="400" alt="Screenshot 2025-08-04 at 4 24 57 PM" src="https://github.com/user-attachments/assets/7a0ec26f-df68-4909-862a-09d666513b69" />

### Direct Comms
<img width="641" height="378" alt="Screenshot 2025-08-04 at 4 25 26 PM" src="https://github.com/user-attachments/assets/3cdadd9a-bbe2-425b-8d67-246ef4124507" />
