### PR TITLE
Ensure parameter overrides work for all mission scheduling

### DIFF
--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -254,11 +254,15 @@ const MissionModal: React.FC<MissionModalProps> = ({
       onSelectMissionCategory={handleSelectMissionCategory}
       selectedMissionCategory={selectedMissionCategory}
       defaultSearchText={globalModalId?.meta?.mission ?? ''}
-      defaultOverrides={[
-        ...parametersWithOverrides,
-        ...commsParamsWithOverrides,
-        ...safetyParamsWithOverrides,
-      ]}
+      defaultOverrides={
+        selectedMissionCategory === 'Recent Runs'
+          ? [
+              ...parametersWithOverrides,
+              ...commsParamsWithOverrides,
+              ...safetyParamsWithOverrides,
+            ]
+          : undefined
+      }
     />
   )
 }

--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -167,11 +167,12 @@ const MissionModal: React.FC<MissionModalProps> = ({
     }) ?? []
 
   const { data: stationsData } = useStations({ enabled: waypoints.length > 0 })
+  // GeoJSON coordinates are in [lon, lat] order
   const stations: WaypointTableProps['stations'] =
     stationsData?.map(({ name, geojson }) => ({
       name,
-      lat: `${geojson.geometry.coordinates[0]}`,
-      lon: `${geojson.geometry.coordinates[1]}`,
+      lat: `${geojson.geometry.coordinates[1]}`,
+      lon: `${geojson.geometry.coordinates[0]}`,
     })) ?? []
 
   const [previewText, setPreviewText] = useState<string | undefined>()

--- a/packages/react-ui/src/Modals/MissionModalSteps/hooks/useManagedWaypoints.ts
+++ b/packages/react-ui/src/Modals/MissionModalSteps/hooks/useManagedWaypoints.ts
@@ -82,7 +82,7 @@ const useManagedWaypoints = (waypoints: WaypointProps[] = []) => {
   }
 
   // Determine count of waypoints with actual values.
-  const plottedWaypoints = waypoints.filter(
+  const plottedWaypoints = (updatedWaypoints?.waypoints ?? waypoints).filter(
     ({ lat, lon }) => lat !== 'NaN' || lon !== 'NaN'
   )
   const plottedWaypointCount = plottedWaypoints.length ?? 0

--- a/packages/react-ui/src/Modals/MissionModalView.tsx
+++ b/packages/react-ui/src/Modals/MissionModalView.tsx
@@ -121,7 +121,7 @@ const MissionModalBody: React.FC<MissionModalViewProps> = ({
   defaultOverrides,
   defaultSearchText,
   missionsLoading,
-  onSelectMissionCategory: handleSelectCategory,
+  onSelectMissionCategory,
 }) => {
   const {
     state: {
@@ -159,6 +159,12 @@ const MissionModalBody: React.FC<MissionModalViewProps> = ({
     commsParams,
     defaultOverrides,
   })
+
+  // Reset overrides when the mission category changes
+  const handleSelectCategory = (category?: string) => {
+    resetOverrides()
+    onSelectMissionCategory?.(category)
+  }
 
   const { steps, currentStep, handleNext, handlePrevious, showSummary } =
     useMissionModalSteps({


### PR DESCRIPTION
- Clear overrides when switching mission selection categories (ie Recent Runs, Frequent Runs, Science), so that new overrides can take effect
- Updated default overrides to only be applied when selecting a previously run mission
- Update how plotted waypoints are defined so that waypoints will be reflected correctly in the final mission scheduling review step
- Map stations correctly so that latitude and longitude are being defined properly from the geojson data (the geojson array is longitude first, but that was previously being mapped to longitude). 

<img width="393" height="210" alt="Screenshot 2025-09-04 at 1 12 48 PM" src="https://github.com/user-attachments/assets/23c712b0-2b16-4dd9-b379-5fce43f41f7c" />
