### PR TITLE
Make unit helper function case sensitive

### DIFF
--- a/packages/utils/src/getUnitFromAbbreviation.ts
+++ b/packages/utils/src/getUnitFromAbbreviation.ts
@@ -4,7 +4,5 @@ export const getUnitFromAbbreviation = (
 ) => {
   if (!abbreviation || !unitsData) return undefined
   if (abbreviation.toLowerCase() === 'degree') return 'degree'
-  return unitsData?.find(
-    (u) => u.abbreviation?.toLowerCase() === (abbreviation ?? '').toLowerCase()
-  )?.name
+  return unitsData?.find((u) => u.abbreviation === (abbreviation ?? ''))?.name
 }


### PR DESCRIPTION
- When looking up full unit names by abbreviation, use a case-sensitive search (ie: h = hour and H = Henry)

References #473 