### PR TITLE
Rerun command from scheduler

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -58,6 +58,21 @@ export const parseMissionCommand = (name: string) => {
   }
 }
 
+/**
+ * Detects if a command is actually a mission command by checking if it contains
+ * "load" followed by a mission file path and "run"
+ */
+export const isMissionCommand = (
+  commandData?: string,
+  commandText?: string
+): boolean => {
+  const text = commandText || commandData || ''
+  // Check if it contains "load" followed by a mission file (.xml or .tl) and "run"
+  const hasLoad = /\bload\s+[A-Za-z0-9_/]+\.(?:xml|tl)/i.test(text)
+  const hasRun = /\brun\b/i.test(text)
+  return hasLoad && hasRun
+}
+
 export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
   currentDeploymentId,
   activeDeployment,
@@ -283,7 +298,10 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         onMoreClick={openMoreMenu}
         eventId={mission.event.eventId}
         commandType={
-          mission?.event?.eventType === 'run' ? 'mission' : 'command'
+          mission?.event?.eventType === 'run' ||
+          isMissionCommand(mission?.event?.data, mission?.event?.text)
+            ? 'mission'
+            : 'command'
         }
       />
     ) : (
@@ -300,15 +318,20 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
   }) => {
     const event = results.find((r) => r?.event.eventId === eventId)?.event
 
-    if (commandType === 'mission') {
+    // Check if this is actually a mission command based on content, not just commandType
+    const isMission = isMissionCommand(event?.data, event?.text)
+
+    if (commandType === 'mission' || isMission) {
       const missionPath =
-        event?.data?.match(/[A-Za-z0-9_/]+\.(?:xml|tl)/)?.[0] ?? ''
+        event?.data?.match(/[A-Za-z0-9_/]+\.(?:xml|tl)/)?.[0] ??
+        event?.text?.match(/[A-Za-z0-9_/]+\.(?:xml|tl)/)?.[0] ??
+        ''
       setGlobalModalId({
         id: 'newMission',
         meta: {
           mission: missionPath,
           eventId: eventId,
-          eventData: event?.data ?? null,
+          eventData: event?.data ?? event?.text ?? null,
           eventUser: event?.user ?? null,
           eventNote: event?.note ?? null,
           eventIsoTime: event?.unixTime

--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildFreeformCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildFreeformCommandStep.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import { TextAreaField, TextAreaFieldProps } from '../../Fields'
 
 export interface BuildFreeformCommandStepProps {
@@ -9,7 +9,19 @@ export interface BuildFreeformCommandStepProps {
 export const BuildFreeformCommandStep: React.FC<
   BuildFreeformCommandStepProps
 > = ({ command: initialCommand, onCommandTextChange }) => {
-  const [command, setCommand] = useState(initialCommand)
+  const [command, setCommand] = useState(initialCommand ?? '')
+
+  // Sync internal state with prop changes (only needed if prop changes externally ie when rerunning commands from schedule history)
+  useEffect(() => {
+    if (
+      initialCommand !== undefined &&
+      initialCommand !== null &&
+      initialCommand !== command
+    ) {
+      setCommand(initialCommand)
+    }
+  }, [initialCommand, command])
+
   const handleChangedCommand: TextAreaFieldProps['onChange'] = (e) => {
     setCommand(e.target.value)
     onCommandTextChange?.(e.target.value)

--- a/packages/react-ui/src/Modals/CommandModalView.tsx
+++ b/packages/react-ui/src/Modals/CommandModalView.tsx
@@ -158,7 +158,15 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
   )
 
   const handleNext = () => {
-    if (selectedCommandId) setCurrentStep(currentStep + 1)
+    // Allow advancing if:
+    // 1. selectedCommandId is set (templated commands)
+    // 2. OR we're on step 1 and have commandText or selectedCommandName (freeform commands)
+    if (
+      selectedCommandId ||
+      (currentStep === 1 && (commandText || selectedCommandName))
+    ) {
+      setCurrentStep(currentStep + 1)
+    }
   }
 
   const handlePrevious = () => {
@@ -194,7 +202,9 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
       : [back]
   }
 
-  const [commandText, setCommandText] = useState<string | null>(null)
+  const [commandText, setCommandText] = useState<string | null>(
+    defaultCommand ?? null
+  )
 
   const [selectedSyntax, setSelectedSyntax] = useState<string | null>(
     syntaxVariations?.[0]?.help ?? null
@@ -311,11 +321,16 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
         ))}
 
       {currentStep === 2 &&
-        selectedCommandId &&
+        (selectedCommandId || commandText || selectedCommandName) &&
         (showAlternateAddress ? (
           <AlternativeAddressStep
             vehicleName={vehicleName}
-            mission={commandText ?? getCommandNameById(selectedCommandId) ?? ''}
+            mission={
+              commandText ??
+              getCommandNameById(selectedCommandId ?? '') ??
+              selectedCommandName ??
+              ''
+            }
             commandDescriptor="command"
             alternativeAddresses={alternativeAddresses}
           />
@@ -323,7 +338,10 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
           <ScheduleStep
             vehicleName={vehicleName}
             commandText={
-              commandText ?? getCommandNameById(selectedCommandId) ?? ''
+              commandText ??
+              getCommandNameById(selectedCommandId ?? '') ??
+              selectedCommandName ??
+              ''
             }
             commandDescriptor="command"
           />


### PR DESCRIPTION
- Verify whether a given schedule entry is actually a command or a mission (previously incorrect)
- Allow commands in scheduler to be rerun as freeform commands
- Next button is now active when rerunning from scheduler

Note: I tried for quite a while to allow commands that are rerun from the scheduler to use the actual command template builder with dropdown menus. However, due to the amount of variation in how commands are created and the inconsistent formatting, I was unable to get it to work across all commands. Hopefully using the freeform format will work for users.

## Selecting to rerun command
<img width="666" height="226" alt="Screenshot 2025-12-05 at 5 02 45 PM" src="https://github.com/user-attachments/assets/9d7c5a23-c6b7-4732-b16c-b0a254d2d94d" />

## Freeform command builder
<img width="1018" height="375" alt="Screenshot 2025-12-05 at 5 03 01 PM" src="https://github.com/user-attachments/assets/25a0f884-694f-40aa-8327-9c16ab244947" />

## Another example of rerunning with freeform command builder
<img width="1017" height="361" alt="Screenshot 2025-12-05 at 5 03 42 PM" src="https://github.com/user-attachments/assets/b56ce24b-aa1d-411d-b041-81b60db02bbf" />
