### PR TITLE
Show Unavailable For PIC / OnCall Roles When User Is Not Logged In

### DIFF
--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -70,8 +70,10 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
   }
 
   const handoffLabel =
-    picLabel || onCallLabel
-      ? `${picLabel ?? 'Unassigned'} / ${onCallLabel ?? 'Unassigned'}`
+    (picLabel || onCallLabel) && authenticated
+      ? `${!!picLabel ? picLabel : 'Unassigned'} / ${
+          !!onCallLabel ? onCallLabel : 'Unassigned'
+        }`
       : undefined
 
   const { setGlobalModalId } = useGlobalModalId()

--- a/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
+++ b/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
@@ -107,9 +107,14 @@ const Vehicle: NextPage = () => {
     }
   )
 
-  const { data, isLoading: loadingPicAndOnCall } = useVehiclePicAndOnCall({
-    vehicleName,
-  })
+  const { data, isLoading: loadingPicAndOnCall } = useVehiclePicAndOnCall(
+    {
+      vehicleName,
+    },
+    {
+      enabled: !!vehicleName && authenticated,
+    }
+  )
 
   const { profile } = useTethysApiContext()
   const currentUserName = profile
@@ -120,10 +125,22 @@ const Vehicle: NextPage = () => {
   const onCalls = data?.[0]?.onCalls.map((o) => o.user)
 
   const picLabel = pics?.length
-    ? createRoleLabel(pics, 'PIC', currentUserName)
+    ? createRoleLabel({
+        operators: pics,
+        role: 'PIC',
+        currentUser: currentUserName,
+        authenticated,
+        loading: loadingPicAndOnCall,
+      })
     : ''
   const onCallLabel = onCalls?.length
-    ? createRoleLabel(onCalls, 'On-Call', currentUserName)
+    ? createRoleLabel({
+        operators: onCalls,
+        role: 'On-Call',
+        currentUser: currentUserName,
+        authenticated,
+        loading: loadingPicAndOnCall,
+      })
     : ''
 
   useEffect(() => {
@@ -240,9 +257,8 @@ const Vehicle: NextPage = () => {
                       unixTime: deployment?.startEvent?.unixTime,
                     }
               }
-              onRoleReassign={
-                loadingPicAndOnCall ? undefined : handleRoleReassign
-              }
+              onRoleReassign={handleRoleReassign}
+              loadingPicAndOnCall={loadingPicAndOnCall}
               supportIcon1={
                 pingEvent?.reachable ? <ConnectedIcon /> : <NotConnectedIcon />
               }
@@ -296,6 +312,7 @@ const Vehicle: NextPage = () => {
                   )}`}
                 />
               )}
+              authenticated={authenticated}
             />
             <div className={styles.content}>
               <Allotment separator defaultSizes={[75, 25]}>
@@ -383,8 +400,8 @@ const Vehicle: NextPage = () => {
                       vehicleName={vehicleName}
                       from={adjustedDeploymentStartTime}
                       to={endTime}
-                      picLabel={loadingPicAndOnCall ? '...' : picLabel}
-                      onCallLabel={loadingPicAndOnCall ? '...' : onCallLabel}
+                      picLabel={picLabel}
+                      onCallLabel={onCallLabel}
                       activeDeployment={deployment.active}
                       currentDeploymentId={deployment.deploymentId as number}
                     />

--- a/packages/api-client/src/react-query/User/useVehiclePicAndOnCall.ts
+++ b/packages/api-client/src/react-query/User/useVehiclePicAndOnCall.ts
@@ -6,6 +6,7 @@ import { useTethysApiContext } from '../TethysApiProvider'
 import { useQuery } from 'react-query'
 import { DateTime } from 'luxon'
 import { getAdjustedUnixTime } from '@mbari/utils'
+import { SupportedQueryOptions } from '../types'
 
 const THREE_MONTHS_AGO = getAdjustedUnixTime({
   unixTime: DateTime.now().toMillis(),
@@ -33,18 +34,19 @@ export interface UseVehiclePicAndOnCallResult {
 
 export interface UseVehiclePicAndOnCallParams {
   vehicleName: string | string[]
-  enabled?: boolean
 }
 
 /**
- * Hook to get the PIC and OnCall users for a vehicle from note events
- * @param params Parameters including vehicleName and enabled flag
- * @returns The PIC and OnCall users found in the notes, with loading state
+ * Hook to get the PIC and On-Call users for one or more vehicles from note events
+ * @param params   Query parameters (currently only vehicleName)
+ * @param options  React-Query options such as enabled, staleTime, etc.
+ * @returns The PIC and On-Call users found in the notes, with loading state
  */
-export const useVehiclePicAndOnCall = ({
-  vehicleName,
-  enabled = true,
-}: UseVehiclePicAndOnCallParams): UseVehiclePicAndOnCallResult => {
+export const useVehiclePicAndOnCall = (
+  params: UseVehiclePicAndOnCallParams,
+  options?: SupportedQueryOptions
+): UseVehiclePicAndOnCallResult => {
+  const { vehicleName } = params
   const vehicleNames = Array.isArray(vehicleName) ? vehicleName : [vehicleName]
   const { axiosInstance } = useTethysApiContext()
 
@@ -79,7 +81,7 @@ export const useVehiclePicAndOnCall = ({
     },
     {
       staleTime: STALE_TIME,
-      enabled,
+      ...options,
     }
   )
 

--- a/packages/react-ui/src/Navigation/RoleReassignButton.test.tsx
+++ b/packages/react-ui/src/Navigation/RoleReassignButton.test.tsx
@@ -2,29 +2,37 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import { RoleReassignButton } from './RoleReassignButton'
 
+const args = {
+  authenticated: true,
+  loading: false,
+}
+
 describe('RoleReassignButton', () => {
   test('should render the component with default props', () => {
     expect(() => render(<RoleReassignButton />)).not.toThrow()
   })
 
   test('should display "No PIC" when pics array is empty', () => {
-    render(<RoleReassignButton />)
+    render(<RoleReassignButton {...args} />)
     expect(screen.getByText('No PIC')).toBeInTheDocument()
   })
 
   test('should display "No On-Call" when onCalls array is empty', () => {
-    render(<RoleReassignButton />)
+    render(<RoleReassignButton {...args} />)
     expect(screen.getByText('No On-Call')).toBeInTheDocument()
   })
 
   test('should display shortenedsingle PIC name when provided', () => {
-    render(<RoleReassignButton pics={['John Doe']} />)
+    render(<RoleReassignButton pics={['John Doe']} {...args} />)
     expect(screen.getByText('John D.')).toBeInTheDocument()
   })
 
   test('should display the count when multiple PICs are provided', () => {
     render(
-      <RoleReassignButton pics={['John Doe', 'Jane Smith', 'Bob Johnson']} />
+      <RoleReassignButton
+        pics={['John Doe', 'Jane Smith', 'Bob Johnson']}
+        {...args}
+      />
     )
     expect(screen.getByText('3 PIC')).toBeInTheDocument()
   })
@@ -34,6 +42,7 @@ describe('RoleReassignButton', () => {
       <RoleReassignButton
         pics={['Alice Cooper']}
         currentUserName="Alice Cooper"
+        {...args}
       />
     )
     expect(screen.getByText('You')).toBeInTheDocument()
@@ -44,6 +53,7 @@ describe('RoleReassignButton', () => {
       <RoleReassignButton
         pics={['Alice Cooper', 'Bob Dylan', 'Charlie Parker']}
         currentUserName="Alice Cooper"
+        {...args}
       />
     )
     expect(screen.getByText('You and 2 others')).toBeInTheDocument()
@@ -54,6 +64,7 @@ describe('RoleReassignButton', () => {
       <RoleReassignButton
         pics={['Alice Cooper', 'Bob Dylan']}
         currentUserName="Alice Cooper"
+        {...args}
       />
     )
     expect(screen.getByText('You and 1 other')).toBeInTheDocument()
@@ -64,6 +75,7 @@ describe('RoleReassignButton', () => {
       <RoleReassignButton
         pics={['Alice Cooper']}
         currentUserName="Alice Cooper"
+        {...args}
       />
     )
 
@@ -76,6 +88,7 @@ describe('RoleReassignButton', () => {
       <RoleReassignButton
         onCalls={['Alice Cooper']}
         currentUserName="Alice Cooper"
+        {...args}
       />
     )
 
@@ -84,14 +97,27 @@ describe('RoleReassignButton', () => {
   })
 
   test('should display shortened name for a single onCall user', () => {
-    render(<RoleReassignButton onCalls={['John Smith']} />)
+    render(<RoleReassignButton onCalls={['John Smith']} {...args} />)
     expect(screen.getByText('John S.')).toBeInTheDocument()
   })
 
   test('should display the count when multiple onCalls are provided', () => {
     render(
-      <RoleReassignButton onCalls={['John Doe', 'Jane Smith', 'Bob Johnson']} />
+      <RoleReassignButton
+        onCalls={['John Doe', 'Jane Smith', 'Bob Johnson']}
+        {...args}
+      />
     )
     expect(screen.getByText('3 On-Call')).toBeInTheDocument()
+  })
+
+  test('should display "Unavailable" when authenticated is false', () => {
+    render(<RoleReassignButton {...args} authenticated={false} />)
+    expect(screen.getByText('Unavailable')).toBeInTheDocument()
+  })
+
+  test('should display "..." when loading is true', () => {
+    render(<RoleReassignButton {...args} loading={true} />)
+    expect(screen.getAllByText('...').length).toBe(2)
   })
 })

--- a/packages/react-ui/src/Navigation/RoleReassignButton.tsx
+++ b/packages/react-ui/src/Navigation/RoleReassignButton.tsx
@@ -7,6 +7,8 @@ export interface RoleReassignButtonProps {
   pics?: string[]
   onCalls?: string[]
   currentUserName?: string
+  authenticated?: boolean
+  loading?: boolean
   onRoleReassign?: () => void
   className?: string
 }
@@ -15,6 +17,8 @@ export const RoleReassignButton: React.FC<RoleReassignButtonProps> = ({
   pics = [],
   onCalls = [],
   currentUserName,
+  authenticated,
+  loading,
   onRoleReassign,
   className,
 }) => {
@@ -22,8 +26,20 @@ export const RoleReassignButton: React.FC<RoleReassignButtonProps> = ({
   const currentUserIsOnCall = !!(
     currentUserName && onCalls.includes(currentUserName)
   )
-  const picLabel = createRoleLabel(pics, 'PIC', currentUserName)
-  const onCallLabel = createRoleLabel(onCalls, 'On-Call', currentUserName)
+  const picLabel = createRoleLabel({
+    operators: pics,
+    role: 'PIC',
+    loading,
+    currentUser: currentUserName,
+    authenticated,
+  })
+  const onCallLabel = createRoleLabel({
+    operators: onCalls,
+    role: 'On-Call',
+    loading,
+    currentUser: currentUserName,
+    authenticated,
+  })
   return (
     <AccessoryButton
       label={picLabel}

--- a/packages/react-ui/src/Toolbars/OverviewToolbar.test.tsx
+++ b/packages/react-ui/src/Toolbars/OverviewToolbar.test.tsx
@@ -72,6 +72,8 @@ const props: OverviewToolbarProps = {
   ),
   supportIcon1: <></>,
   supportIcon2: <></>,
+  loadingPicAndOnCall: false,
+  authenticated: true,
 }
 
 test('should render deployment name to the screen', async () => {

--- a/packages/react-ui/src/Toolbars/OverviewToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/OverviewToolbar.tsx
@@ -33,6 +33,8 @@ export interface OverviewToolbarProps {
   onIcon1hover?: () => JSX.Element
   onIcon2hover?: () => JSX.Element
   deployments?: DeploymentInfo[]
+  authenticated?: boolean
+  loadingPicAndOnCall?: boolean
   onSelectDeployment?: (deployment: DeploymentInfo) => void
 }
 
@@ -68,6 +70,8 @@ export const OverviewToolbar: React.FC<OverviewToolbarProps> = ({
   onRoleReassign,
   onIcon1hover,
   onIcon2hover,
+  authenticated,
+  loadingPicAndOnCall,
 }) => {
   const [hovering, setHovering] = useState<HoverOption>(null)
   const [showDeployments, setShowDeployments] = useState(false)
@@ -164,6 +168,8 @@ export const OverviewToolbar: React.FC<OverviewToolbarProps> = ({
               pics={pics}
               onCalls={onCalls}
               currentUserName={currentUserName}
+              authenticated={authenticated}
+              loading={loadingPicAndOnCall}
               onRoleReassign={onRoleReassign}
             />
           </li>

--- a/packages/utils/src/createRoleLabel.ts
+++ b/packages/utils/src/createRoleLabel.ts
@@ -1,5 +1,13 @@
 import { shortenName } from './shortenName'
 
+export interface CreateRoleLabelParams {
+  operators: string[]
+  role: 'PIC' | 'On-Call'
+  currentUser?: string
+  authenticated?: boolean
+  loading?: boolean
+}
+
 /**
  * Creates a human-readable label for role assignments based on a list of operators and the current user's status.
  *
@@ -8,11 +16,17 @@ import { shortenName } from './shortenName'
  * @param role - The type of role, either 'PIC' (Person In Charge) or 'On-Call'
  * @returns A string representing the role status in a user-friendly format
  */
-export const createRoleLabel = (
-  operators: string[],
-  role: 'PIC' | 'On-Call',
-  currentUser?: string
-) => {
+export const createRoleLabel = ({
+  operators,
+  role,
+  currentUser,
+  authenticated,
+  loading,
+}: CreateRoleLabelParams) => {
+  if (!authenticated && role === 'PIC') return 'Unavailable'
+  if (!authenticated && role === 'On-Call') return ''
+  if (loading) return '...'
+
   const operatorCount = operators.length
   if (!operatorCount) return `No ${role}`
 


### PR DESCRIPTION
- Update createRoleLabel util function and RoleReassignButton with unauthenticated and loading states
- Display Unavailable message for role reassignment button when user is not logged in
- Do not display any role information in Handoff section header when user is not logged in
- Update useVehiclePicAndOnCall hook to accept query param options in the same way as other hooks
- Only enable useVehiclePicAndOnCall on the deployment page when user is authenticated
- Fix issue where empty strings were causing the roles to render incorrectly in the handoff section header (ie instead of reading 'Unassigned/Brian K' when Brian was the OnCall and no-one was PIC, it would read '/BrianK')