### PR TITLE
fix(#515): stop wiping session cookie on successful token validation

### DIFF
--- a/apps/lrauv-dash2/lib/useSessionToken.ts
+++ b/apps/lrauv-dash2/lib/useSessionToken.ts
@@ -13,26 +13,31 @@ const useSessionToken = (name: string) => {
 
   useEffect(() => {
     const stored = getCookie(name)
-    console.log(
-      '[useSessionToken] hydrate — raw cookie length:',
-      stored?.length ?? 0,
-      '| has value:',
-      stored?.length > 0
-    )
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(
+        '[useSessionToken] hydrate — cookie length:',
+        stored?.length ?? 0,
+        '| has value:',
+        stored?.length > 0
+      )
+      if (!stored) {
+        console.warn(
+          '[useSessionToken] cookie is empty on hydrate — user will see login page'
+        )
+      }
+    }
     if (stored) {
       setSessionToken_(stored)
-    } else {
-      console.warn(
-        '[useSessionToken] cookie is empty on hydrate — user will see login page'
-      )
     }
   }, [name])
 
   const setSessionToken = (token: string) => {
-    console.log(
-      '[useSessionToken] setSessionToken — length:',
-      token?.length ?? 0
-    )
+    if (process.env.NODE_ENV !== 'production') {
+      console.log(
+        '[useSessionToken] setSessionToken — length:',
+        token?.length ?? 0
+      )
+    }
     setSessionToken_(token)
     setCookie(name, token, {
       days: 7,

--- a/apps/lrauv-dash2/lib/useSessionToken.ts
+++ b/apps/lrauv-dash2/lib/useSessionToken.ts
@@ -31,9 +31,7 @@ const useSessionToken = (name: string) => {
   const setSessionToken = (token: string) => {
     console.log(
       '[useSessionToken] setSessionToken — length:',
-      token?.length ?? 0,
-      '| preview:',
-      token ? token.substring(0, 20) + '...' : '(empty)'
+      token?.length ?? 0
     )
     setSessionToken_(token)
     setCookie(name, token, {
@@ -42,13 +40,13 @@ const useSessionToken = (name: string) => {
       Secure:
         typeof window !== 'undefined' && window.location.protocol === 'https:',
     })
-    const verify = getCookie(name)
-    console.log(
-      '[useSessionToken] post-write verify — cookie length:',
-      verify?.length ?? 0,
-      '| match:',
-      verify === token
-    )
+    if (process.env.NODE_ENV !== 'production') {
+      const verify = getCookie(name)
+      console.log(
+        '[useSessionToken] post-write verify — cookie length:',
+        verify?.length ?? 0
+      )
+    }
   }
 
   return { sessionToken, setSessionToken }

--- a/apps/lrauv-dash2/lib/useSessionToken.ts
+++ b/apps/lrauv-dash2/lib/useSessionToken.ts
@@ -1,15 +1,54 @@
-import useCookie from 'react-use-cookie'
+import { useEffect, useState } from 'react'
+import { getCookie, setCookie } from 'react-use-cookie'
 
+// react-use-cookie initializes via useState() on the server where
+// document.cookie is unavailable, so it always starts as ''. During
+// Next.js static-export hydration React reuses that server state, meaning
+// the real cookie value is never read on page refresh.
+// We bypass that by owning the state ourselves and syncing from
+// document.cookie in a useEffect (which only runs on the client, after
+// hydration).
 const useSessionToken = (name: string) => {
-  const [sessionToken, setToken] = useCookie(name, '')
+  const [sessionToken, setSessionToken_] = useState('')
+
+  useEffect(() => {
+    const stored = getCookie(name)
+    console.log(
+      '[useSessionToken] hydrate — raw cookie length:',
+      stored?.length ?? 0,
+      '| has value:',
+      stored?.length > 0
+    )
+    if (stored) {
+      setSessionToken_(stored)
+    } else {
+      console.warn(
+        '[useSessionToken] cookie is empty on hydrate — user will see login page'
+      )
+    }
+  }, [name])
 
   const setSessionToken = (token: string) => {
-    setToken(token, {
+    console.log(
+      '[useSessionToken] setSessionToken — length:',
+      token?.length ?? 0,
+      '| preview:',
+      token ? token.substring(0, 20) + '...' : '(empty)'
+    )
+    setSessionToken_(token)
+    setCookie(name, token, {
       days: 7,
       SameSite: 'Strict',
       Secure:
         typeof window !== 'undefined' && window.location.protocol === 'https:',
     })
+    const verify = getCookie(name)
+    console.log(
+      '[useSessionToken] post-write verify — cookie length:',
+      verify?.length ?? 0,
+      '| match:',
+      verify === token
+    )
   }
 
   return { sessionToken, setSessionToken }

--- a/apps/lrauv-dash2/lib/useSessionToken.ts
+++ b/apps/lrauv-dash2/lib/useSessionToken.ts
@@ -26,9 +26,7 @@ const useSessionToken = (name: string) => {
         )
       }
     }
-    if (stored) {
-      setSessionToken_(stored)
-    }
+    setSessionToken_(stored || '')
   }, [name])
 
   const setSessionToken = (token: string) => {

--- a/packages/api-client/src/react-query/User/useCreateLogin.ts
+++ b/packages/api-client/src/react-query/User/useCreateLogin.ts
@@ -13,7 +13,16 @@ export const useCreateLogin = (config: {
       return createLogin(params, { instance })
     },
     {
-      onSettled: data => {
+      onSettled: (data, error) => {
+        console.log(
+          '[useCreateLogin] onSettled — token length:',
+          data?.token?.length ?? 0,
+          '| has error:',
+          !!error
+        )
+        if (error) {
+          console.error('[useCreateLogin] login failed, clearing token:', error)
+        }
         setSessionToken(data?.token ?? '')
       },
     }

--- a/packages/api-client/src/react-query/User/useCreateLogin.ts
+++ b/packages/api-client/src/react-query/User/useCreateLogin.ts
@@ -14,14 +14,18 @@ export const useCreateLogin = (config: {
     },
     {
       onSettled: (data, error) => {
-        console.log(
-          '[useCreateLogin] onSettled — token length:',
-          data?.token?.length ?? 0,
-          '| has error:',
-          !!error
-        )
-        if (error) {
-          console.error('[useCreateLogin] login failed, clearing token:', error)
+        if (process.env.NODE_ENV !== 'production') {
+          console.log(
+            '[useCreateLogin] onSettled — token length:',
+            data?.token?.length ?? 0,
+            '| has error:',
+            !!error
+          )
+          if (error) {
+            const message =
+              error instanceof Error ? error.message : 'login request failed'
+            console.error('[useCreateLogin] login failed:', message)
+          }
         }
         setSessionToken(data?.token ?? '')
       },

--- a/packages/api-client/src/react-query/User/useRefreshSessionToken.test.tsx
+++ b/packages/api-client/src/react-query/User/useRefreshSessionToken.test.tsx
@@ -118,7 +118,11 @@ describe('useRefreshSessionToken', () => {
     expect(mockSetSessionToken).not.toHaveBeenCalled()
   })
 
-  it('should clear token when a successful response omits token', async () => {
+  it('should preserve existing token when a successful response omits token', async () => {
+    // The TethysDash /user/token endpoint validates the token and returns the
+    // user profile without re-issuing a new token. The existing cookie must NOT
+    // be cleared — clearing it was the root cause of users being logged out on
+    // browser refresh in the static-export build.
     server.use(
       rest.get('/user/token', (_req, res, ctx) => {
         return res(ctx.status(200), ctx.json({ result: {} }))
@@ -133,7 +137,7 @@ describe('useRefreshSessionToken', () => {
       expect(screen.getByTestId('status')).toHaveTextContent('success')
     })
 
-    expect(mockSetSessionToken).toHaveBeenCalledWith('')
+    expect(mockSetSessionToken).not.toHaveBeenCalled()
   })
 
   it('should set refreshed token when a successful response includes token', async () => {

--- a/packages/api-client/src/react-query/User/useRefreshSessionToken.ts
+++ b/packages/api-client/src/react-query/User/useRefreshSessionToken.ts
@@ -23,13 +23,18 @@ export const useRefreshSessionToken = (config: {
       staleTime: 60 * 60 * 1000,
       retry: false,
       onSuccess: (data) => {
+        console.log(
+          '[useRefreshSessionToken] onSuccess — data.token length:',
+          data?.token?.length ?? 0,
+          '| has profile:',
+          !!(data?.firstName || data?.email)
+        )
         if (data?.token) {
+          // Server issued a new/rotated token — update the cookie.
           setSessionToken(data.token)
-        } else {
-          // Successful validation responses without a token should clear the
-          // session so callers don't keep using an unusable auth state.
-          setSessionToken('')
         }
+        // If the server validated the token but didn't return a new one,
+        // the existing cookie is still valid — do NOT clear it.
       },
       onError: (err: unknown) => {
         // Only clear the session token on explicit authentication failures
@@ -39,7 +44,9 @@ export const useRefreshSessionToken = (config: {
         const status = axios.isAxiosError(err)
           ? err.response?.status
           : undefined
+        console.log('[useRefreshSessionToken] onError — status:', status)
         if (status === 401 || status === 403) {
+          console.warn('[useRefreshSessionToken] 401/403 — clearing token')
           setSessionToken('')
         }
       },

--- a/packages/api-client/src/react-query/User/useRefreshSessionToken.ts
+++ b/packages/api-client/src/react-query/User/useRefreshSessionToken.ts
@@ -23,12 +23,14 @@ export const useRefreshSessionToken = (config: {
       staleTime: 60 * 60 * 1000,
       retry: false,
       onSuccess: (data) => {
-        console.log(
-          '[useRefreshSessionToken] onSuccess — data.token length:',
-          data?.token?.length ?? 0,
-          '| has profile:',
-          !!(data?.firstName || data?.email)
-        )
+        if (process.env.NODE_ENV !== 'production') {
+          console.log(
+            '[useRefreshSessionToken] onSuccess — data.token length:',
+            data?.token?.length ?? 0,
+            '| has profile:',
+            !!(data?.firstName || data?.email)
+          )
+        }
         if (data?.token) {
           // Server issued a new/rotated token — update the cookie.
           setSessionToken(data.token)
@@ -44,9 +46,13 @@ export const useRefreshSessionToken = (config: {
         const status = axios.isAxiosError(err)
           ? err.response?.status
           : undefined
-        console.log('[useRefreshSessionToken] onError — status:', status)
+        if (process.env.NODE_ENV !== 'production') {
+          console.log('[useRefreshSessionToken] onError — status:', status)
+          if (status === 401 || status === 403) {
+            console.warn('[useRefreshSessionToken] 401/403 — clearing token')
+          }
+        }
         if (status === 401 || status === 403) {
-          console.warn('[useRefreshSessionToken] 401/403 — clearing token')
           setSessionToken('')
         }
       },


### PR DESCRIPTION
## Root Cause

Two bugs combined to cause persistent logout on browser refresh in the static-export (staging) build. Neither was obvious because everything works correctly in `next dev` locally.

### Bug 1 — Cookie wiped after every successful login (primary)

`useRefreshSessionToken.onSuccess` had an `else { setSessionToken('') }` branch intended to handle "unusable" validation responses. In practice, the TethysDash `/user/token` endpoint validates the token and returns the user profile **without** re-issuing a new token in the response body. That means `data?.token` is always `undefined` on a valid session, so the `else` branch fired on every successful refresh — clearing the cookie immediately after login.

The user stayed authenticated for the current session (React state still had `currentUser`), but the cookie was empty. On the next page refresh, the cookie was empty → `/user/token` was never called → user appeared logged out.

**Evidence**: DevTools showed `TETHYS_SESSION_TOKEN` cookie present but empty, and its expiry timestamp was being refreshed on every page load (i.e. `setSessionToken('')` was being actively called).

### Bug 2 — SSR hydration prevents cookie read on refresh (defense-in-depth)

`useSessionToken` used `react-use-cookie`'s `useCookie` hook, which calls `useState(() => getCookie(...))`. During Next.js build-time pre-rendering, `document.cookie` is unavailable, so the initializer returns `''`. React hydration in the browser reuses that server state — the lazy initializer is never re-run — so even a valid cookie is invisible after a hard refresh.

This is masked in `next dev` because no pre-rendering occurs. Replaced with an explicit `useEffect` that reads the cookie only on the client after hydration.

## Changes

- `useRefreshSessionToken.ts`: Remove `else { setSessionToken('') }` from `onSuccess`. If the server validates without re-issuing a token, the existing cookie is still valid and must not be cleared.
- `useSessionToken.ts`: Replace `useCookie` hook with `useState + useEffect` pattern that reads the cookie client-side after hydration, bypassing the SSR issue.
- `useCreateLogin.ts`: Add temporary console logs to confirm the fix on staging.

## Testing

After merging and deploying to staging:
1. Log in as a PIC user
2. Open DevTools → Console — should see `[useSessionToken]` and `[useRefreshSessionToken]` logs confirming the cookie is written and not cleared
3. Hard refresh the page — should remain authenticated
4. Verify PIC/On-Call role label shows correctly (not "Unavailable")

Console logs will be removed in a follow-up commit once the fix is confirmed on staging.