### PR TITLE
ci: make release tagging branch-aware

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
   push:
     tags:
       - 'v*'  # Run when a version tag is pushed
-  # Tags are created automatically when PRs merge into develop
   release:
     types: [created]
 
@@ -23,43 +22,62 @@ jobs:
     outputs:
       env_name: ${{ steps.set-env.outputs.env_name }}
       is_production: ${{ steps.set-env.outputs.is_production }}
+      version: ${{ steps.set-env.outputs.version }}
     steps:
-      - name: Checkout code to determine branch for tag
+      - name: Checkout code to inspect tag metadata
         uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Need full history to determine branch for tag
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
 
-      - name: Determine environment based on tag branch
+      - name: Determine environment based on tag annotation
         id: set-env
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ startsWith(github.ref, 'refs/tags/v') }}" == "true" ]]; then
-            # Get the branch where the tag was created
-            TAG_NAME="${{ github.ref_name }}"
-            COMMIT_SHA=$(git rev-list -n 1 $TAG_NAME)
-            
-            # Check if tag is on main branch (production) or develop branch (staging)
-            if git branch --contains $COMMIT_SHA | grep "main"; then
-              echo "Tag is on main branch - PRODUCTION environment"
-              echo "env_name=production" >> $GITHUB_OUTPUT
-              echo "is_production=true" >> $GITHUB_OUTPUT
-            elif git branch --contains $COMMIT_SHA | grep "develop"; then
-              echo "Tag is on develop branch - STAGING environment"
-              echo "env_name=staging" >> $GITHUB_OUTPUT
-              echo "is_production=false" >> $GITHUB_OUTPUT
-            else
-              echo "Tag is on an unknown branch - defaulting to STAGING"
-              echo "env_name=staging" >> $GITHUB_OUTPUT
-              echo "is_production=false" >> $GITHUB_OUTPUT
-            fi
-          elif [[ "${{ github.event_name }}" == "release" ]]; then
-            echo "Release event - PRODUCTION environment"
-            echo "env_name=production" >> $GITHUB_OUTPUT
-            echo "is_production=true" >> $GITHUB_OUTPUT
-          else
-            echo "Manual workflow dispatch - STAGING environment"
-            echo "env_name=staging" >> $GITHUB_OUTPUT
-            echo "is_production=false" >> $GITHUB_OUTPUT
+          TAG_NAME="${GITHUB_REF_NAME}"
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAG_NAME="${{ github.event.release.tag_name }}"
           fi
+
+          if [[ -z "$TAG_NAME" ]]; then
+            echo "Manual workflow dispatch - defaulting to STAGING"
+            echo "env_name=staging" >> "$GITHUB_OUTPUT"
+            echo "is_production=false" >> "$GITHUB_OUTPUT"
+            echo "version=manual-${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          TAG_SUBJECT=$(git for-each-ref "refs/tags/${TAG_NAME}" --format='%(subject)')
+          VERSION="${TAG_NAME#v}"
+
+          echo "Tag ${TAG_NAME} subject: ${TAG_SUBJECT}"
+
+          if [[ "$TAG_SUBJECT" == Production\ release* ]]; then
+            echo "Annotated as PRODUCTION"
+            echo "env_name=production" >> "$GITHUB_OUTPUT"
+            echo "is_production=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG_SUBJECT" == Staging\ release* ]]; then
+            echo "Annotated as STAGING"
+            echo "env_name=staging" >> "$GITHUB_OUTPUT"
+            echo "is_production=false" >> "$GITHUB_OUTPUT"
+          else
+            COMMIT_SHA=$(git rev-list -n 1 "$TAG_NAME")
+
+            if git branch -r --contains "$COMMIT_SHA" | grep -q 'origin/main$'; then
+              echo "Falling back to branch detection: PRODUCTION"
+              echo "env_name=production" >> "$GITHUB_OUTPUT"
+              echo "is_production=true" >> "$GITHUB_OUTPUT"
+            elif git branch -r --contains "$COMMIT_SHA" | grep -q 'origin/develop$'; then
+              echo "Falling back to branch detection: STAGING"
+              echo "env_name=staging" >> "$GITHUB_OUTPUT"
+              echo "is_production=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "Unable to infer branch. Defaulting to STAGING."
+              echo "env_name=staging" >> "$GITHUB_OUTPUT"
+              echo "is_production=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
   build-static:
     runs-on: ubuntu-latest
