### PR TITLE
Links to real time logs

### DIFF
--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -21,7 +21,11 @@ import formatEvent, {
 import { applyEventFilters } from '../lib/eventFilterUtils'
 import { createLogger, useDebounce } from '@mbari/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import {
+  faChevronDown,
+  faChevronUp,
+  faExternalLink,
+} from '@fortawesome/free-solid-svg-icons'
 
 const logger = createLogger('components.LogsSection')
 
@@ -55,6 +59,17 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   const [filtersOpen, setFiltersOpen] = useState(false)
   const [searchText, setSearchText] = useState('')
   const debouncedSearchText = useDebounce(searchText, 250)
+
+  const espUrl = useMemo(() => {
+    const base = siteConfig?.appConfig.external.tethysdash
+    if (!base || !vehicleName) return undefined
+    return `${base}/data/${vehicleName}/realtime/ESPlogs/`
+  }, [siteConfig, vehicleName])
+
+  const handleEspClick = () => {
+    if (!espUrl) return
+    window.open(espUrl, '_blank', 'noopener,noreferrer')
+  }
 
   const eventFilterIds = useMemo(() => Object.keys(eventFilters), [])
 
@@ -268,6 +283,15 @@ const LogsSection: React.FC<LogsSectionProps> = ({
               </div>
             )}
           </div>
+          <Button
+            appearance="secondary"
+            onClick={handleEspClick}
+            disabled={!espUrl}
+            aria-label="Open ESP Logs listing in a new browser tab"
+          >
+            <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
+            ESP Log
+          </Button>
         </div>
         <LogsToolbar
           deploymentLogsOnly={deploymentLogsOnly}

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -1,5 +1,9 @@
 import React, { useMemo, useState } from 'react'
