### PR TITLE
GH489 Remove Data Events from Logs by Default

### DIFF
--- a/apps/lrauv-dash2/components/LogsSection.test.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import LogsSection from './LogsSection'
 import { QueryClient } from 'react-query'
 import { rest } from 'msw'
@@ -106,5 +106,111 @@ describe('LogsSection', () => {
       screen.getByText(/Received 840 bytes/i)
     })
     expect(screen.getByText(/Received 840 bytes/i)).toBeInTheDocument()
+  })
+
+  test('should hide data events by default', async () => {
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <LogsSection
+          vehicleName="triton"
+          from={1657733848418}
+          deploymentLogsOnly={false}
+          setDeploymentLogsOnly={() => {}}
+        />
+      </MockProviders>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Deployment/i)).toBeInTheDocument()
+    })
+
+    // The mock includes one `dataProcessed` event which maps to the "Data" label.
+    expect(screen.queryByText(/^Data$/)).not.toBeInTheDocument()
+  })
+
+  test('should include data events when checkbox is checked', async () => {
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <LogsSection
+          vehicleName="triton"
+          from={1657733848418}
+          deploymentLogsOnly={false}
+          setDeploymentLogsOnly={() => {}}
+        />
+      </MockProviders>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /filter/i })
+      ).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }))
+
+    const checkbox = await waitFor(() =>
+      screen.getByRole('checkbox', {
+        name: /include data events/i,
+      })
+    )
+
+    fireEvent.click(checkbox)
+
+    await waitFor(() => {
+      expect(screen.getByText(/^Data$/)).toBeInTheDocument()
+    })
+  })
+
+  test('shows help when no event types are selected', async () => {
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <LogsSection
+          vehicleName="triton"
+          from={1657733848418}
+          deploymentLogsOnly={false}
+          setDeploymentLogsOnly={() => {}}
+        />
+      </MockProviders>
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /filter/i })
+      ).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }))
+    fireEvent.click(screen.getByLabelText('select-all'))
+
+    const banner = await waitFor(() => screen.getByRole('status'))
+    expect(banner).toHaveTextContent(
+      /Open Filter and choose at least one type to see logs/i
+    )
+  })
+
+  test('shows no matching events banner when log search matches nothing', async () => {
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <LogsSection
+          vehicleName="triton"
+          from={1657733848418}
+          deploymentLogsOnly={false}
+          setDeploymentLogsOnly={() => {}}
+        />
+      </MockProviders>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText(/Deployment/i)).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }))
+    fireEvent.change(screen.getByLabelText('search'), {
+      target: { value: '__no_log_match_xyz__' },
+    })
+
+    const noMatchBanner = await waitFor(() => screen.getByRole('status'), {
+      timeout: 3000,
+    })
+    expect(noMatchBanner).toHaveTextContent(/No matching events/i)
+    expect(noMatchBanner).toHaveTextContent(/Try adjusting Filter or search/i)
   })
 })

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -1,9 +1,5 @@
 import React, { useMemo, useState } from 'react'
-import {
-  EventType,
-  useInfiniteEvents,
-  useTethysApiContext,
-} from '@mbari/api-client'
+import { useInfiniteEvents, useTethysApiContext } from '@mbari/api-client'
 import {
   Virtualizer,
   LogCell,
@@ -18,10 +14,15 @@ import { MultiValue } from 'react-select'
 import { DateTime } from 'luxon'
 import formatEvent, {
   displayNameForEventType,
-  eventFilters,
   isUploadEvent,
 } from '../lib/formatEvent'
-import { applyEventFilters } from '../lib/eventFilterUtils'
+import {
+  applySelectedFilters,
+  defaultModalSelections,
+  deriveEventTypes,
+  hasAllNonDataFiltersSelected,
+  modalVisibleFilterIds,
+} from '../lib/logFilters'
 import { handleCopyEventLogs } from '../lib/handleCopyEventLogs'
 import { createLogger, useDebounce } from '@mbari/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -51,8 +52,6 @@ const styles = {
   emptyLogBannerIcon: 'mr-1 flex-shrink-0 text-amber-600',
 }
 
