### PR TITLE
Mission scheduling parameters disappearing 

### DIFF
--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -81,7 +81,7 @@ const MissionModal: React.FC<MissionModalProps> = ({
     }
   })
   const [selectedMission, setSelectedMission] = useState<string | undefined>(
-    globalModalId?.meta?.mission ?? undefined
+    undefined
   )
   const [selectedMissionCategory, setSelectedMissionCategory] = useState<
     string | undefined

--- a/apps/lrauv-dash2/lib/useMissionData.ts
+++ b/apps/lrauv-dash2/lib/useMissionData.ts
@@ -37,10 +37,17 @@ export const useMissionData = (params: {
     { enabled: !!selectedMission }
   )
 
-  const { data: recentRunsData, isLoading: isRecentRunsLoading } =
-    useRecentRuns({
+  const recentRunsParams = useMemo(
+    () => ({
       vehicles: [], // All vehicles by default
       from: LAST_60_DAYS,
+    }),
+    []
+  )
+
+  const { data: recentRunsData, isLoading: isRecentRunsLoading } =
+    useRecentRuns(recentRunsParams, {
+      staleTime: 60 * 1000,
     })
   const { data: frequentRunsData, isLoading: isFrequentRunsLoading } =
     useFrequentRuns(

--- a/packages/api-client/src/axios/Util/concurrencyLimiter.ts
+++ b/packages/api-client/src/axios/Util/concurrencyLimiter.ts
@@ -1,0 +1,25 @@
+// Concurrency limiter for script fetches
+export const createLimiter = (concurrency: number) => {
+  let activeCount = 0
+  const queue: Array<() => void> = []
+  const next = () => {
+    if (queue.length === 0 || activeCount >= concurrency) return
+    activeCount++
+    const run = queue.shift()!
+    run()
+  }
+  return <T>(fn: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const task = () => {
+        fn()
+          .then((value) => resolve(value))
+          .catch(reject)
+          .finally(() => {
+            activeCount--
+            next()
+          })
+      }
+      queue.push(task)
+      next()
+    })
+}

--- a/packages/api-client/src/react-query/Command/useRecentRuns.ts
+++ b/packages/api-client/src/react-query/Command/useRecentRuns.ts
@@ -5,6 +5,7 @@ import { generateMissionKey } from '../../axios/Util/generateMissionKey'
 import { useQuery } from 'react-query'
 import { useTethysApiContext } from '../TethysApiProvider'
 import { getScript } from '../../axios'
+import { createLimiter } from '../../axios/Util/concurrencyLimiter'
 
 export const useRecentRuns = (
   params: {
@@ -35,6 +36,16 @@ export const useRecentRuns = (
       //   • [a-zA-Z0-9_/]+  → one or more letters, digits, "_", or "/" (captures a simple path or filename)
       //   • (\.xml|\.tl)    → that sequence must end with ".xml" **or** ".tl" (the dot is escaped to mean a literal dot)
       // Summary → Pulls out the first path-like token in event.data that ends in one of those extensions
+
+      // Limit concurrent getScript requests
+      const limit = createLimiter(1)
+
+      // Cache script metadata requests by mission so we only fetch once per mission during this run
+      const scriptRequestByMission = new Map<
+        string,
+        ReturnType<typeof getScript>
+      >()
+
       const results = await Promise.all(
         query.data.map(async (event) => {
           const mission =
@@ -51,13 +62,20 @@ export const useRecentRuns = (
 
           if (hasNonstandardLatLonKeywords && mission) {
             try {
-              const { latLonNamePairs } = await getScript(
-                { path: mission, gitRef: 'master' },
-                {
-                  instance: axiosInstance,
-                  headers: { Authorization: `Bearer ${token}` },
-                }
-              )
+              let request = scriptRequestByMission.get(mission)
+              if (!request) {
+                request = limit(() =>
+                  getScript(
+                    { path: mission, gitRef: 'master' },
+                    {
+                      instance: axiosInstance,
+                      headers: { Authorization: `Bearer ${token}` },
+                    }
+                  )
+                ) as ReturnType<typeof getScript>
+                scriptRequestByMission.set(mission, request)
+              }
+              const { latLonNamePairs } = await request
               if (latLonNamePairs?.length) {
                 const newOverrides = extractOverrides(
                   event.data ?? '',
@@ -99,6 +117,8 @@ export const useRecentRuns = (
     },
     {
       enabled: !!query.data,
+      staleTime: options?.staleTime ?? 30 * 60 * 1000,
+      refetchOnWindowFocus: false,
     }
   )
 

--- a/packages/api-client/src/react-query/Event/useEvents.ts
+++ b/packages/api-client/src/react-query/Event/useEvents.ts
@@ -89,6 +89,8 @@ export const useEvents = (
     },
     {
       staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
       ...options,
     }
   )

--- a/packages/api-client/src/react-query/types.ts
+++ b/packages/api-client/src/react-query/types.ts
@@ -2,4 +2,6 @@ export interface SupportedQueryOptions {
   staleTime?: number
   enabled?: boolean
   baseUrl?: string
+  refetchOnWindowFocus?: boolean
+  refetchOnReconnect?: boolean
 }


### PR DESCRIPTION
- Create helper function to limit amount of concurrent api calls
- Limit the amount of concurrent calls to the commands/script endpoint and cache the results in useRecentRuns
- Do not refetch data on window refocus for useRecentRuns or useEvents since they are both computationally intensive
- Memoize the parameters and provide a stale time for useRecentRuns to further minimize refetching in useMissionData hook
- By default, no mission should be selected when scheduling missions