### PR TITLE
Provide recent run filter options for current vehicle or all vehicles

### DIFF
--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -87,13 +87,15 @@ const MissionModal: React.FC<MissionModalProps> = ({
     string | undefined
   >('Recent Runs')
 
+  const [showAllVehicleMissions, setShowAllVehicleMissions] = useState(false)
+
   const {
     recentRuns,
     allMissions: missions,
     selectedMissionData,
     isRecentRunsLoading: recentRunsLoading,
     missionCategories,
-  } = useMissionData({ vehicleName, selectedMission })
+  } = useMissionData({ vehicleName, selectedMission, showAllVehicleMissions })
 
   const {
     parameters,
@@ -255,6 +257,8 @@ const MissionModal: React.FC<MissionModalProps> = ({
       onSelectMissionCategory={handleSelectMissionCategory}
       selectedMissionCategory={selectedMissionCategory}
       defaultSearchText={globalModalId?.meta?.mission ?? ''}
+      showAllVehicleMissions={showAllVehicleMissions}
+      onShowAllVehicleMissions={setShowAllVehicleMissions}
       defaultOverrides={
         selectedMissionCategory === 'Recent Runs'
           ? [

--- a/apps/lrauv-dash2/lib/useMissionData.ts
+++ b/apps/lrauv-dash2/lib/useMissionData.ts
@@ -24,8 +24,9 @@ const LAST_60_DAYS = getAdjustedUnixTime({
 export const useMissionData = (params: {
   vehicleName: string
   selectedMission?: string
+  showAllVehicleMissions?: boolean
 }) => {
-  const { vehicleName, selectedMission } = params
+  const { vehicleName, selectedMission, showAllVehicleMissions } = params
 
   const { data: missionData } = useMissionList()
   // this gets the original mission template data (ie it would be the original sci2_flat_and_level mission, not a recent run of sci2_flat_and_level where the pilot has applied overrides)
@@ -39,10 +40,11 @@ export const useMissionData = (params: {
 
   const recentRunsParams = useMemo(
     () => ({
-      vehicles: [], // All vehicles by default
-      from: LAST_60_DAYS,
+      vehicles: showAllVehicleMissions ? [] : vehicleName ? [vehicleName] : [],
+      from: showAllVehicleMissions ? LAST_60_DAYS : 0,
+      limit: showAllVehicleMissions ? undefined : 100,
     }),
-    []
+    [vehicleName, showAllVehicleMissions]
   )
 
   const { data: recentRunsData, isLoading: isRecentRunsLoading } =

--- a/packages/react-ui/src/Modals/MissionModalSteps/MissionStep.tsx
+++ b/packages/react-ui/src/Modals/MissionModalSteps/MissionStep.tsx
@@ -13,6 +13,8 @@ export interface MissionStepProps {
   missionCategories?: SelectOption[]
   selectedCategory?: string
   onSelectCategory?: (id?: string) => void
+  showAllVehicleMissions?: boolean
+  onShowAllVehicleMissions?: (show: boolean) => void
   defaultSearchText?: string
   loading?: boolean
 }
@@ -25,6 +27,8 @@ export const MissionStep: React.FC<MissionStepProps> = ({
   missionCategories,
   onSelectCategory: handleSelectCategory,
   selectedCategory = 'Recent Runs',
+  showAllVehicleMissions = false,
+  onShowAllVehicleMissions: handleShowAllVehicleMissions,
   defaultSearchText = '',
   loading,
 }) => {
@@ -108,11 +112,37 @@ export const MissionStep: React.FC<MissionStepProps> = ({
   return (
     <article className="h-full">
       <ul className="grid grid-cols-5 pb-2">
-        <li className="col-span-2 self-center">
-          Select a command for{' '}
-          <span className="text-teal-500" data-testid="vehicle name">
-            {vehicleName}
-          </span>
+        <li className="col-span-2 flex flex-col items-start">
+          <div>
+            {' '}
+            Select a command for{' '}
+            <span className="text-teal-500" data-testid="vehicle name">
+              {vehicleName}
+            </span>
+          </div>
+          <label
+            htmlFor="showAllVehicleMissions"
+            onClick={(e) => e.stopPropagation()}
+            className={`flex items-center text-sm ${
+              selectedCategory?.match(/recent runs/i)
+                ? 'cursor-pointer'
+                : 'opacity-40'
+            }`}
+          >
+            <input
+              id="showAllVehicleMissions"
+              name="showAllVehicleMissions"
+              type="checkbox"
+              className="mr-1 h-4 w-4 cursor-pointer disabled:cursor-not-allowed"
+              checked={showAllVehicleMissions}
+              disabled={!selectedCategory?.match(/recent runs/i)}
+              onChange={(e) => {
+                e.stopPropagation()
+                handleShowAllVehicleMissions?.(e.target.checked)
+              }}
+            />
+            Show recent runs for all vehicles
+          </label>
         </li>
         <li className="col-span-3 flex items-center">
           <SelectField

--- a/packages/react-ui/src/Modals/MissionModalView.tsx
+++ b/packages/react-ui/src/Modals/MissionModalView.tsx
@@ -76,6 +76,8 @@ export interface MissionModalViewProps
   defaultSearchText?: string
   missionsLoading?: boolean
   onSelectMissionCategory?: (category?: string) => void
+  showAllVehicleMissions?: boolean
+  onShowAllVehicleMissions?: (show: boolean) => void
 }
 
 export const MissionModalView: React.FC<MissionModalViewProps> = (props) => (
@@ -122,6 +124,8 @@ const MissionModalBody: React.FC<MissionModalViewProps> = ({
   defaultSearchText,
   missionsLoading,
   onSelectMissionCategory,
+  showAllVehicleMissions,
+  onShowAllVehicleMissions,
 }) => {
   const {
     state: {
@@ -279,6 +283,8 @@ const MissionModalBody: React.FC<MissionModalViewProps> = ({
             selectedCategory={selectedMissionCategory}
             defaultSearchText={defaultSearchText}
             loading={missionsLoading}
+            showAllVehicleMissions={showAllVehicleMissions}
+            onShowAllVehicleMissions={onShowAllVehicleMissions}
           />
         )
 


### PR DESCRIPTION
- Add checkbox for showing recent runs for all vehicles
- Checkbox is unchecked by default so that recent runs for only the current vehicle are displayed
- Checkbox is in a disabled state when a category other than Recent Runs is selected (ie Frequent Runs)

### Unchecked - showing recent runs for current vehicle
<img width="1026" height="1244" alt="Screenshot 2025-09-22 at 4 57 42 PM" src="https://github.com/user-attachments/assets/5d438adc-cf1c-4867-b635-5c32ae8f4c84" />

### Checked - showing recent runs for all vehicles
<img width="1020" height="1249" alt="Screenshot 2025-09-22 at 4 59 20 PM" src="https://github.com/user-attachments/assets/7f39c46e-e36e-4743-8b33-28af598642ff" />