-const DATA_FILTER_ID = 'Data'
-
 const LogsSection: React.FC<LogsSectionProps> = ({
   vehicleName,
   from,
@@ -65,44 +64,37 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   }
 
   const { siteConfig } = useTethysApiContext()
-  const [filters, setFilters] = useState<MultiValue<SelectOption>>(() =>
-    Object.keys(eventFilters)
-      .filter((id) => id !== DATA_FILTER_ID)
-      .map((id) => ({ id, name: id }))
+  const [filters, setFilters] = useState<MultiValue<SelectOption>>(
+    defaultModalSelections
   )
   const [filtersOpen, setFiltersOpen] = useState(false)
   const [searchText, setSearchText] = useState('')
   const debouncedSearchText = useDebounce(searchText, 250)
   const [includeDataEvents, setIncludeDataEvents] = useState(false)
 
-  const modalEventFilterIds = useMemo(
-    () => Object.keys(eventFilters).filter((id) => id !== DATA_FILTER_ID),
-    []
-  )
+  const modalFilterIds = modalVisibleFilterIds()
 
   const eventFilterOptions = useMemo(
     () =>
-      modalEventFilterIds.map((id) => ({
+      modalFilterIds.map((id) => ({
         id,
         label: id,
       })),
-    [modalEventFilterIds]
+    [modalFilterIds]
   )
-  const allFiltersSelected = useMemo(
-    () => filters.length === modalEventFilterIds.length,
-    [filters, modalEventFilterIds]
+  const allNonDataFiltersSelected = useMemo(
+    () => hasAllNonDataFiltersSelected(filters.map((f) => f.id)),
+    [filters]
   )
 
-  const eventTypes = useMemo((): EventType[] | undefined => {
-    if (!filters.length || allFiltersSelected) return undefined
-    const base = filters
-      .flatMap(({ id }) => eventFilters[id].eventTypes)
-      .filter((k, i, a) => a.indexOf(k) === i)
-    if (includeDataEvents && !base.includes('dataProcessed')) {
-      return [...base, 'dataProcessed']
-    }
-    return base
-  }, [filters, allFiltersSelected, includeDataEvents])
+  const eventTypes = useMemo(
+    () =>
+      deriveEventTypes(
+        filters.map((f) => f.id),
+        includeDataEvents
+      ),
+    [filters, includeDataEvents]
+  )
 
   const deploymentParams = useMemo(
     () => ({
@@ -142,11 +134,14 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   const flatData = useMemo(() => {
     if (filters.length === 0) return []
     if (!data?.pages) return []
-    let events = data.pages.flat()
-    if (filters.length && !allFiltersSelected) {
-      const selectedFilterNames = filters.map(({ id }) => id)
-      events = applyEventFilters(events, selectedFilterNames)
-    }
+    let events = applySelectedFilters(
+      data.pages.flat(),
+      filters.map(({ id }) => id),
+      {
+        includeDataEvents,
+        allNonDataFiltersSelected,
+      }
+    )
     if (debouncedSearchText.trim().length) {
       const searchTerm = debouncedSearchText.toLowerCase()
       events = events.filter((e) => {
@@ -161,14 +156,11 @@ const LogsSection: React.FC<LogsSectionProps> = ({
         return parts.some((p) => p.toLowerCase().includes(searchTerm))
       })
     }
-    if (!includeDataEvents) {
-      events = events.filter((e) => e.eventType !== 'dataProcessed')
-    }
     return events
   }, [
     data?.pages,
     filters,
-    allFiltersSelected,
+    allNonDataFiltersSelected,
     debouncedSearchText,
     includeDataEvents,
   ])

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -1,5 +1,9 @@
 import React, { useMemo, useState } from 'react'
-import { useInfiniteEvents, useTethysApiContext } from '@mbari/api-client'
+import {
+  EventType,
+  useInfiniteEvents,
+  useTethysApiContext,
+} from '@mbari/api-client'
 import {
   Virtualizer,
   LogCell,
@@ -21,7 +25,11 @@ import { applyEventFilters } from '../lib/eventFilterUtils'
 import { handleCopyEventLogs } from '../lib/handleCopyEventLogs'
 import { createLogger, useDebounce } from '@mbari/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons'
+import {
+  faChevronDown,
+  faChevronUp,
+  faTriangleExclamation,
+} from '@fortawesome/free-solid-svg-icons'
 import { RealTimeLogs } from './RealTimeLogs'
 
 const logger = createLogger('components.LogsSection')
@@ -38,7 +46,12 @@ export interface LogsSectionProps {
 
 const styles = {
   icon: 'ml-1 my-auto flex-grow-0 mr-2 flex-shrink-0',
+  emptyLogBanner:
+    'flex items-center justify-center gap-0.5 bg-amber-50 px-2 py-6 text-xl text-black',
+  emptyLogBannerIcon: 'mr-1 flex-shrink-0 text-amber-600',
 }
+
+const DATA_FILTER_ID = 'Data'
 
 const LogsSection: React.FC<LogsSectionProps> = ({
   vehicleName,
@@ -52,36 +65,44 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   }
 
   const { siteConfig } = useTethysApiContext()
-  const [filters, setFilters] = useState<MultiValue<SelectOption>>([])
+  const [filters, setFilters] = useState<MultiValue<SelectOption>>(() =>
+    Object.keys(eventFilters)
+      .filter((id) => id !== DATA_FILTER_ID)
+      .map((id) => ({ id, name: id }))
+  )
   const [filtersOpen, setFiltersOpen] = useState(false)
   const [searchText, setSearchText] = useState('')
   const debouncedSearchText = useDebounce(searchText, 250)
+  const [includeDataEvents, setIncludeDataEvents] = useState(false)
 
-  const eventFilterIds = useMemo(() => Object.keys(eventFilters), [])
+  const modalEventFilterIds = useMemo(
+    () => Object.keys(eventFilters).filter((id) => id !== DATA_FILTER_ID),
+    []
+  )
 
   const eventFilterOptions = useMemo(
     () =>
-      eventFilterIds.map((id) => ({
+      modalEventFilterIds.map((id) => ({
         id,
         label: id,
       })),
-    [eventFilterIds]
+    [modalEventFilterIds]
   )
   const allFiltersSelected = useMemo(
-    () => filters.length === eventFilterIds.length,
-    [filters, eventFilterIds]
+    () => filters.length === modalEventFilterIds.length,
+    [filters, modalEventFilterIds]
   )
 
-  const eventTypes = useMemo(
-    () =>
-      filters.length && !allFiltersSelected
-        ? filters
-            .map(({ id }) => eventFilters[id].eventTypes)
-            .flat()
-            .filter((k, i, a) => a.indexOf(k) === i)
-        : undefined,
-    [filters, allFiltersSelected]
-  )
+  const eventTypes = useMemo((): EventType[] | undefined => {
+    if (!filters.length || allFiltersSelected) return undefined
+    const base = filters
+      .flatMap(({ id }) => eventFilters[id].eventTypes)
+      .filter((k, i, a) => a.indexOf(k) === i)
+    if (includeDataEvents && !base.includes('dataProcessed')) {
+      return [...base, 'dataProcessed']
+    }
+    return base
+  }, [filters, allFiltersSelected, includeDataEvents])
 
   const deploymentParams = useMemo(
     () => ({
@@ -119,9 +140,10 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   } = deploymentLogsOnly ? deploymentResponse : allLogsResponse
 
   const flatData = useMemo(() => {
+    if (filters.length === 0) return []
     if (!data?.pages) return []
     let events = data.pages.flat()
-    if (filters.length) {
+    if (filters.length && !allFiltersSelected) {
       const selectedFilterNames = filters.map(({ id }) => id)
       events = applyEventFilters(events, selectedFilterNames)
     }
@@ -139,10 +161,24 @@ const LogsSection: React.FC<LogsSectionProps> = ({
         return parts.some((p) => p.toLowerCase().includes(searchTerm))
       })
     }
+    if (!includeDataEvents) {
+      events = events.filter((e) => e.eventType !== 'dataProcessed')
+    }
     return events
-  }, [data?.pages, filters, debouncedSearchText])
+  }, [
+    data?.pages,
+    filters,
+    allFiltersSelected,
+    debouncedSearchText,
+    includeDataEvents,
+  ])
   const dataCount = flatData?.length ?? 0
   const totalCount = hasNextPage ? dataCount + 1 : dataCount
+  const listLoading = filters.length > 0 && (isLoading || isFetching)
+  const showNoFiltersMessage = filters.length === 0 && !listLoading
+  const accordionCount = showNoFiltersMessage ? 0 : totalCount
+  const showNoMatchingEventsMessage =
+    filters.length > 0 && !listLoading && dataCount === 0
 
   const handleLoadMore = () => {
     fetchNextPage()
@@ -218,6 +254,8 @@ const LogsSection: React.FC<LogsSectionProps> = ({
                   onSearchChange={setSearchText}
                   onDismiss={() => setFiltersOpen(false)}
                   placeholder="Search logs"
+                  includeDataEvents={includeDataEvents}
+                  onIncludeDataEventsChange={setIncludeDataEvents}
                 />
               </div>
             )}
@@ -232,10 +270,39 @@ const LogsSection: React.FC<LogsSectionProps> = ({
         />
       </header>
 
+      {showNoFiltersMessage ? (
+        <div className={styles.emptyLogBanner} role="status">
+          <FontAwesomeIcon
+            icon={faTriangleExclamation}
+            className={styles.emptyLogBannerIcon}
+            size="lg"
+            aria-hidden
+          />
+          <p className="m-0">
+            Open <strong className="font-semibold">Filter</strong> and choose at
+            least one type to see logs.
+          </p>
+        </div>
+      ) : null}
+      {showNoMatchingEventsMessage ? (
+        <div className={styles.emptyLogBanner} role="status">
+          <FontAwesomeIcon
+            icon={faTriangleExclamation}
+            className={styles.emptyLogBannerIcon}
+            size="lg"
+            aria-hidden
+          />
+          <p className="m-0">
+            No matching events. Try adjusting{' '}
+            <strong className="font-semibold">Filter</strong> or search.
+          </p>
+        </div>
+      ) : null}
+
       <AccordionCells
         cellAtIndex={cellAtIndex}
-        count={totalCount}
-        loading={isLoading || isFetching}
+        count={accordionCount}
+        loading={listLoading}
       />
     </>
   )

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -21,6 +21,7 @@ import {
   defaultModalSelections,
   deriveEventTypes,
   hasAllNonDataFiltersSelected,
+  hasLogFilterSelection,
   modalVisibleFilterIds,
 } from '../lib/logFilters'
 import { handleCopyEventLogs } from '../lib/handleCopyEventLogs'
@@ -87,6 +88,15 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     [filters]
   )
 
+  const hasSelection = useMemo(
+    () =>
+      hasLogFilterSelection(
+        filters.map((f) => f.id),
+        includeDataEvents
+      ),
+    [filters, includeDataEvents]
+  )
+
   const eventTypes = useMemo(
     () =>
       deriveEventTypes(
@@ -132,7 +142,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   } = deploymentLogsOnly ? deploymentResponse : allLogsResponse
 
   const flatData = useMemo(() => {
-    if (filters.length === 0) return []
+    if (!hasSelection) return []
     if (!data?.pages) return []
     let events = applySelectedFilters(
       data.pages.flat(),
@@ -162,15 +172,16 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     filters,
     allNonDataFiltersSelected,
     debouncedSearchText,
+    hasSelection,
     includeDataEvents,
   ])
   const dataCount = flatData?.length ?? 0
   const totalCount = hasNextPage ? dataCount + 1 : dataCount
-  const listLoading = filters.length > 0 && (isLoading || isFetching)
-  const showNoFiltersMessage = filters.length === 0 && !listLoading
+  const listLoading = hasSelection && (isLoading || isFetching)
+  const showNoFiltersMessage = !hasSelection && !listLoading
   const accordionCount = showNoFiltersMessage ? 0 : totalCount
   const showNoMatchingEventsMessage =
-    filters.length > 0 && !listLoading && dataCount === 0
+    hasSelection && !listLoading && dataCount === 0
 
   const handleLoadMore = () => {
     fetchNextPage()

--- a/apps/lrauv-dash2/lib/logFilters.test.ts
+++ b/apps/lrauv-dash2/lib/logFilters.test.ts
@@ -1,0 +1,83 @@
+import {
+  applySelectedFilters,
+  deriveEventTypes,
+  hasAllNonDataFiltersSelected,
+  modalVisibleFilterIds,
+} from './logFilters'
+import { GetEventsResponse } from '@mbari/api-client'
+
+describe('logFilters', () => {
+  const modalIds = modalVisibleFilterIds()
+
+  describe('deriveEventTypes', () => {
+    test('returns undefined when no filters selected', () => {
+      expect(deriveEventTypes([], false)).toBeUndefined()
+      expect(deriveEventTypes([], true)).toBeUndefined()
+    })
+
+    test('returns undefined when all non-Data filters selected', () => {
+      expect(deriveEventTypes(modalIds, false)).toBeUndefined()
+      expect(deriveEventTypes(modalIds, true)).toBeUndefined()
+    })
+
+    test('returns union of event types for a subset', () => {
+      const ids = ['Deployment', 'Note']
+      const result = deriveEventTypes(ids, false)
+      expect(result).toEqual(expect.arrayContaining(['deploy', 'note']))
+      expect(result?.length).toBe(2)
+    })
+
+    test('appends dataProcessed when Include Data is on and not already covered', () => {
+      const ids = ['Deployment']
+      expect(deriveEventTypes(ids, true)).toEqual(['deploy', 'dataProcessed'])
+    })
+  })
+
+  describe('applySelectedFilters', () => {
+    const dataEvent = {
+      eventType: 'dataProcessed',
+    } as GetEventsResponse
+    const deployEvent = { eventType: 'deploy' } as GetEventsResponse
+
+    test('adds Data when Include Data is on and selection is partial', () => {
+      const result = applySelectedFilters(
+        [deployEvent, dataEvent],
+        ['Deployment'],
+        { includeDataEvents: true, allNonDataFiltersSelected: false }
+      )
+      expect(result).toEqual([deployEvent, dataEvent])
+    })
+
+    test('drops data when Include Data is off and selection is partial', () => {
+      const result = applySelectedFilters(
+        [deployEvent, dataEvent],
+        ['Deployment'],
+        { includeDataEvents: false, allNonDataFiltersSelected: false }
+      )
+      expect(result).toEqual([deployEvent])
+    })
+
+    test('when every non-Data filter is selected, skips narrowing by name but still drops data if Include Data is off', () => {
+      const result = applySelectedFilters([deployEvent, dataEvent], modalIds, {
+        includeDataEvents: false,
+        allNonDataFiltersSelected: true,
+      })
+      expect(result).toEqual([deployEvent])
+    })
+
+    test('when every non-Data filter is selected and Include Data is on, keeps data events', () => {
+      const result = applySelectedFilters([deployEvent, dataEvent], modalIds, {
+        includeDataEvents: true,
+        allNonDataFiltersSelected: true,
+      })
+      expect(result).toEqual([deployEvent, dataEvent])
+    })
+  })
+
+  describe('hasAllNonDataFiltersSelected', () => {
+    test('is true only when counts match modal-visible list', () => {
+      expect(hasAllNonDataFiltersSelected(modalIds)).toBe(true)
+      expect(hasAllNonDataFiltersSelected(['Deployment'])).toBe(false)
+    })
+  })
+})

--- a/apps/lrauv-dash2/lib/logFilters.test.ts
+++ b/apps/lrauv-dash2/lib/logFilters.test.ts
@@ -2,6 +2,7 @@ import {
   applySelectedFilters,
   deriveEventTypes,
   hasAllNonDataFiltersSelected,
+  hasLogFilterSelection,
   modalVisibleFilterIds,
 } from './logFilters'
 import { GetEventsResponse } from '@mbari/api-client'
@@ -10,9 +11,9 @@ describe('logFilters', () => {
   const modalIds = modalVisibleFilterIds()
 
   describe('deriveEventTypes', () => {
-    test('returns undefined when no filters selected', () => {
+    test('when no modal filters selected, requests only data or nothing', () => {
       expect(deriveEventTypes([], false)).toBeUndefined()
-      expect(deriveEventTypes([], true)).toBeUndefined()
+      expect(deriveEventTypes([], true)).toEqual(['dataProcessed'])
     })
 
     test('returns undefined when all non-Data filters selected', () => {
@@ -48,6 +49,14 @@ describe('logFilters', () => {
       expect(result).toEqual([deployEvent, dataEvent])
     })
 
+    test('data-only: modal empty and Include Data on keeps only data events', () => {
+      const result = applySelectedFilters([deployEvent, dataEvent], [], {
+        includeDataEvents: true,
+        allNonDataFiltersSelected: false,
+      })
+      expect(result).toEqual([dataEvent])
+    })
+
     test('drops data when Include Data is off and selection is partial', () => {
       const result = applySelectedFilters(
         [deployEvent, dataEvent],
@@ -78,6 +87,17 @@ describe('logFilters', () => {
     test('is true only when counts match modal-visible list', () => {
       expect(hasAllNonDataFiltersSelected(modalIds)).toBe(true)
       expect(hasAllNonDataFiltersSelected(['Deployment'])).toBe(false)
+    })
+  })
+
+  describe('hasLogFilterSelection', () => {
+    test('is true when Include Data is on even if no modal filters', () => {
+      expect(hasLogFilterSelection([], true)).toBe(true)
+      expect(hasLogFilterSelection([], false)).toBe(false)
+    })
+
+    test('is true when at least one modal filter is selected', () => {
+      expect(hasLogFilterSelection(['Deployment'], false)).toBe(true)
     })
   })
 })

--- a/apps/lrauv-dash2/lib/logFilters.ts
+++ b/apps/lrauv-dash2/lib/logFilters.ts
@@ -1,0 +1,82 @@
+import { EventType, GetEventsResponse } from '@mbari/api-client'
+import { applyEventFilters } from './eventFilterUtils'
+import { eventFilters } from './formatEvent'
+
+export const DATA_FILTER_ID = 'Data'
+
+export type LogFilterId = keyof typeof eventFilters
+
+const MODAL_VISIBLE_FILTER_IDS = Object.keys(eventFilters).filter(
+  (id) => id !== DATA_FILTER_ID
+)
+
+/** Ids for filters shown in the modal (everything except Data, which uses the separate toggle). */
+export const modalVisibleFilterIds = (): string[] => MODAL_VISIBLE_FILTER_IDS
+
+/** Initial checkbox state: every modal-visible filter turned on. */
+export const defaultModalSelections = (): Array<{ id: string; name: string }> =>
+  MODAL_VISIBLE_FILTER_IDS.map((id) => ({ id, name: id }))
+
+/** True when the user has every non-Data filter selected (same count as the modal list). */
+export const hasAllNonDataFiltersSelected = (
+  selectedFilterIds: string[]
+): boolean => selectedFilterIds.length === MODAL_VISIBLE_FILTER_IDS.length
+
+/**
+ * Event types to request from the API: narrowed list when the user picks a subset of
+ * filters; `undefined` means “all types.” Adds dataProcessed when Include Data is on.
+ */
+export const deriveEventTypes = (
+  selectedFilterIds: string[],
+  includeDataEvents: boolean
+): EventType[] | undefined => {
+  if (
+    !selectedFilterIds.length ||
+    hasAllNonDataFiltersSelected(selectedFilterIds)
+  ) {
+    return undefined
+  }
+  const base = selectedFilterIds
+    .flatMap((id) => eventFilters[id].eventTypes)
+    .filter((k, i, a) => a.indexOf(k) === i)
+  if (includeDataEvents && !base.includes('dataProcessed')) {
+    return [...base, 'dataProcessed']
+  }
+  return base
+}
+
+const filterNamesForApply = (
+  selectedFilterIds: string[],
+  includeDataEvents: boolean
+): string[] => {
+  if (includeDataEvents && !selectedFilterIds.includes(DATA_FILTER_ID)) {
+    return [...selectedFilterIds, DATA_FILTER_ID]
+  }
+  return [...selectedFilterIds]
+}
+
+/**
+ * Keeps events that match the modal selection and Include Data toggle. When every
+ * non-Data filter is selected, skips narrowing by filter name (same as “all types” fetch).
+ */
+export const applySelectedFilters = (
+  events: GetEventsResponse[],
+  selectedFilterIds: string[],
+  options: {
+    includeDataEvents: boolean
+    allNonDataFiltersSelected: boolean
+  }
+): GetEventsResponse[] => {
+  const { includeDataEvents, allNonDataFiltersSelected } = options
+  let result = events
+  if (!allNonDataFiltersSelected) {
+    result = applyEventFilters(
+      result,
+      filterNamesForApply(selectedFilterIds, includeDataEvents)
+    )
+  }
+  if (!includeDataEvents) {
+    result = result.filter((e) => e.eventType !== 'dataProcessed')
+  }
+  return result
+}

--- a/apps/lrauv-dash2/lib/logFilters.ts
+++ b/apps/lrauv-dash2/lib/logFilters.ts
@@ -22,18 +22,25 @@ export const hasAllNonDataFiltersSelected = (
   selectedFilterIds: string[]
 ): boolean => selectedFilterIds.length === MODAL_VISIBLE_FILTER_IDS.length
 
+/** At least one modal filter checked, or Include Data Events is on. */
+export const hasLogFilterSelection = (
+  selectedFilterIds: string[],
+  includeDataEvents: boolean
+): boolean => selectedFilterIds.length > 0 || includeDataEvents
+
 /**
  * Event types to request from the API: narrowed list when the user picks a subset of
  * filters; `undefined` means “all types.” Adds dataProcessed when Include Data is on.
+ * When no modal filters are selected but Include Data is on, only `dataProcessed` is requested.
  */
 export const deriveEventTypes = (
   selectedFilterIds: string[],
   includeDataEvents: boolean
 ): EventType[] | undefined => {
-  if (
-    !selectedFilterIds.length ||
-    hasAllNonDataFiltersSelected(selectedFilterIds)
-  ) {
+  if (!selectedFilterIds.length) {
+    return includeDataEvents ? ['dataProcessed'] : undefined
+  }
+  if (hasAllNonDataFiltersSelected(selectedFilterIds)) {
     return undefined
   }
   const base = selectedFilterIds

--- a/packages/react-ui/src/Cells/AccordionCells.tsx
+++ b/packages/react-ui/src/Cells/AccordionCells.tsx
@@ -11,6 +11,7 @@ export interface AccordionCellsProps {
   loading?: boolean
   header?: React.ReactNode
   maxHeight?: string
+  hideBottomFade?: boolean
 }
 
 export const AccordionCells: React.FC<AccordionCellsProps> = ({
@@ -21,6 +22,7 @@ export const AccordionCells: React.FC<AccordionCellsProps> = ({
   loading,
   header,
   maxHeight,
+  hideBottomFade = false,
 }) => {
   return (
     <div
@@ -40,7 +42,9 @@ export const AccordionCells: React.FC<AccordionCellsProps> = ({
         )}
         header={header}
       />
-      <div className="absolute inset-x-0 bottom-0 z-10 h-2 bg-gradient-to-t from-stone-400/20" />
+      {!hideBottomFade ? (
+        <div className="absolute inset-x-0 bottom-0 z-10 h-2 bg-gradient-to-t from-stone-400/20" />
+      ) : null}
       {loading && <AbsoluteOverlay />}
     </div>
   )

--- a/packages/react-ui/src/Dropdowns/LogFiltersDropdown.test.tsx
+++ b/packages/react-ui/src/Dropdowns/LogFiltersDropdown.test.tsx
@@ -77,3 +77,16 @@ test('should check the All checkbox when all options are selected', async () => 
   const allCheckbox = screen.getAllByRole('checkbox')[0]
   expect(allCheckbox).toBeChecked()
 })
+
+test('should render Include Data Events when handler is provided', async () => {
+  const props = getProps({
+    onIncludeDataEventsChange: jest.fn(),
+    includeDataEvents: false,
+  })
+  render(<LogFiltersDropdown {...props} />)
+
+  expect(screen.getByText('Include Data Events')).toBeInTheDocument()
+  expect(
+    screen.getByRole('checkbox', { name: /include data events/i })
+  ).not.toBeChecked()
+})

--- a/packages/react-ui/src/Dropdowns/LogFiltersDropdown.tsx
+++ b/packages/react-ui/src/Dropdowns/LogFiltersDropdown.tsx
@@ -14,6 +14,8 @@ export interface LogFiltersDropdownProps {
   onSearchChange: (value: string) => void
   onDismiss?: () => void
   placeholder?: string
+  includeDataEvents?: boolean
+  onIncludeDataEventsChange?: (next: boolean) => void
 }
 
 const styles = {
@@ -37,15 +39,18 @@ export const LogFiltersDropdown: React.FC<LogFiltersDropdownProps> = ({
   onSearchChange,
   onDismiss = () => undefined,
   placeholder = 'Search',
+  includeDataEvents = false,
+  onIncludeDataEventsChange,
 }) => {
   const ref = useRef<HTMLElement | null>(null)
   useOnClickOutside(ref, onDismiss)
 
-  const allIds = options.map((o) => o.id)
-  const allChecked = selectedIds.length === allIds.length && allIds.length > 0
+  const baseIds = options.map((o) => o.id)
+  const allChecked =
+    baseIds.length > 0 && baseIds.every((id) => selectedIds.includes(id))
 
   const handleAllClick = (checked: boolean) => {
-    const next = checked ? allIds : []
+    const next = checked ? baseIds : []
     onChange(next)
   }
 
@@ -78,6 +83,33 @@ export const LogFiltersDropdown: React.FC<LogFiltersDropdownProps> = ({
         <li>
           <hr />
         </li>
+
+        {onIncludeDataEventsChange ? (
+          <>
+            <li>
+              <label
+                className={clsx(
+                  styles.rowBtn,
+                  styles.cellPadding,
+                  'cursor-pointer'
+                )}
+                htmlFor="logfilters-include-data-events"
+              >
+                <input
+                  id="logfilters-include-data-events"
+                  type="checkbox"
+                  checked={includeDataEvents}
+                  onChange={(e) => onIncludeDataEventsChange(e.target.checked)}
+                  className={styles.checkbox}
+                />
+                <span className="w-full">Include Data Events</span>
+              </label>
+            </li>
+            <li>
+              <hr />
+            </li>
+          </>
+        ) : null}
 
         {/* All checkbox */}
         <li>


### PR DESCRIPTION
- **Less noisy “Data” rows in logs** — “Data” / `dataProcessed` lines are **off by default**. Operators turn them on with **Include Data Events** in the **Filter** dropdown (not a separate control on the toolbar).
- **Filter modal** — **Include Data Events** sits **above** the **All** row; **All** checks or clears every **listed** event type. **Data** is **not** a row in the list (it’s only controlled by Include Data Events), so “All” matches what’s in the modal.
- **Default filter state** — On load, **every** modal event type is **selected**, so the log matches “show everything” without an empty checklist.
- **No types selected** — If someone clears **All** and has **no** types checked, the list is empty and a **short banner** explains opening **Filter** and picking at least one type (warning icon, shared banner styling).
- **No matches** — If filters/search leave **no** events, a second banner explains **no matching events** and suggests adjusting **Filter** or search (same visual pattern as the other banner).
- **Load more** — When the “no types selected” banner shows, **Load more** is suppressed and the virtual list count is **0** so the empty state isn’t mixed with pagination.
- **Client filtering rules** — Per-type filtering runs only when **not** “all modal types selected,” so you don’t drop events that only map to **Data** when **Data** isn’t in the checkbox list. **`dataProcessed`** is still stripped on the client when Include Data Events is off.
- **Accordion UI building block** — **`AccordionCells`** accepts **`hideBottomFade`** to hide the bottom gradient fade (for empty or message-only layouts); **optional** for other screens.
- **Tests** — **`LogFiltersDropdown`** and **`LogsSection`** tests updated for the new filter behavior, empty states, and search/no-match behavior.

### Include data events checkbox (off by default)
<img width="636" height="501" alt="Screenshot 2026-03-25 at 4 36 38 PM" src="https://github.com/user-attachments/assets/020868a1-c121-4320-8e7b-48bd7c7af2fe" />


Note: previously the Filter modal was set up so that when nothing was selected, it would show all events by default. This made it so the behavior didn't match the checkbox values since it was showing All events, but the All checkbox wasn't selected. Now, the behavior matches the checkboxes so they are all selected by default. When the user unselects everything, it shows a warning message that no logs are being shown due to the filters.