@@ -68,6 +86,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
         
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -123,6 +143,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
         
       - name: Download static build
         uses: actions/download-artifact@v4
@@ -152,29 +174,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
-      # Extract metadata for Docker tags
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: |
-            mbari/lrauv-dash-5
-            ghcr.io/${{ github.repository_owner }}/lrauv-dash-5
-          tags: |
-            # Always publish the environment tag (staging or production)
-            type=raw,value=${{ needs.determine-environment.outputs.env_name }}
+      - name: Prepare Docker tags
+        id: docker-tags
+        run: |
+          CHANNEL="${{ needs.determine-environment.outputs.env_name }}"
+          VERSION="${{ needs.determine-environment.outputs.version }}"
 
-            # Staging-only: publish a versioned staging tag for easy rollback/debugging
-            # Example: staging-1.2.3
-            type=semver,pattern=staging-{{version}},enable=${{ needs.determine-environment.outputs.is_production != 'true' }}
+          {
+            echo "tags<<EOF"
+            echo "mbari/lrauv-dash-5:${CHANNEL}"
+            echo "ghcr.io/${{ github.repository_owner }}/lrauv-dash-5:${CHANNEL}"
 
-            # Production-only: publish semver tags
-            type=semver,pattern={{version}},enable=${{ needs.determine-environment.outputs.is_production == 'true' }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ needs.determine-environment.outputs.is_production == 'true' }}
-            type=semver,pattern={{major}},enable=${{ needs.determine-environment.outputs.is_production == 'true' }}
+            if [[ "$CHANNEL" == "staging" ]]; then
+              echo "mbari/lrauv-dash-5:${CHANNEL}-${VERSION}"
+              echo "ghcr.io/${{ github.repository_owner }}/lrauv-dash-5:${CHANNEL}-${VERSION}"
+            fi
 
-            # Production-only: publish latest
-            type=raw,value=latest,enable=${{ needs.determine-environment.outputs.is_production == 'true' }}
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
       
       # Build and push Docker image
       - name: Build and push Docker image
@@ -183,24 +200,15 @@ jobs:
           context: .
           file: ./docker/Dockerfile
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.docker-tags.outputs.tags }}
           build-args: |
             ENVIRONMENT=${{ needs.determine-environment.outputs.env_name }}
       
-      # Trigger Watchtower to update container (for production environment)
-      - name: Trigger Watchtower to update production container
+      - name: Skip Watchtower for production
         if: needs.determine-environment.outputs.is_production == 'true'
-        shell: bash
         run: |
-          if [ -n "${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}" ] && [ -n "${{ secrets.TETHYSDASH2_WATCHTOWER_ENDPOINT }}" ]; then
-            curl -H "Authorization: Bearer ${{ secrets.WATCHTOWER_HTTP_API_TOKEN }}" ${{ secrets.TETHYSDASH2_WATCHTOWER_ENDPOINT }}
-            echo "Watchtower update triggered successfully for PRODUCTION"
-          else
-            echo "Skipping Watchtower update - required secrets not configured"
-          fi
+          echo "Production image published. Watchtower auto-update is intentionally disabled."
 
