### PR TITLE
Display seconds in CommsSection timestamps (fixes #491)

### DIFF
--- a/apps/lrauv-dash2/components/CommsSection.test.tsx
+++ b/apps/lrauv-dash2/components/CommsSection.test.tsx
@@ -146,4 +146,21 @@ describe('CommsSection', () => {
       'text-indigo-600'
     )
   })
+
+  test('should display timestamps with seconds (H:mm:ss)', async () => {
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <CommsSection vehicleName="makai" from="" />
+      </MockProviders>
+    )
+    await waitFor(() => {
+      screen.getByText(/One More/i)
+    })
+    const timeElements = screen.getAllByLabelText('time')
+    expect(timeElements.length).toBeGreaterThan(0)
+    const timeFormat = /^\d{1,2}:\d{2}:\d{2}$/
+    timeElements.forEach((el) => {
+      expect(el.textContent).toMatch(timeFormat)
+    })
+  })
 })

--- a/apps/lrauv-dash2/components/CommsSection.tsx
+++ b/apps/lrauv-dash2/components/CommsSection.tsx
@@ -88,7 +88,7 @@ const CommsSection: React.FC<CommsSectionProps> = ({
     const day = today
       ? 'Today'
       : DateTime.fromISO(item?.commsIsoTime ?? '').toFormat('MMM d yyyy')
-    const time = DateTime.fromISO(item?.commsIsoTime ?? '').toFormat('H:mm')
+    const time = DateTime.fromISO(item?.commsIsoTime ?? '').toFormat('H:mm:ss')
 
     return item ? (
       <CommsCell


### PR DESCRIPTION
Extends the full-resolution timestamp display from LogsSection to CommsSection. Command and mission event timestamps now show H:mm:ss for correlation with other datastreams and sources.

Addresses #491.