### PR TITLE
Show map and available track line for deployed vehicles

### DIFF
--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -141,26 +141,26 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   }, [vehicleName, setLatestGPS])
 
   useEffect(() => {
-    if (mapRef.current && !showVehicleColors) {
+    if (mapRef?.current && !showVehicleColors) {
       setTimeout(() => {
         try {
           // Try to invalidateSize method(s)
-          if (typeof mapRef.current.invalidateSize === 'function') {
-            mapRef.current.invalidateSize()
+          if (typeof mapRef?.current.invalidateSize === 'function') {
+            mapRef?.current.invalidateSize()
           } else if (
-            mapRef.current._leafletContainer &&
-            typeof mapRef.current._leafletContainer.invalidateSize ===
+            mapRef?.current._leafletContainer &&
+            typeof mapRef?.current._leafletContainer.invalidateSize ===
               'function'
           ) {
-            mapRef.current._leafletContainer.invalidateSize()
+            mapRef?.current._leafletContainer.invalidateSize()
           } else if (
-            mapRef.current.leafletElement &&
-            typeof mapRef.current.leafletElement.invalidateSize === 'function'
+            mapRef?.current.leafletElement &&
+            typeof mapRef?.current.leafletElement.invalidateSize === 'function'
           ) {
-            mapRef.current.leafletElement.invalidateSize()
+            mapRef?.current.leafletElement.invalidateSize()
           } else {
             // Log what we have for debugging
-            logger.debug('Map structure:', mapRef.current)
+            logger.debug('Map structure:', mapRef?.current)
           }
         } catch (e) {
           logger.warn('Error invalidating map size:', e)
@@ -197,7 +197,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
         setLatestGPS(gps)
       }
       // Store position for path bounds calculation
-      if (gps.latitude && gps.longitude) {
+      if (gps?.latitude && gps?.longitude) {
         pathPoints.current.push([gps.latitude, gps.longitude])
       }
       // Limit stored positions to prevent memory issues
@@ -217,20 +217,20 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       setSelectedMarkerId((prevId) => (prevId === markerId ? null : markerId))
 
       // Close any open popups if a different marker is selected
-      if (mapRef.current && selectedMarkerId !== markerId) {
+      if (mapRef?.current && selectedMarkerId !== markerId) {
         try {
           // Try different ways to access closePopup
-          if (typeof mapRef.current.closePopup === 'function') {
-            mapRef.current.closePopup()
+          if (typeof mapRef?.current.closePopup === 'function') {
+            mapRef?.current.closePopup()
           } else if (
-            mapRef.current &&
-            typeof mapRef.current.closePopup === 'function'
+            mapRef?.current &&
+            typeof mapRef?.current.closePopup === 'function'
           ) {
             // Some React wrappers use _leafletElement
-            mapRef.current.closePopup()
-          } else if (mapRef.current.getContainer) {
+            mapRef?.current.closePopup()
+          } else if (mapRef?.current.getContainer) {
             // If we can access the container, try to find any open popups and close them manually
-            const container = mapRef.current.getContainer()
+            const container = mapRef?.current.getContainer()
             const popups = container.querySelectorAll('.leaflet-popup')
             if (popups.length > 0) {
               logger.debug('Closing popups manually')
@@ -362,7 +362,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
         )
 
         // Trigger UI updates if needed
-        if (shouldSave && mapRef.current) {
+        if (shouldSave && mapRef?.current) {
           // This could optionally trigger a map UI update
         }
       } catch (error) {
@@ -488,23 +488,23 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
 
     // Time for map to adjust after modal closes
     setTimeout(() => {
-      if (mapRef.current) {
+      if (mapRef?.current) {
         try {
           // Try invalidateSize method(s)
-          if (typeof mapRef.current.invalidateSize === 'function') {
-            mapRef.current.invalidateSize()
+          if (typeof mapRef?.current.invalidateSize === 'function') {
+            mapRef?.current.invalidateSize()
           } else if (
-            mapRef.current._leafletContainer &&
-            typeof mapRef.current._leafletContainer.invalidateSize ===
+            mapRef?.current._leafletContainer &&
+            typeof mapRef?.current._leafletContainer.invalidateSize ===
               'function'
           ) {
-            mapRef.current._leafletContainer.invalidateSize()
+            mapRef?.current._leafletContainer.invalidateSize()
           } else {
             // Log for debugging
-            logger.debug('Map reference type:', typeof mapRef.current)
+            logger.debug('Map reference type:', typeof mapRef?.current)
             logger.debug(
               'Map reference properties:',
-              Object.keys(mapRef.current)
+              Object.keys(mapRef?.current)
             )
           }
           logger.debug('Map size invalidated after closing modal')
@@ -578,7 +578,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
           />
         )}
         renderDraggableMarkers={() =>
-          markers.map(
+          markers?.map(
             (marker) =>
               // Only render the marker if visible or if visibility !== false
               marker.visible !== false && (

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -235,7 +235,9 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
       if (!grouped) {
         dispatch({ type: 'clear' })
         if (route?.length) {
-          map.fitBounds(route)
+          map.fitBounds(route, {
+            paddingBottomRight: [0, 320], // Add bottom padding to deployment map to show path above the vehicle diagram
+          })
         }
       } else {
         dispatch({ type: 'append', coords: { [name]: route } })

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -1,23 +1,11 @@
 import React, { useEffect, useRef, useCallback, useState, useMemo } from 'react'
 import { useVehiclePos, useLastDeployment, VPosDetail } from '@mbari/api-client'
 import { Polyline, useMap, Circle, Tooltip } from 'react-leaflet'
-import {
-  LatLng,
-  LeafletMouseEventHandlerFn,
-  Popup,
-  circle,
-  icon,
-} from 'leaflet'
+import { LatLng, LeafletMouseEventHandlerFn } from 'leaflet'
 import { useSharedPath } from './SharedPathContextProvider'
 import { distance } from '@turf/turf'
 import { parseISO, getTime } from 'date-fns'
 import { useVehicleColors } from './VehicleColorsContext'
-import { createLogger } from '@mbari/utils'
-
-const logger = createLogger('VehiclePath')
-
-let timeSinceFix
-let hours: number, minutes: number
 
 const getDistance = (a: VPosDetail, b: LatLng) =>
   distance([a.latitude, a.longitude], [b.lat, b.lng])

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useCallback, useState, useMemo } from 'react'
-import { DateTime } from 'luxon'
 import { useVehiclePos, useLastDeployment, VPosDetail } from '@mbari/api-client'
 import { Polyline, useMap, Circle, Tooltip } from 'react-leaflet'
 import {

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -1,11 +1,6 @@
 import React, { useEffect, useRef, useCallback, useState, useMemo } from 'react'
 import { DateTime } from 'luxon'
-import {
-  useVehiclePos,
-  useVehicles,
-  useLastDeployment,
-  VPosDetail,
-} from '@mbari/api-client'
+import { useVehiclePos, useLastDeployment, VPosDetail } from '@mbari/api-client'
 import { Polyline, useMap, Circle, Tooltip } from 'react-leaflet'
 import {
   LatLng,
@@ -83,19 +78,18 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
 }) => {
   const map = useMap()
   const { sharedPath, dispatch } = useSharedPath()
-  const { data: vehicleData } = useVehicles({})
 
   const { data: lastDeployment } = useLastDeployment(
     {
       vehicle: name,
     },
-    { staleTime: 5 * 60 * 1000 }
+    { staleTime: 5 * 60 * 1000, enabled: !from }
   )
   const { data: vehiclePosition } = useVehiclePos(
     {
       vehicle: name as string,
-      from: lastDeployment?.startEvent?.unixTime ?? 0,
-      to: to,
+      from: from ? from : lastDeployment?.startEvent?.unixTime ?? 0,
+      to: from ? to : lastDeployment?.endEvent?.unixTime,
     },
     {
       enabled: !!from || !!lastDeployment?.startEvent?.unixTime,
@@ -279,7 +273,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     }
   }
 
-  return route ? (
+  return route?.length ? (
     <>
       <Polyline
         pathOptions={lineStyle}

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -167,24 +167,24 @@ const OverViewMap: React.FC<{
   }, [elevationAvailable, handleDepthRequest])
 
   useEffect(() => {
-    if (mapRef.current) {
+    if (mapRef?.current) {
       // Add timeout to ensure map has initialized properly
       setTimeout(() => {
         try {
           // Try multiple ways to access invalidateSize
-          if (typeof mapRef.current?.invalidateSize === 'function') {
-            mapRef.current.invalidateSize()
+          if (typeof mapRef?.current?.invalidateSize === 'function') {
+            mapRef?.current.invalidateSize()
             logger.debug('Map size invalidated directly')
           } else if (
-            mapRef.current &&
+            mapRef?.current &&
             // Use type assertion to access internal property
-            (mapRef.current as any)._leafletContainer?.invalidateSize
+            (mapRef?.current as any)._leafletContainer?.invalidateSize
           ) {
-            ;(mapRef.current as any)._leafletContainer.invalidateSize()
+            ;(mapRef?.current as any)._leafletContainer.invalidateSize()
             logger.debug('Map size invalidated via _leafletContainer')
-          } else if (mapRef.current?.getContainer?.()) {
+          } else if (mapRef?.current?.getContainer?.()) {
             // Try to access via container
-            const container = mapRef.current.getContainer()
+            const container = mapRef?.current.getContainer()
             if (container) {
               // Trigger a resize event manually
               const evt = new Event('resize')
@@ -272,10 +272,10 @@ const OverViewMap: React.FC<{
     }
 
     // Access layers if map reference exists
-    if (mapRef.current) {
+    if (mapRef?.current) {
       try {
         // Store the map reference
-        const leafletMap = mapRef.current
+        const leafletMap = mapRef?.current
 
         if (typeof leafletMap.eachLayer === 'function') {
           // Use eachLayer to iterate over all layers
@@ -332,18 +332,18 @@ const OverViewMap: React.FC<{
       setSelectedMarkerId((prevId) => (prevId === markerId ? null : markerId))
 
       // Close any open popups if a different marker is selected
-      if (mapRef.current && selectedMarkerId !== markerId) {
+      if (mapRef?.current && selectedMarkerId !== markerId) {
         try {
-          if (typeof mapRef.current.closePopup === 'function') {
-            mapRef.current.closePopup()
+          if (typeof mapRef?.current.closePopup === 'function') {
+            mapRef?.current.closePopup()
           } else if (
-            mapRef.current &&
-            typeof mapRef.current.closePopup === 'function'
+            mapRef?.current &&
+            typeof mapRef?.current.closePopup === 'function'
           ) {
-            mapRef.current.closePopup()
-          } else if (mapRef.current.getContainer) {
+            mapRef?.current.closePopup()
+          } else if (mapRef?.current.getContainer) {
             // Find open popups and close them manually
-            const container = mapRef.current.getContainer()
+            const container = mapRef?.current.getContainer()
             const popups = container.querySelectorAll('.leaflet-popup')
             if (popups.length > 0) {
               logger.debug('Closing popups manually')
@@ -467,7 +467,7 @@ const OverViewMap: React.FC<{
         )
 
         // Trigger UI updates if needed
-        if (shouldSave && mapRef.current) {
+        if (shouldSave && mapRef?.current) {
         }
       } catch (error) {
         logger.error('Error in handleSaveMarkerToLayer:', error)
@@ -524,16 +524,16 @@ const OverViewMap: React.FC<{
 
     // Map might need time to adjust after modal closes
     setTimeout(() => {
-      if (mapRef.current) {
+      if (mapRef?.current) {
         try {
           // Try invalidateSize method(s)
-          if (typeof mapRef.current.invalidateSize === 'function') {
-            mapRef.current.invalidateSize()
+          if (typeof mapRef?.current.invalidateSize === 'function') {
+            mapRef?.current.invalidateSize()
           } else {
             // Logs for debugging
             logger.debug(
               'Map reference properties:',
-              Object.keys(mapRef.current)
+              Object.keys(mapRef?.current)
             )
           }
           logger.debug('Map size invalidated after closing modal')
@@ -545,13 +545,13 @@ const OverViewMap: React.FC<{
   }, [])
 
   useEffect(() => {
-    if (mapRef.current) {
+    if (mapRef?.current) {
       logger.debug(
         'Available methods:',
-        Object.getOwnPropertyNames(mapRef.current).filter(
+        Object.getOwnPropertyNames(mapRef?.current).filter(
           (prop) =>
-            mapRef.current &&
-            typeof (mapRef.current as unknown as Record<string, unknown>)[
+            mapRef?.current &&
+            typeof (mapRef?.current as unknown as Record<string, unknown>)[
               prop
             ] === 'function'
         )
@@ -561,7 +561,7 @@ const OverViewMap: React.FC<{
 
   // Handle map reference
   useEffect(() => {
-    logger.debug('mapRef.current in OverViewMap:', mapRef.current)
+    logger.debug('mapRef?.current in OverViewMap:', mapRef?.current)
   }, [mapRef])
 
   return (
@@ -589,7 +589,7 @@ const OverViewMap: React.FC<{
             }
           }, 200)
         }}
-        trackedVehicles={trackedVehicles.map((vehicle) => ({
+        trackedVehicles={trackedVehicles?.map((vehicle) => ({
           ...vehicle,
           id: vehicle.id || vehicle.name, // Ensure id is always present
         }))}
@@ -670,7 +670,7 @@ const OverViewMap: React.FC<{
           )
         }
       >
-        {uniqueTrackedVehicles.map((name, index) => (
+        {uniqueTrackedVehicles?.map((name, index) => (
           <VehiclePath
             name={name.name}
             key={`path-${name}-${index}`}
@@ -678,7 +678,7 @@ const OverViewMap: React.FC<{
             grouped
           />
         ))}
-        {selectedStations.map((station) => {
+        {selectedStations?.map((station) => {
           const lng = station.geojson?.geometry?.coordinates[0]
           const lat = station.geojson?.geometry?.coordinates[1]
 

--- a/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
+++ b/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, useCallback } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import { DateTime } from 'luxon'
@@ -19,7 +19,6 @@ import {
 } from '@mbari/react-ui'
 import {
   useDeployments,
-  useMissionStartedEvent,
   useTethysApiContext,
   useChartData,
   useVehiclePicAndOnCall,

--- a/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
+++ b/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
@@ -98,15 +98,6 @@ const Vehicle: NextPage = () => {
     }
   )
 
-  const { data: missionStartedEvent } = useMissionStartedEvent(
-    {
-      vehicle: vehicleName as string,
-    },
-    {
-      enabled: !!vehicleName && !!deployment?.lastEvent,
-    }
-  )
-
   const { data, isLoading: loadingPicAndOnCall } = useVehiclePicAndOnCall(
     {
       vehicleName,
@@ -158,20 +149,16 @@ const Vehicle: NextPage = () => {
       name: dep.name,
     })) ?? []
 
-  const deploymentStartTime = deployment?.startEvent?.unixTime ?? 0
-  const startTime =
-    deployment?.active && missionStartedEvent?.[0]?.unixTime
-      ? missionStartedEvent?.[0]?.unixTime
-      : deploymentStartTime
+  const startTime = deployment?.startEvent?.unixTime ?? 0
 
   const adjustedDeploymentStartTime = getAdjustedUnixTime({
-    unixTime: deploymentStartTime,
+    unixTime: startTime,
     offsetDays: deployment?.active ? -1 : 0,
   })
 
   const endTime = deployment?.active
     ? DateTime.utc().plus({ hours: 4 }).endOf('day').toMillis()
-    : deployment?.lastEvent ?? 0
+    : deployment?.endEvent?.unixTime ?? 0
 
   const lastCommsMillis = useLastCommsTime(vehicleName, startTime)
   const lastCommsTime = lastCommsMillis

--- a/packages/api-client/src/axios/Deployment/getLastDeployment.ts
+++ b/packages/api-client/src/axios/Deployment/getLastDeployment.ts
@@ -22,6 +22,8 @@ export interface DListResult {
   messages?: string[]
 }
 
+// IMPORTANT NOTE: the last deployment endpoint sometimes returns a deployment with a start event that is in the future in preparation for the mission
+
 export interface GetLastDeploymentResponse {
   deploymentId: string
   vehicle: string

--- a/packages/api-client/src/react-query/Deployment/useLastDeployment.ts
+++ b/packages/api-client/src/react-query/Deployment/useLastDeployment.ts
@@ -3,6 +3,8 @@ import { getLastDeployment, GetLastDeploymentParams } from '../../axios'
 import { useTethysApiContext } from '../TethysApiProvider'
 import { SupportedQueryOptions } from '../types'
 
+// IMPORTANT NOTE: the last deployment endpoint sometimes returns a deployment with a start event that is in the future in preparation for the mission
+
 export const useLastDeployment = (
   params: GetLastDeploymentParams,
   options?: SupportedQueryOptions

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -33,7 +33,6 @@ import { Measurement } from './Measurement'
 import MovingDot from './MovingDot'
 import { AreaComponent, PathComponent, MeasurementProps } from './Measurement'
 import { CenterView } from './MapViews'
-import toast from 'react-hot-toast'
 import { createLogger, loadGoogleMapsOnce } from '@mbari/utils'
 import VehicleColorsModal from '@mbari/lrauv-dash2/components/VehicleColorsModal'
 

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -60,6 +60,8 @@ const createSafeLogger = (
 // safeLogger instance that will be used during initialization
 const safeLogger = createSafeLogger(logger, ['debug'])
 
+const DEFAULT_CENTER: [number, number] = [36.8022, -121.788]
+
 const regex = /\B(?=(\d{3})+(?!\d))/g
 
 declare global {
@@ -140,7 +142,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
     {
       className,
       style,
-      center = [36.7849, -122.12097],
+      center = DEFAULT_CENTER,
       centerZoom,
       zoom = 17,
       minZoom = 4,
@@ -192,6 +194,13 @@ const Map = React.forwardRef<L.Map, MapProps>(
     const [showVehicleColorsModal, setShowVehicleColorsModal] = useState(false)
     const vehicleColorsButtonRef = useRef<HTMLButtonElement>(null)
     const [modalPosition, setModalPosition] = useState({ top: 0, left: 0 })
+
+    const validatedCenter: [number, number] =
+      Array.isArray(center) &&
+      Number.isFinite(center[0]) &&
+      Number.isFinite(center[1])
+        ? center
+        : DEFAULT_CENTER
 
     // Google Maps initialization
     useEffect(() => {
@@ -309,16 +318,16 @@ const Map = React.forwardRef<L.Map, MapProps>(
 
     // Skip the log if ref is null - this is expected during initial render
     useEffect(() => {
-      if (ref && !mapRef.current) {
+      if (ref && !mapRef?.current) {
         // Don't log every time - very noisy
         return
       }
 
       // Forward the ref
       if (typeof ref === 'function') {
-        ref(mapRef.current)
+        ref(mapRef?.current)
       } else if (ref && typeof ref === 'object') {
-        ref.current = mapRef.current
+        ref.current = mapRef?.current
       }
     }, [ref])
 
@@ -703,7 +712,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
 
     return (
       <MapContainer
-        center={center}
+        center={validatedCenter}
         zoom={zoom}
         scrollWheelZoom={true}
         className={className}
@@ -767,7 +776,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
       >
         {!isMeasuring && (
           <CenterView
-            coords={center as [number, number]}
+            coords={validatedCenter}
             bounds={fitBounds as [[number, number], [number, number]]}
             zoom={centerZoom as number}
             viewMode={viewMode as 'center' | 'bounds' | null}


### PR DESCRIPTION
- Validate center coordinates and add default center so it is always available in Map to avoid cases where it causes map not to render
- Update VehiclePath to use **_either_** from/to props **_or_** lastDeployment start and end event times to use when querying the vehicle position endpoint to avoid random mismatches of start and end times
- Standardize the deployment start and end times on the deployment page to always use the start and end events from useCurrentDeployment instead of sometimes using useMissionStartedEvent to avoid random mismatches of start and end times
- Add bottom padding to the fit bounds for the deployment map in VehiclePath so that the vehicle path is always fully visible above the vehicle diagram on the deployment page
- Add optional chaining to many objects in the files listed above for objects that are potentially undefined to avoid property access errors on objects that don't exist
- Add comment to last deployment endpoint and hook that it sometimes returns future missions since that is not obvious from the name

### Currently deployed vehicle with available waypoints map
<img width="1921" height="1298" alt="Screenshot 2025-09-18 at 3 24 14 PM" src="https://github.com/user-attachments/assets/5b3e6295-d540-4035-81b8-e145b3427d2b" />

### Currently "deployed" vehicle with no waypoints
<img width="1922" height="1223" alt="Screenshot 2025-09-18 at 3 07 59 PM" src="https://github.com/user-attachments/assets/dcff8d76-c0ce-466e-bf4f-2e55c8958e87" />

### Vehicle that is not deployed showing previous deployment on map
<img width="1946" height="1290" alt="Screenshot 2025-09-18 at 3 07 16 PM" src="https://github.com/user-attachments/assets/b1ba49c8-1981-4e80-bc78-236a51ff2eca" />

References #340 

