### PR TITLE
Mission parameter UI updates

### DIFF
--- a/packages/react-ui/src/Modals/MissionModalSteps/ParameterStep.tsx
+++ b/packages/react-ui/src/Modals/MissionModalSteps/ParameterStep.tsx
@@ -125,20 +125,20 @@ export const ParameterStep: React.FC<ParameterStepProps> = ({
   return (
     <article className="flex h-full flex-col">
       <section className="pb-2">
-        <div className="mb-4">
+        <div>
           Set mission parameters for {vehicleName}&apos;s{' '}
           <span className="text-teal-500" data-testid="mission name">
             {mission}
           </span>{' '}
           mission
         </div>
-        <div className="py-4">
+        <div className="py-2">
           <ul className="grid grid-cols-2 gap-4">
             <li>
               <Input
                 name="Search parameters field"
                 placeholder="Search parameters"
-                className="ml-2 h-full"
+                className="h-full"
                 value={searchTerm}
                 onChange={(e) => handleSearch(e.target.value)}
               />

--- a/packages/react-ui/src/Modals/MissionModalView.tsx
+++ b/packages/react-ui/src/Modals/MissionModalView.tsx
@@ -480,7 +480,7 @@ const MissionModalBody: React.FC<MissionModalViewProps> = ({
       return (
         <Modal
           className={className}
-          style={style}
+          style={{ ...style, maxHeight: '95vh' }}
           title={
             <StepProgress
               steps={steps.slice(0, steps.length - 1)}

--- a/packages/react-ui/src/Modals/MissionModalView.tsx
+++ b/packages/react-ui/src/Modals/MissionModalView.tsx
@@ -447,6 +447,7 @@ const MissionModalBody: React.FC<MissionModalViewProps> = ({
           title="Review and Send Command"
           onConfirm={handleSchedule}
           onCancel={handlePrevious}
+          onClose={handlePrevious}
           loading={loading}
           open
           extraWideModal
@@ -490,6 +491,7 @@ const MissionModalBody: React.FC<MissionModalViewProps> = ({
           onConfirm={handleNext}
           disableConfirm={disableConfirm()}
           onCancel={onCancel}
+          onClose={onCancel}
           confirmButtonText={confirmButtonText}
           extraButtons={extraButtons()}
           snapTo="top-right"

--- a/packages/react-ui/src/Tables/AccordionParameterTable.tsx
+++ b/packages/react-ui/src/Tables/AccordionParameterTable.tsx
@@ -82,7 +82,7 @@ export const AccordionParameterTable: React.FC<
                       {name}
                     </span>
                     {description && (
-                      <div className="break-words text-stone-600/60">
+                      <div className="break-words text-sm text-stone-600/60">
                         {description}
                       </div>
                     )}

--- a/packages/react-ui/src/Tables/AccordionParameterTable.tsx
+++ b/packages/react-ui/src/Tables/AccordionParameterTable.tsx
@@ -129,13 +129,14 @@ export const AccordionParameterTable: React.FC<
   return (
     <div
       className={clsx(
-        'flex h-full flex-col border-2 border-stone-200',
+        'flex flex-col border-2 border-stone-200',
+        open && 'h-3/4',
         className
       )}
       style={style}
     >
       <AccordionHeader
-        className="sticky top-0 z-10"
+        className="top-0 z-10"
         label={`${label} parameters:`}
         ariaLabel={label}
         onExpand={onExpand}
@@ -143,10 +144,14 @@ export const AccordionParameterTable: React.FC<
         open={open}
       />
       <div
-        className={clsx('relative flex flex-col', !open && 'hidden')}
+        className={clsx(
+          'relative flex min-h-0 flex-1 flex-col',
+          !open && 'hidden'
+        )}
         aria-hidden={!open}
       >
         <AccordionCells
+          className="min-h-0 flex-1"
           header={
             <div
               className={clsx(
@@ -170,7 +175,7 @@ export const AccordionParameterTable: React.FC<
           }
           count={items.length}
           loading={loading}
-          maxHeight="max-h-400"
+          maxHeight="max-h-full"
         />
       </div>
     </div>


### PR DESCRIPTION
Changes requested by the design team for the updated mission parameter step

- Reduce vertical padding between mission text, search bar and mission parameter tables
- Add X button in top right corner of modal as another method to close modal besides cancel button
- Reduce font size of parameter description text
- Reduce height of mission parameter tables to always allow multiple tables to display, so that user knows that more parameter options are available
- Fix text overflowing parameter tables
- Increase modal height for mission scheduling to allow more content to show