-      # Trigger Watchtower to update container (for staging environment)
       - name: Trigger Watchtower to update staging container
         if: needs.determine-environment.outputs.is_production == 'false'
         shell: bash

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ Some projects in this repo depend on their siblings. For example the `@mbari/rea
 
 ### Deployment
 
-Deployments are handled automatically via [CircleCI](https://www.circleci.com).
+Deployments are handled by GitHub Actions and branch-aware release tags.
+
+- `develop` bumps create a staging release tag. CI publishes `mbari/lrauv-dash-5:staging` and `mbari/lrauv-dash-5:staging-X.Y.Z`, and Watchtower updates staging automatically.
+- `main` bumps create a production release tag. CI publishes `mbari/lrauv-dash-5:production`, but production deployment remains a manual pull and recreate step.
+- Use `yarn version:patch`, `yarn version:minor`, or `yarn version:major` only from `develop` or `main`. The script refuses version bumps from other branches.
 
 ## Packages
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -e  # Exit on error
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Colors for better terminal output
 GREEN='\033[0;32m'
@@ -8,12 +8,16 @@ RED='\033[0;31m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Function to display help
 display_help() {
   echo -e "${BLUE}DASH5 Version Bumper${NC}"
   echo "Usage: $0 [options]"
   echo
-  echo "Automatically bumps the semantic version based on the most recent git tag"
+  echo "Automatically bumps the semantic version based on the most recent git tag."
+  echo
+  echo "Branch rules:"
+  echo "  develop  Creates a staging release tag. CI publishes :staging and :staging-X.Y.Z."
+  echo "  main     Creates a production release tag. CI publishes :production."
+  echo "           Production does not auto-update; release managers deploy it intentionally."
   echo
   echo "Options:"
   echo "  -h, --help       Display this help message"
@@ -24,10 +28,50 @@ display_help() {
   echo "  -f, --force      Force creating a tag even if it already exists (overwrites existing tag)"
   echo
   echo "Examples:"
-  echo "  $0                 # Bumps patch version"
+  echo "  $0                 # Bumps patch version from develop or main"
   echo "  $0 --minor         # Bumps minor version"
   echo "  $0 --major         # Bumps major version"
   echo "  $0 --patch --force # Forces patch version bump"
+}
+
+log_info() {
+  echo -e "${YELLOW}$1${NC}"
+}
+
+log_note() {
+  echo -e "${BLUE}$1${NC}"
+}
+
+fail() {
+  echo -e "${RED}Error: $1${NC}" >&2
+  exit 1
+}
+
+tag_exists() {
+  git show-ref --tags --verify --quiet "refs/tags/$1"
+}
+
+latest_version_tag() {
+  git tag -l 'v*' | awk '/^v[0-9]+\.[0-9]+\.[0-9]+$/ { print }' | sort -V | tail -n 1
+}
+
+print_release_guidance() {
+  local environment="$1"
+  local version="$2"
+
+  echo
+  log_info "CI will publish:"
+  echo -e "${BLUE}mbari/lrauv-dash-5:${environment}${NC}"
+
+  if [ "$environment" = "staging" ]; then
+    echo -e "${BLUE}mbari/lrauv-dash-5:${environment}-${version}${NC}"
+  fi
+
+  if [ "$environment" = "staging" ]; then
+    log_info "Staging should update automatically when Watchtower sees the new :staging image."
+  else
+    log_info "Production will not auto-update. Pull and recreate the production container intentionally."
+  fi
 }
 
 # Default values
@@ -37,104 +81,138 @@ FORCE=false
 
 # Parse command line arguments
 while [[ "$#" -gt 0 ]]; do
-  case $1 in
+  case "$1" in
     -h|--help) display_help; exit 0 ;;
     -M|--major) BUMP_TYPE="major"; shift ;;
     -m|--minor) BUMP_TYPE="minor"; shift ;;
     -p|--patch) BUMP_TYPE="patch"; shift ;;
     -d|--dry-run) DRY_RUN=true; shift ;;
     -f|--force) FORCE=true; shift ;;
-    *) echo -e "${RED}Unknown parameter: $1${NC}"; display_help; exit 1 ;;
+    *) fail "Unknown parameter: $1" ;;
   esac
 done
 
-# Check if git is installed
-if ! command -v git &> /dev/null; then
-  echo -e "${RED}Error: git is not installed.${NC}"
-  exit 1
+if ! command -v git >/dev/null 2>&1; then
+  fail "git is not installed."
 fi
 
-# Ensure that the local git repo is up to date
-git fetch --tags --prune
-if [ $? -ne 0 ]; then
-  echo -e "${RED}Error: Failed to fetch tags from the remote repository.${NC}"
-  exit 1
+git fetch origin main develop --tags --prune
+
+CURRENT_BRANCH=$(git symbolic-ref --quiet --short HEAD || true)
+if [ -z "$CURRENT_BRANCH" ]; then
+  fail "Detached HEAD detected. Check out develop or main before bumping a version."
 fi
 
-# Get the latest version tag
-LATEST_TAG=$(git tag -l "v*" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1)
+case "$CURRENT_BRANCH" in
+  develop)
+    TARGET_ENVIRONMENT="staging"
+    TAG_MESSAGE_PREFIX="Staging release"
+    ;;
+  main)
+    TARGET_ENVIRONMENT="production"
+    TAG_MESSAGE_PREFIX="Production release"
+    ;;
+  *)
+    fail "Version bumps are only supported from develop (staging) or main (production). Current branch: ${CURRENT_BRANCH}"
+    ;;
+esac
+
+REMOTE_BRANCH="origin/${CURRENT_BRANCH}"
+if ! git show-ref --verify --quiet "refs/remotes/${REMOTE_BRANCH}"; then
+  fail "Remote branch ${REMOTE_BRANCH} was not found. Fetch the branch and try again."
+fi
+
+LOCAL_SHA=$(git rev-parse HEAD)
+REMOTE_SHA=$(git rev-parse "$REMOTE_BRANCH")
+
+if [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
+  if git merge-base --is-ancestor "$LOCAL_SHA" "$REMOTE_SHA"; then
+    fail "Local ${CURRENT_BRANCH} is behind ${REMOTE_BRANCH}. Run: git checkout ${CURRENT_BRANCH} && git pull origin ${CURRENT_BRANCH}"
+  elif git merge-base --is-ancestor "$REMOTE_SHA" "$LOCAL_SHA"; then
+    fail "Local ${CURRENT_BRANCH} has commits that are not on ${REMOTE_BRANCH}. Push or merge them before tagging a release."
+  else
+    fail "Local ${CURRENT_BRANCH} has diverged from ${REMOTE_BRANCH}. Sync the branch before tagging a release."
+  fi
+fi
+
+LATEST_TAG=$(latest_version_tag)
+
+if [ -n "$LATEST_TAG" ] && [ "$CURRENT_BRANCH" = "main" ]; then
+  LATEST_TAG_SHA=$(git rev-list -n 1 "$LATEST_TAG")
+  if ! git merge-base --is-ancestor "$LATEST_TAG_SHA" HEAD; then
+    fail "main does not contain ${LATEST_TAG}. Merge develop into main before creating a production release."
+  fi
+fi
 
 if [ -z "$LATEST_TAG" ]; then
-  echo -e "${YELLOW}No existing version tags found. Starting from v0.1.0${NC}"
+  log_info "No existing version tags found. Starting from v0.1.0"
   MAJOR=0
   MINOR=1
   PATCH=0
 else
-  echo -e "${YELLOW}Latest version tag: ${LATEST_TAG}${NC}"
-  
-  # Extract version components
+  log_info "Latest version tag: ${LATEST_TAG}"
   VERSION=${LATEST_TAG#v}
-  MAJOR=$(echo $VERSION | cut -d. -f1)
-  MINOR=$(echo $VERSION | cut -d. -f2)
-  PATCH=$(echo $VERSION | cut -d. -f3)
+  MAJOR=$(echo "$VERSION" | cut -d. -f1)
+  MINOR=$(echo "$VERSION" | cut -d. -f2)
+  PATCH=$(echo "$VERSION" | cut -d. -f3)
 fi
 
-# Bump version based on specified type
-case $BUMP_TYPE in
+case "$BUMP_TYPE" in
   major)
     NEW_MAJOR=$((MAJOR + 1))
     NEW_MINOR=0
     NEW_PATCH=0
-    echo -e "${YELLOW}Bumping major version: ${MAJOR}.${MINOR}.${PATCH} -> ${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}${NC}"
+    log_info "Bumping major version for ${TARGET_ENVIRONMENT}: ${MAJOR}.${MINOR}.${PATCH} -> ${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
     ;;
   minor)
     NEW_MAJOR=$MAJOR
     NEW_MINOR=$((MINOR + 1))
     NEW_PATCH=0
-    echo -e "${YELLOW}Bumping minor version: ${MAJOR}.${MINOR}.${PATCH} -> ${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}${NC}"
+    log_info "Bumping minor version for ${TARGET_ENVIRONMENT}: ${MAJOR}.${MINOR}.${PATCH} -> ${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
     ;;
   patch)
     NEW_MAJOR=$MAJOR
     NEW_MINOR=$MINOR
     NEW_PATCH=$((PATCH + 1))
-    echo -e "${YELLOW}Bumping patch version: ${MAJOR}.${MINOR}.${PATCH} -> ${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}${NC}"
+    log_info "Bumping patch version for ${TARGET_ENVIRONMENT}: ${MAJOR}.${MINOR}.${PATCH} -> ${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+    ;;
+  *)
+    fail "Unsupported bump type: ${BUMP_TYPE}"
     ;;
 esac
 
 NEW_VERSION="v${NEW_MAJOR}.${NEW_MINOR}.${NEW_PATCH}"
+DOCKER_VERSION="${NEW_VERSION#v}"
+TAG_MESSAGE="${TAG_MESSAGE_PREFIX} ${NEW_VERSION}"
 
-# Check if the tag already exists
-if git rev-parse "$NEW_VERSION" >/dev/null 2>&1; then
+if tag_exists "$NEW_VERSION"; then
   if [ "$FORCE" = true ]; then
-    echo -e "${YELLOW}Warning: Tag ${NEW_VERSION} already exists. --force option specified, will overwrite.${NC}"
+    log_info "Warning: Tag ${NEW_VERSION} already exists. --force specified, so it will be replaced."
   else
-    echo -e "${RED}Error: Tag ${NEW_VERSION} already exists. Use --force to overwrite.${NC}"
-    exit 1
+    fail "Tag ${NEW_VERSION} already exists. Use --force to overwrite it."
   fi
 fi
 
-# Execute the version bump
+log_note "Release target: ${TARGET_ENVIRONMENT} (branch ${CURRENT_BRANCH})"
+log_note "Tag annotation: ${TAG_MESSAGE}"
+
 if [ "$DRY_RUN" = true ]; then
-  echo -e "${BLUE}Dry run: Would create tag ${NEW_VERSION}${NC}"
-else
-  # Create and push the new tag
-  if [ "$FORCE" = true ] && git rev-parse "$NEW_VERSION" >/dev/null 2>&1; then
-    echo -e "${YELLOW}Deleting existing tag ${NEW_VERSION}...${NC}"
-    git tag -d "$NEW_VERSION"
-    git push origin --delete "$NEW_VERSION" 2>/dev/null || true
-  fi
-  
-  echo -e "${YELLOW}Creating new tag ${NEW_VERSION}...${NC}"
-  git tag -a "$NEW_VERSION" -m "Release $NEW_VERSION"
-  
-  echo -e "${YELLOW}Pushing new tag to origin...${NC}"
-  git push origin "$NEW_VERSION"
-  
-  echo -e "${GREEN}✅ Successfully created and pushed tag ${NEW_VERSION}${NC}"
-  echo -e "${YELLOW}To create a release, go to:${NC}"
-  echo -e "${BLUE}https://github.com/$(git config --get remote.origin.url | sed -E 's|.*github.com[:/]([^/]+/[^/]+).*|\1|' | sed 's/\.git$//')/releases/new?tag=${NEW_VERSION}${NC}"
+  log_note "Dry run: Would create tag ${NEW_VERSION}"
+  print_release_guidance "$TARGET_ENVIRONMENT" "$DOCKER_VERSION"
+  exit 0
 fi
 
-echo
-echo -e "${YELLOW}To trigger a release workflow, run:${NC}"
-echo -e "${BLUE}gh workflow run release.yml --ref ${NEW_VERSION}${NC}"
+if [ "$FORCE" = true ] && tag_exists "$NEW_VERSION"; then
+  log_info "Deleting existing tag ${NEW_VERSION}..."
+  git tag -d "$NEW_VERSION"
+  git push origin --delete "$NEW_VERSION" 2>/dev/null || true
+fi
+
+log_info "Creating new tag ${NEW_VERSION}..."
+git tag -a "$NEW_VERSION" -m "$TAG_MESSAGE"
+
+log_info "Pushing new tag to origin..."
+git push origin "$NEW_VERSION"
+
+echo -e "${GREEN}Successfully created and pushed tag ${NEW_VERSION}${NC}"
+print_release_guidance "$TARGET_ENVIRONMENT" "$DOCKER_VERSION"


### PR DESCRIPTION
## Summary
- make the version bump script enforce develop vs main release rules and annotate tags with staging or production intent
- update the release workflow to publish non-overlapping Docker tags and skip Watchtower auto-updates for production
- document the revised deployment flow in the README

## Testing
- bash -n scripts/bump-version.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'
- dry-run in a clean temp clone from develop produced `Staging release v5.1.3` with `:staging` and `:staging-5.1.3`
- dry-run in a clean temp clone from main failed with `main does not contain v5.1.2. Merge develop into main before creating a production release.`