### PR TITLE
Fix partially loaded map

### DIFF
--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -533,7 +533,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   }, [trackedVehicles, vehicleName])
 
   return (
-    <>
+    <div className="h-full min-h-0 w-full">
       {showLayersModal ? (
         <MapLayersListModal
           onClose={handleCloseLayers}
@@ -542,7 +542,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       ) : null}
       <Map
         ref={mapRef}
-        className="h-full w-full"
+        className="h-full min-h-0 w-full"
         maxZoom={17}
         onMapReady={(map) => {
           logger.debug('Map is ready!')
@@ -673,7 +673,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
           forceShowAll={true}
         />
       </Map>
-    </>
+    </div>
   )
 }
 

--- a/apps/lrauv-dash2/components/Layout.tsx
+++ b/apps/lrauv-dash2/components/Layout.tsx
@@ -91,7 +91,7 @@ const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
 
   const vehicleName = router.query.deployment?.[0] ?? ''
   return (
-    <div className="flex h-screen w-screen flex-col">
+    <div className="flex h-screen min-h-screen w-screen flex-col">
       <Head>
         <title>LRAUV Dash Client</title>
         <meta

--- a/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
+++ b/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
@@ -44,13 +44,16 @@ import { SelectedStationsProvider } from '../../components/SelectedStationContex
 import { SelectedPlatformsProvider } from '../../components/SelectedPlatformContext'
 import { createRoleLabel } from '@mbari/utils'
 
+// Every flex parent of the map needs `min-h-0`
+// Without it, Leaflet sometimes shows gray tiles
+
 const styles = {
-  content: 'flex flex-shrink flex-grow flex-row overflow-hidden',
-  primary: 'flex h-full flex-shrink flex-grow flex-col',
+  content: 'flex flex-shrink flex-grow flex-row overflow-hidden min-h-0',
+  primary: 'flex h-full flex-shrink flex-grow flex-col min-h-0',
   mapContainer:
-    'flex flex-shrink flex-col flex-grow bg-blue-300 relative h-full',
+    'flex flex-shrink flex-col flex-grow bg-blue-300 relative h-full min-h-0',
   secondary:
-    'flex w-full h-full flex-shrink-0 flex-col bg-white border-t-2 border-t-secondary-300/60 border-l border-l-slate-300',
+    'flex w-full h-full flex-shrink-0 flex-col bg-white border-t-2 border-t-secondary-300/60 border-l border-l-slate-300 min-h-0',
 }
 
 const LineChart = dynamic(
@@ -315,14 +318,14 @@ const Vehicle: NextPage = () => {
               authenticated={authenticated}
             />
             <div className={styles.content}>
-              <Allotment separator defaultSizes={[75, 25]}>
+              <Allotment separator defaultSizes={[75, 25]} className="min-h-0">
                 <section className={styles.primary}>
                   <MissionProgressToolbar
                     startTime={DateTime.fromMillis(startTime).toISO()}
                     endTime={DateTime.fromMillis(endTime).toISO()}
                     ticks={6}
                     ariaLabel="Mission Progress"
-                    className="bg-secondary-300/60"
+                    className="min-h-0 bg-secondary-300/60"
                     onScrub={handleTimeScrub}
                     indicatorTime={indicatorTime}
                   />

--- a/apps/lrauv-dash2/styles/globals.css
+++ b/apps/lrauv-dash2/styles/globals.css
@@ -14,3 +14,10 @@ a {
 * {
   box-sizing: border-box;
 }
+
+/*  This is a workaround to make sure that every parent element of the map has a min height on load to prevent Leaflet from showing gray tiles */
+
+.split-view-container,
+.split-view-view {
+  min-height: 0 !important;
+}

--- a/packages/react-ui/src/Toolbars/OverviewToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/OverviewToolbar.tsx
@@ -39,7 +39,7 @@ export interface OverviewToolbarProps {
 }
 
 const styles = {
-  container: 'flex font-display bg-white px-4 py-2',
+  container: 'flex font-display bg-white px-4 py-2 min-h-0',
   leftWrapper: 'flex flex-grow items-center px-2',
   rightWrapper: 'flex items-center px-2',
   chevron: 'pl-4 text-xs',

--- a/packages/react-ui/src/Toolbars/PrimaryToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/PrimaryToolbar.tsx
@@ -7,7 +7,7 @@ import { faPlus, faSignIn, faTimes } from '@fortawesome/free-solid-svg-icons'
 import { faUser } from '@fortawesome/free-solid-svg-icons'
 
 const styles = {
-  bar: 'w-full flex flex-row bg-secondary-300 px-8 py-4',
+  bar: 'w-full flex flex-row bg-secondary-300 px-8 py-4 min-h-0',
   list: 'flex flex-row items-center align-center justify-between flex-grow w-full',
   item: 'flex my-auto self-center relative',
   option: 'mr-2',


### PR DESCRIPTION
Weird issue where Leaflet will render some tiles as gray if it doesn't have a container with a non-zero height on load
- Add `min-h-0` to all flex parents of deployment map to resolve the issue
- Add styles that target the Allotment library panes to add minimum height zero to them

Note: it resolves the issue, so I'm not sure if it's worth looking for a more elegant solution since it's a tricky browser based issue

### Google's AI writeup on the issue
<img width="693" height="2015" alt="Screenshot 2025-09-25 at 1 29 21 PM" src="https://github.com/user-attachments/assets/b5f6bca2-3f95-4116-a0e3-5000102737ef" />