-import { useInfiniteEvents, useTethysApiContext } from '@mbari/api-client'
+import {
+  useInfiniteEvents,
+  useTethysApiContext,
+  useEvents,
+} from '@mbari/api-client'
 import {
   Virtualizer,
   LogCell,
@@ -60,15 +64,38 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   const [searchText, setSearchText] = useState('')
   const debouncedSearchText = useDebounce(searchText, 250)
 
+  const { data: latestDataProcessed } = useEvents(
+    {
+      vehicles: [vehicleName],
+      eventTypes: ['dataProcessed'],
+      from: 0,
+      limit: 1,
+      ascending: 'n',
+    },
+    { staleTime: 60 * 1000 }
+  )
+
   const espUrl = useMemo(() => {
     const base = siteConfig?.appConfig.external.tethysdash
     if (!base || !vehicleName) return undefined
     return `${base}/data/${vehicleName}/realtime/ESPlogs/`
   }, [siteConfig, vehicleName])
 
+  const shoreUrl = useMemo(() => {
+    const base = siteConfig?.appConfig.external.tethysdash
+    const path = latestDataProcessed?.[0]?.path
+    if (!base || !vehicleName || !path) return undefined
+    return `${base}/data/${vehicleName}/realtime/sbdlogs/${path}/shore.log`
+  }, [siteConfig, vehicleName, latestDataProcessed])
+
   const handleEspClick = () => {
     if (!espUrl) return
     window.open(espUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  const handleShoreClick = () => {
+    if (!shoreUrl) return
+    window.open(shoreUrl, '_blank', 'noopener,noreferrer')
   }
 
   const eventFilterIds = useMemo(() => Object.keys(eventFilters), [])
@@ -283,6 +310,15 @@ const LogsSection: React.FC<LogsSectionProps> = ({
               </div>
             )}
           </div>
+          <Button
+            appearance="secondary"
+            onClick={handleShoreClick}
+            disabled={!shoreUrl}
+            aria-label="Open shore log file in a new browser tab"
+          >
+            <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
+            Shore Log
+          </Button>
           <Button
             appearance="secondary"
             onClick={handleEspClick}

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -25,11 +25,8 @@ import formatEvent, {
 import { applyEventFilters } from '../lib/eventFilterUtils'
 import { createLogger, useDebounce } from '@mbari/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faChevronDown,
-  faChevronUp,
-  faExternalLink,
-} from '@fortawesome/free-solid-svg-icons'
+import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import { RealTimeLogs } from './RealTimeLogs'
 
 const logger = createLogger('components.LogsSection')
 
@@ -63,40 +60,6 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   const [filtersOpen, setFiltersOpen] = useState(false)
   const [searchText, setSearchText] = useState('')
   const debouncedSearchText = useDebounce(searchText, 250)
-
-  const { data: latestDataProcessed } = useEvents(
-    {
-      vehicles: [vehicleName],
-      eventTypes: ['dataProcessed'],
-      from: 0,
-      limit: 1,
-      ascending: 'n',
-    },
-    { staleTime: 60 * 1000 }
-  )
-
-  const espUrl = useMemo(() => {
-    const base = siteConfig?.appConfig.external.tethysdash
-    if (!base || !vehicleName) return undefined
-    return `${base}/data/${vehicleName}/realtime/ESPlogs/`
-  }, [siteConfig, vehicleName])
-
-  const shoreUrl = useMemo(() => {
-    const base = siteConfig?.appConfig.external.tethysdash
-    const path = latestDataProcessed?.[0]?.path
-    if (!base || !vehicleName || !path) return undefined
-    return `${base}/data/${vehicleName}/realtime/sbdlogs/${path}/shore.log`
-  }, [siteConfig, vehicleName, latestDataProcessed])
-
-  const handleEspClick = () => {
-    if (!espUrl) return
-    window.open(espUrl, '_blank', 'noopener,noreferrer')
-  }
-
-  const handleShoreClick = () => {
-    if (!shoreUrl) return
-    window.open(shoreUrl, '_blank', 'noopener,noreferrer')
-  }
 
   const eventFilterIds = useMemo(() => Object.keys(eventFilters), [])
 
@@ -310,24 +273,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
               </div>
             )}
           </div>
-          <Button
-            appearance="secondary"
-            onClick={handleShoreClick}
-            disabled={!shoreUrl}
-            aria-label="Open shore log file in a new browser tab"
-          >
-            <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
-            Shore Log
-          </Button>
-          <Button
-            appearance="secondary"
-            onClick={handleEspClick}
-            disabled={!espUrl}
-            aria-label="Open ESP Logs listing in a new browser tab"
-          >
-            <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
-            ESP Log
-          </Button>
+          <RealTimeLogs vehicleName={vehicleName} />
         </div>
         <LogsToolbar
           deploymentLogsOnly={deploymentLogsOnly}

--- a/apps/lrauv-dash2/components/RealTimeLogs.tsx
+++ b/apps/lrauv-dash2/components/RealTimeLogs.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo } from 'react'
+import { useEvents, useTethysApiContext } from '@mbari/api-client'
+import { Button } from '@mbari/react-ui'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExternalLink } from '@fortawesome/free-solid-svg-icons'
+
+export interface RealTimeLogsProps {
+  vehicleName: string
+}
+
+export const RealTimeLogs: React.FC<RealTimeLogsProps> = ({ vehicleName }) => {
+  const { siteConfig } = useTethysApiContext()
+
+  // Latest dataProcessed event (for Shore Log link)
+  const { data: latestDataProcessed } = useEvents(
+    {
+      vehicles: [vehicleName],
+      eventTypes: ['dataProcessed'],
+      from: 0,
+      limit: 1,
+      ascending: 'n',
+    },
+    { staleTime: 60 * 1000 }
+  )
+
+  const espUrl = useMemo(() => {
+    const base = siteConfig?.appConfig.external.tethysdash
+    if (!base || !vehicleName) return undefined
+    return `${base}/data/${vehicleName}/realtime/ESPlogs/`
+  }, [siteConfig, vehicleName])
+
+  const shoreUrl = useMemo(() => {
+    const base = siteConfig?.appConfig.external.tethysdash
+    const path = latestDataProcessed?.[0]?.path
+    if (!base || !vehicleName || !path) return undefined
+    return `${base}/data/${vehicleName}/realtime/sbdlogs/${path}/shore.log`
+  }, [siteConfig, vehicleName, latestDataProcessed])
+
+  const handleEspClick = () => {
+    if (!espUrl) return
+    window.open(espUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  const handleShoreClick = () => {
+    if (!shoreUrl) return
+    window.open(shoreUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  return (
+    <>
+      <Button
+        appearance="secondary"
+        onClick={handleShoreClick}
+        disabled={!shoreUrl}
+        aria-label="Open shore log file in a new browser tab"
+      >
+        <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
+        Shore Log
+      </Button>
+
+      <Button
+        appearance="secondary"
+        onClick={handleEspClick}
+        disabled={!espUrl}
+        aria-label="Open ESP Logs listing in a new browser tab"
+      >
+        <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
+        ESP Log
+      </Button>
+    </>
+  )
+}
+
+RealTimeLogs.displayName = 'components.RealTimeLogs'


### PR DESCRIPTION
- Add button to link to the ESP logs in a separate browser window
- Add another button to link to the shore logs in a separate browser window
- Create a self contained RealTimeLogs component with both buttons and implement it in LogsSection
- Verified that they work identically to those in dash4

Closes #467 

### ESP and Shore buttons in the Logs section
<img width="637" height="474" alt="Screenshot 2025-10-13 at 5 09 23 PM" src="https://github.com/user-attachments/assets/011c4ec1-0bc4-40b5-80e5-af696fb93960" />
