### PR TITLE
Make mission scheduling search more selective

### DIFF
--- a/packages/react-ui/src/Data/TableCell.tsx
+++ b/packages/react-ui/src/Data/TableCell.tsx
@@ -22,22 +22,26 @@ export const TableCell: React.FC<TableCellProps> = ({
   highlighted,
   fixedIconWidth,
 }) => {
+  // Add a zero width space after underscores so line breaks happen cleanly at underscores instead of randomly
+  const preparedLabel =
+    typeof label === 'string' ? label.split('_').join('_\u200b') : label
   return (
     <ul className={clsx(styles.container, className)} data-testid="table cell">
       {icon && (
         <li className={clsx('text-4xl', fixedIconWidth && 'w-2/5')}>{icon}</li>
       )}
-      <li className="flex h-full w-full flex-col">
+      <li className="flex h-full w-full min-w-0 flex-col">
         <div
           className={clsx(
             !scrollable && firstColumn && !highlighted && 'font-mono',
             scrollable && !firstColumn && !highlighted && 'text-sm',
             firstColumn &&
               !highlighted &&
-              (scrollable ? 'font-medium' : 'font-semibold')
+              (scrollable ? 'font-medium' : 'font-semibold'),
+            'min-w-0 whitespace-normal break-normal'
           )}
         >
-          {label}
+          {preparedLabel}
         </div>
         {secondary && (
           <div className={clsx(scrollable && 'text-sm')}>{secondary}</div>

--- a/packages/react-ui/src/Modals/MissionModalSteps/MissionStep.tsx
+++ b/packages/react-ui/src/Modals/MissionModalSteps/MissionStep.tsx
@@ -79,14 +79,27 @@ export const MissionStep: React.FC<MissionStepProps> = ({
     }) as Mission[]
   }, [filteredMissions, sortColumn, sortDirection])
 
+  // If it's a recent run, include pilot name in the searchable text, otherwise include mission description for other categroies (mission description for recent runs is the parameters, which should not be included)
+  const searchableMissionTextMap = useMemo(() => {
+    const map = new Map<string, string>()
+    sortedMissions?.forEach((mission) => {
+      let text = `${mission?.id ?? ''} ${mission?.note ?? ''}`.toLowerCase()
+      selectedCategory?.match(/recent runs/i)
+        ? (text += mission?.ranBy?.toLowerCase() ?? '')
+        : (text += mission?.description?.toLowerCase() ?? '')
+      if (mission?.id) map.set(mission.id, text)
+    })
+    return map
+  }, [sortedMissions, selectedCategory])
+
   // Apply search term to the sorted list if present
   const searchedMissions = useMemo(() => {
     if (!searchTerm) return sortedMissions ?? []
     const lowerCaseTerm = searchTerm.toLowerCase()
     return sortedMissions.filter((mission) =>
-      Object.values(mission).join(' ').toLowerCase().includes(lowerCaseTerm)
+      (searchableMissionTextMap?.get(mission.id) ?? '').includes(lowerCaseTerm)
     )
-  }, [searchTerm, sortedMissions])
+  }, [searchTerm, sortedMissions, searchableMissionTextMap])
 
   const handleSelectCategoryId = (id: string | null) => {
     if (!id) {
@@ -98,6 +111,7 @@ export const MissionStep: React.FC<MissionStepProps> = ({
   }
 
   const handleSearch = (term: string) => {
+    // deselect any selected mission when searching so it doesn't stay selected when not visible due to search
     if (selectedId) {
       onSelect(null)
     }


### PR DESCRIPTION
- Update mission scheduling search to search by mission name, note, and pilot it was ran by when using recent runs and for all other categories, it searches the mission name and the mission description
- Allow mission names to break at underscores so they don't extend beyond their container

### Searchable recent run text indicated in red
<img width="1012" height="375" alt="Screenshot 2025-10-13 at 12 33 19 PM" src="https://github.com/user-attachments/assets/804626f1-b721-427c-98d1-b77ad26abc68" />

### Searchable text for other categories indicated in red
<img width="1017" height="228" alt="Screenshot 2025-10-13 at 12 34 21 PM" src="https://github.com/user-attachments/assets/e5d92844-cc2b-4434-929a-b60fc7fedc02" />

### Issue with mission names not wrapping before fix
<img width="1005" height="631" alt="Screenshot 2025-10-13 at 12 16 21 PM" src="https://github.com/user-attachments/assets/c240c507-e4b9-4ba8-b67b-8b69b2378ca6" />

### Fixed mission name wrapping
<img width="1007" height="624" alt="Screenshot 2025-10-13 at 12 22 19 PM" src="https://github.com/user-attachments/assets/bccf7bcd-289a-4688-9869-73349caaac87" />

