### PR TITLE
Missing vehicle dropdown options

### DIFF
--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -22,7 +22,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
   const { profile, axiosInstance, token } = useTethysApiContext()
   const email = profile?.email ?? ''
 
-  const { data: siteInfo } = useSiteConfig({}, {}, undefined)
+  const { data: siteInfo } = useSiteConfig()
   const vehicleNames = useMemo(
     () =>
       [...(siteInfo?.vehicleNames ?? [])].sort((a, b) => a.localeCompare(b)),

--- a/packages/api-client/src/react-query/Info/useSiteConfig.ts
+++ b/packages/api-client/src/react-query/Info/useSiteConfig.ts
@@ -8,10 +8,11 @@ export const useSiteConfig = (
   options?: SupportedQueryOptions,
   instance?: AxiosInstance
 ) => {
+  const resolvedParams = params ?? {}
   const query = useQuery(
-    ['info', 'config', params],
+    ['info', 'config', resolvedParams],
     () => {
-      return getInfo(params ?? {}, {
+      return getInfo(resolvedParams, {
         instance: instance,
       })
     },


### PR DESCRIPTION
Closes #496 

- Update useSiteConfig hook, so that it can be used without props
- Remove unnecessary props from useSiteConfig in EmailNotificationsModal

Note: This was actually an issue a lot of places on the site where the vehicle list was supposed to be rendering. It's unclear how the useSiteConfig hook was previously working for me without props, but randomly stopped working. It's possible that the unnecessary props in EmailNotificationsModal were the actual issue, but either way, it should be resolved now.

### Vehicle list populating now
<img width="630" height="559" alt="Screenshot 2025-10-27 at 10 41 39 AM" src="https://github.com/user-attachments/assets/931b7894-2d3b-4088-a730-f85c40463dc8" />
