### PR TITLE
feat(#520): station star/spotlight and center-map in Layers panel

### DIFF
--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -717,7 +717,8 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
             const lng = station.geojson.geometry.coordinates[0]
             const lat = station.geojson.geometry.coordinates[1]
 
-            if (!lng || !lat) return null
+            if (lng == null || lat == null || !isFinite(lng) || !isFinite(lat))
+              return null
             return (
               <StationMarker
                 key={station.name}

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -179,6 +179,10 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   const [showPlatformsModal, setShowPlatformsModal] = useState(false)
   const { selectedStations, highlightedStationName } = useSelectedStations()
   const [colorModalOpen, setColorModalOpen] = useState(false)
+  const [waypointFitTrigger, setWaypointFitTrigger] = useState(0)
+  const prevFocusedWaypointIndexRef = useRef<number | null | undefined>(
+    undefined
+  )
   const [colorModalPosition, setColorModalPosition] = useState<{
     top: number
     left: number
@@ -212,6 +216,16 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       latestVehicle.current = vehicleName
     }
   }, [vehicleName, setLatestGPS])
+
+  // Bump fitTrigger when leaving waypoint focus mode so WaypointPreviewPath
+  // re-fits bounds even when the route coordinates didn't change.
+  useEffect(() => {
+    const prev = prevFocusedWaypointIndexRef.current
+    if (typeof prev === 'number' && focusedWaypointIndex == null) {
+      setWaypointFitTrigger((n) => n + 1)
+    }
+    prevFocusedWaypointIndexRef.current = focusedWaypointIndex
+  }, [focusedWaypointIndex])
 
   useEffect(() => {
     if (mapRef?.current && !showVehicleColors) {
@@ -755,6 +769,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
                   lat: Number(waypoint.lat),
                   lon: Number(waypoint.lon),
                 }))}
+                fitTrigger={waypointFitTrigger}
               />
             </>
           ) : (

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -85,6 +85,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   const {
     updatedWaypoints,
     handleWaypointsUpdate,
+    clearWaypoint,
     editable,
     focusedWaypointIndex,
   } = useManagedWaypoints()
@@ -105,18 +106,6 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
         )
       )
     },
-    [updatedWaypoints, handleWaypointsUpdate]
-  )
-
-  const handleDeleteWaypoint = useCallback(
-    (index: number) =>
-      handleWaypointsUpdate(
-        updatedWaypoints.map((m, i) =>
-          i === index
-            ? { ...m, lat: 'NaN', lon: 'NaN', stationName: 'Custom' }
-            : m
-        )
-      ),
     [updatedWaypoints, handleWaypointsUpdate]
   )
 
@@ -767,9 +756,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
                       })
                     }
                     onDelete={
-                      editable
-                        ? () => handleDeleteWaypoint(originalIndex)
-                        : undefined
+                      editable ? () => clearWaypoint(originalIndex) : undefined
                     }
                   />
                 )

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -730,6 +730,18 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
           })}
           <PlatformPaths />
           <MapFlyTo />
+          <VehiclePath
+            name={vehicleName as string}
+            key={`path${vehicleName}`}
+            from={startTime as number}
+            to={endTime as number}
+            indicatorTime={indicatorTime}
+            onScrub={handleMapScrub}
+            onGPSFix={handleGPSFix}
+            onPositionDataLoaded={markInitialLoadDone}
+            // Disable map auto-fit centering when scrubbing the timeline
+            disableAutoFit={isTimelineScrubbing}
+          />
           {plottedWaypoints?.length ? (
             <>
               {plottedWaypoints.map(({ waypoint, originalIndex }) => {
@@ -767,20 +779,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
                 fitTrigger={waypointFitTrigger}
               />
             </>
-          ) : (
-            <VehiclePath
-              name={vehicleName as string}
-              key={`path${vehicleName}`}
-              from={startTime as number}
-              to={endTime as number}
-              indicatorTime={indicatorTime}
-              onScrub={handleMapScrub}
-              onGPSFix={handleGPSFix}
-              onPositionDataLoaded={markInitialLoadDone}
-              // Disable map auto-fit centering when scrubbing the timeline
-              disableAutoFit={isTimelineScrubbing}
-            />
-          )}
+          ) : null}
         </Map>
         <MapRefreshButton
           onClick={refreshAll}

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -129,7 +129,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   const [showLayersModal, setShowLayersModal] = useState(false)
   const [showVehicleColors, setShowVehicleColors] = useState(false)
   const [showPlatformsModal, setShowPlatformsModal] = useState(false)
-  const { selectedStations } = useSelectedStations()
+  const { selectedStations, highlightedStationName } = useSelectedStations()
   const [colorModalOpen, setColorModalOpen] = useState(false)
   const [colorModalPosition, setColorModalPosition] = useState<{
     top: number
@@ -683,6 +683,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
                 name={station.name}
                 lat={lat}
                 lng={lng}
+                isHighlighted={highlightedStationName === station.name}
               />
             )
           })}

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -1,6 +1,7 @@
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
-import React, { useCallback, useState, useRef, useEffect } from 'react'
+import React, { useCallback, useState, useRef, useEffect, useMemo } from 'react'
+import { useMap } from 'react-leaflet'
 import { useManagedWaypoints } from '@mbari/react-ui'
 import useGoogleElevator from '../lib/useGoogleElevator'
 import { VPosDetail } from '@mbari/api-client'
@@ -70,6 +71,23 @@ interface DeploymentMapProps {
   endTime?: number | null
 }
 
+const MapFlyTo: React.FC = () => {
+  const map = useMap()
+  const { flyToRequest, setFlyToRequest } = useSelectedStations()
+
+  useEffect(() => {
+    if (flyToRequest) {
+      map.flyTo(
+        [flyToRequest.lat, flyToRequest.lon],
+        Math.max(map.getZoom(), 13)
+      )
+      setFlyToRequest(null)
+    }
+  }, [flyToRequest, map, setFlyToRequest])
+
+  return null
+}
+
 const DeploymentMap: React.FC<DeploymentMapProps> = ({
   vehicleName,
   indicatorTime,
@@ -81,21 +99,51 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   const mapRef = useRef<any>(null)
   const {
     updatedWaypoints,
-    setWaypointCustomPosition,
-    clearWaypoint,
+    handleWaypointsUpdate,
     editable,
     focusedWaypointIndex,
   } = useManagedWaypoints()
+  const handleDragEnd = useCallback(
+    (index: number, { lat, lng }: { lat: number; lng: number }) =>
+      handleWaypointsUpdate(
+        updatedWaypoints.map((m, i) =>
+          i === index ? { ...m, lat: lat.toString(), lon: lng.toString() } : m
+        )
+      ),
+    [updatedWaypoints, handleWaypointsUpdate]
+  )
+
+  const handleDeleteWaypoint = useCallback(
+    (index: number) =>
+      handleWaypointsUpdate(
+        updatedWaypoints.map((m, i) =>
+          i === index
+            ? { ...m, lat: 'NaN', lon: 'NaN', stationName: 'Custom' }
+            : m
+        )
+      ),
+    [updatedWaypoints, handleWaypointsUpdate]
+  )
 
   const { handleDepthRequest } = useGoogleElevator()
 
-  // Filter out waypoints with NaN lat/lon
-  const plottedWaypoints = updatedWaypoints
-    .map((wp, originalIndex) => ({ wp, originalIndex }))
-    .filter(
-      ({ wp }) =>
-        ![wp.lat?.toLowerCase(), wp.lon?.toLowerCase()].includes('nan')
-    )
+  // Keep original indices so drag/delete updates target the correct waypoint
+  // even when some waypoints are filtered out from map rendering.
+  const plottedWaypoints = useMemo(
+    () =>
+      updatedWaypoints
+        .map((waypoint, originalIndex) => ({ waypoint, originalIndex }))
+        .filter(
+          ({ waypoint }) =>
+            !!waypoint.lat?.trim() &&
+            !!waypoint.lon?.trim() &&
+            ![
+              waypoint.lat?.trim().toLowerCase(),
+              waypoint.lon?.trim().toLowerCase(),
+            ].includes('nan')
+        ),
+    [updatedWaypoints]
+  )
 
   const { trackedVehicles } = useTrackedVehicles()
   const [showAll, setShowAll] = useState(true)
@@ -135,10 +183,6 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
     top: number
     left: number
   }>({ top: 0, left: 0 })
-  const [waypointFitTrigger, setWaypointFitTrigger] = useState(0)
-  const prevFocusedWaypointIndexRef = useRef<number | null | undefined>(
-    focusedWaypointIndex
-  )
   const [layersModalPosition, setLayersModalPosition] = useState({
     top: 0,
     left: 0,
@@ -161,18 +205,6 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   } = useMarkers()
 
   const latestVehicle = useRef(vehicleName)
-  useEffect(() => {
-    // When leaving waypoint focus mode (e.g. clicking "Done" after placing via map click),
-    // force a waypoint bounds fit so the map recenters deterministically.
-    if (
-      prevFocusedWaypointIndexRef.current != null &&
-      focusedWaypointIndex == null
-    ) {
-      setWaypointFitTrigger((v) => v + 1)
-    }
-    prevFocusedWaypointIndexRef.current = focusedWaypointIndex
-  }, [focusedWaypointIndex])
-
   useEffect(() => {
     if (vehicleName !== latestVehicle.current) {
       setLatestGPS(undefined)
@@ -688,43 +720,44 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
             )
           })}
           <PlatformPaths />
-          <>
-            {plottedWaypoints?.length ? (
-              <>
-                {plottedWaypoints.map(({ wp: m, originalIndex }, i) => {
-                  const waypointNumber = Number(
-                    m.latName.match(/\d+/)?.[0] ?? originalIndex + 1
-                  )
-                  return (
-                    <WaypointMapMarker
-                      key={`waypoint-${originalIndex}-${m.latName}-${m.lonName}-${m.lat}-${m.lon}`}
-                      position={[Number(m.lat), Number(m.lon)]}
-                      number={waypointNumber}
-                      draggable={editable && focusedWaypointIndex == null}
-                      onDragEnd={(newPos) =>
-                        setWaypointCustomPosition(originalIndex, {
-                          lat: newPos[0],
-                          lon: newPos[1],
-                        })
-                      }
-                      onDelete={
-                        editable
-                          ? () => clearWaypoint(originalIndex)
-                          : undefined
-                      }
-                    />
-                  )
-                })}
-                {focusedWaypointIndex != null && <ClickableMapPoint />}
-                <WaypointPreviewPath
-                  fitTrigger={waypointFitTrigger}
-                  waypoints={plottedWaypoints.map(({ wp }) => ({
-                    lat: Number(wp.lat),
-                    lon: Number(wp.lon),
-                  }))}
-                />
-              </>
-            ) : null}
+          <MapFlyTo />
+          {plottedWaypoints?.length ? (
+            <>
+              {plottedWaypoints.map(({ waypoint, originalIndex }, i) => {
+                const waypointNumber = Number(
+                  waypoint.latName?.match(/\d+/)?.[0] ?? originalIndex + 1
+                )
+                return (
+                  <WaypointMapMarker
+                    key={`waypoint-${originalIndex}-${waypoint.latName}-${waypoint.lonName}-${waypoint.lat}-${waypoint.lon}`}
+                    position={[Number(waypoint.lat), Number(waypoint.lon)]}
+                    number={waypointNumber}
+                    draggable={editable && focusedWaypointIndex == null}
+                    onDragEnd={(newPos) =>
+                      handleDragEnd(originalIndex, {
+                        lat: newPos[0],
+                        lng: newPos[1],
+                      })
+                    }
+                    onDelete={
+                      editable
+                        ? () => handleDeleteWaypoint(originalIndex)
+                        : undefined
+                    }
+                  />
+                )
+              })}
+              {typeof focusedWaypointIndex === 'number' && (
+                <ClickableMapPoint />
+              )}
+              <WaypointPreviewPath
+                waypoints={plottedWaypoints.map(({ waypoint }) => ({
+                  lat: Number(waypoint.lat),
+                  lon: Number(waypoint.lon),
+                }))}
+              />
+            </>
+          ) : (
             <VehiclePath
               name={vehicleName as string}
               key={`path${vehicleName}`}
@@ -737,7 +770,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
               // Disable map auto-fit centering when scrubbing the timeline
               disableAutoFit={isTimelineScrubbing}
             />
-          </>
+          )}
         </Map>
         <MapRefreshButton
           onClick={refreshAll}

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -1,7 +1,6 @@
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
 import React, { useCallback, useState, useRef, useEffect, useMemo } from 'react'
-import { useMap } from 'react-leaflet'
 import { useManagedWaypoints } from '@mbari/react-ui'
 import useGoogleElevator from '../lib/useGoogleElevator'
 import { VPosDetail } from '@mbari/api-client'
@@ -54,6 +53,9 @@ const MapClickHandler = dynamic(() => import('./MapClickHandler'), {
 const CustomMarkerSet = dynamic(() => import('./CustomMarkerSet'), {
   ssr: false,
 })
+const MapFlyTo = dynamic(() => import('./MapFlyTo'), {
+  ssr: false,
+})
 const PlatformPaths = dynamic(
   () =>
     import('./PlatformPaths').then((mod) => ({ default: mod.PlatformPaths })),
@@ -69,23 +71,6 @@ interface DeploymentMapProps {
   onScrub?: (time?: number | null) => void
   startTime?: number | null
   endTime?: number | null
-}
-
-const MapFlyTo: React.FC = () => {
-  const map = useMap()
-  const { flyToRequest, setFlyToRequest } = useSelectedStations()
-
-  useEffect(() => {
-    if (flyToRequest) {
-      map.flyTo(
-        [flyToRequest.lat, flyToRequest.lon],
-        Math.max(map.getZoom(), 13)
-      )
-      setFlyToRequest(null)
-    }
-  }, [flyToRequest, map, setFlyToRequest])
-
-  return null
 }
 
 const DeploymentMap: React.FC<DeploymentMapProps> = ({
@@ -107,7 +92,14 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
     (index: number, { lat, lng }: { lat: number; lng: number }) =>
       handleWaypointsUpdate(
         updatedWaypoints.map((m, i) =>
-          i === index ? { ...m, lat: lat.toString(), lon: lng.toString() } : m
+          i === index
+            ? {
+                ...m,
+                lat: lat.toString(),
+                lon: lng.toString(),
+                stationName: 'Custom',
+              }
+            : m
         )
       ),
     [updatedWaypoints, handleWaypointsUpdate]

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -729,7 +729,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
           <MapFlyTo />
           {plottedWaypoints?.length ? (
             <>
-              {plottedWaypoints.map(({ waypoint, originalIndex }, i) => {
+              {plottedWaypoints.map(({ waypoint, originalIndex }) => {
                 const waypointNumber = Number(
                   waypoint.latName?.match(/\d+/)?.[0] ?? originalIndex + 1
                 )

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -89,19 +89,22 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
     focusedWaypointIndex,
   } = useManagedWaypoints()
   const handleDragEnd = useCallback(
-    (index: number, { lat, lng }: { lat: number; lng: number }) =>
-      handleWaypointsUpdate(
+    (index: number, { lat, lng }: { lat: number; lng: number }) => {
+      const roundedLat = Number(lat.toFixed(5))
+      const roundedLng = Number(lng.toFixed(5))
+      return handleWaypointsUpdate(
         updatedWaypoints.map((m, i) =>
           i === index
             ? {
                 ...m,
-                lat: lat.toString(),
-                lon: lng.toString(),
+                lat: roundedLat.toString(),
+                lon: roundedLng.toString(),
                 stationName: 'Custom',
               }
             : m
         )
-      ),
+      )
+    },
     [updatedWaypoints, handleWaypointsUpdate]
   )
 

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -717,7 +717,12 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
             const lng = station.geojson.geometry.coordinates[0]
             const lat = station.geojson.geometry.coordinates[1]
 
-            if (lng == null || lat == null || !isFinite(lng) || !isFinite(lat))
+            if (
+              lng == null ||
+              lat == null ||
+              !Number.isFinite(lng) ||
+              !Number.isFinite(lat)
+            )
               return null
             return (
               <StationMarker

--- a/apps/lrauv-dash2/components/MapFlyTo.tsx
+++ b/apps/lrauv-dash2/components/MapFlyTo.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react'
+import { useMap } from 'react-leaflet'
+import { useSelectedStations } from './SelectedStationContext'
+
+const MapFlyTo: React.FC = () => {
+  const map = useMap()
+  const { flyToRequest, setFlyToRequest } = useSelectedStations()
+
+  useEffect(() => {
+    if (flyToRequest) {
+      map.flyTo(
+        [flyToRequest.lat, flyToRequest.lon],
+        Math.max(map.getZoom(), 13)
+      )
+      setFlyToRequest(null)
+    }
+  }, [flyToRequest, map, setFlyToRequest])
+
+  return null
+}
+
+export default MapFlyTo

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -148,7 +148,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
                 }}
                 onMouseEnter={onMouseEnterStar}
                 onMouseLeave={onMouseLeaveStar}
-                className="mr-1 focus:outline-none"
+                className="mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
                 aria-label={isStarred ? 'Unstar station' : 'Star station'}
                 style={{
                   width: '22px',
@@ -185,7 +185,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
                   e.stopPropagation()
                   onCenterClick()
                 }}
-                className="ml-2 focus:outline-none"
+                className="ml-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
                 aria-label="Center map on station"
                 style={{
                   width: '20px',
@@ -446,6 +446,25 @@ export const MapLayersListModal: React.FC<{
     return selectedStations.some((s) => s.name === stationName)
   }
 
+  // Memoized starred Set and sorted station list to avoid repeated .includes()
+  // calls inside the sort comparator on every render.
+  const starredSet = useMemo(
+    () => new Set(starredStations ?? []),
+    [starredStations]
+  )
+  const sortedStations = useMemo(
+    () =>
+      [...(stations ?? [])].sort((a, b) => {
+        const aStarred = starredSet.has(a.name)
+        const bStarred = starredSet.has(b.name)
+        if (aStarred && bStarred) return a.name.localeCompare(b.name)
+        if (aStarred) return -1
+        if (bStarred) return 1
+        return 0
+      }),
+    [stations, starredSet]
+  )
+
   // Check if all stations in a group are selected
   const areAllStationsInGroupSelected = (groupName: string): boolean => {
     const groupStations = stationGroups[groupName] || []
@@ -594,64 +613,52 @@ export const MapLayersListModal: React.FC<{
                 iconColor="white"
               >
                 {/* Starred stations first (alphabetical), then unstarred in original API order */}
-                {[...(stations ?? [])]
-                  .sort((a, b) => {
-                    const aStarred = starredStations.includes(a.name)
-                    const bStarred = starredStations.includes(b.name)
-                    if (aStarred && bStarred)
-                      return a.name.localeCompare(b.name)
-                    if (aStarred) return -1
-                    if (bStarred) return 1
-                    return 0
-                  })
-                  .map((station) => (
-                    <TreeItem
-                      key={`station-${station.name}`}
-                      label={station.name}
-                      isChecked={isStationSelected(station.name)}
-                      onToggleCheck={() => {
-                        if (isStationSelected(station.name)) {
-                          setSelectedStations(
-                            selectedStations.filter(
-                              (s) => s.name !== station.name
-                            )
+                {sortedStations.map((station) => (
+                  <TreeItem
+                    key={`station-${station.name}`}
+                    label={station.name}
+                    isChecked={isStationSelected(station.name)}
+                    onToggleCheck={() => {
+                      if (isStationSelected(station.name)) {
+                        setSelectedStations(
+                          selectedStations.filter(
+                            (s) => s.name !== station.name
                           )
-                        } else {
-                          setSelectedStations([
-                            ...selectedStations,
-                            {
-                              name: station.name,
-                              geojson: station.geojson,
-                              lat: station.geojson.geometry.coordinates[1],
-                              lon: station.geojson.geometry.coordinates[0],
-                            },
-                          ])
-                        }
-                      }}
-                      isStarred={starredStations.includes(station.name)}
-                      onStarClick={() => {
-                        const isCurrentlyStarred = starredStations.includes(
-                          station.name
                         )
-                        if (isCurrentlyStarred) {
-                          setHighlightedStationName(null)
-                        }
-                        toggleStarStation(station.name)
-                      }}
-                      onMouseEnterStar={() => {
-                        if (starredStations.includes(station.name)) {
-                          setHighlightedStationName(station.name)
-                        }
-                      }}
-                      onMouseLeaveStar={() => setHighlightedStationName(null)}
-                      onCenterClick={() =>
-                        setFlyToRequest({
-                          lat: station.geojson.geometry.coordinates[1],
-                          lon: station.geojson.geometry.coordinates[0],
-                        })
+                      } else {
+                        setSelectedStations([
+                          ...selectedStations,
+                          {
+                            name: station.name,
+                            geojson: station.geojson,
+                            lat: station.geojson.geometry.coordinates[1],
+                            lon: station.geojson.geometry.coordinates[0],
+                          },
+                        ])
                       }
-                    />
-                  ))}
+                    }}
+                    isStarred={starredSet.has(station.name)}
+                    onStarClick={() => {
+                      const isCurrentlyStarred = starredSet.has(station.name)
+                      if (isCurrentlyStarred) {
+                        setHighlightedStationName(null)
+                      }
+                      toggleStarStation(station.name)
+                    }}
+                    onMouseEnterStar={() => {
+                      if (starredSet.has(station.name)) {
+                        setHighlightedStationName(station.name)
+                      }
+                    }}
+                    onMouseLeaveStar={() => setHighlightedStationName(null)}
+                    onCenterClick={() =>
+                      setFlyToRequest({
+                        lat: station.geojson.geometry.coordinates[1],
+                        lon: station.geojson.geometry.coordinates[0],
+                      })
+                    }
+                  />
+                ))}
                 {stations !== undefined && stations.length === 0 ? (
                   <div className="py-2 pl-10 text-sm italic text-gray-500">
                     No stations available

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -1,4 +1,6 @@
 import React, { useCallback, useState, useRef, useEffect, useMemo } from 'react'
+import Tippy from '@tippyjs/react'
+import 'tippy.js/dist/tippy.css'
 import { useStations } from '@mbari/api-client'
 import { Modal } from '@mbari/react-ui'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -130,76 +132,81 @@ const TreeItem: React.FC<TreeItemProps> = ({
             )
           ) : null}
           {onStarClick !== undefined && (
-            <button
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                onStarClick()
-              }}
-              onMouseEnter={onMouseEnterStar}
-              onMouseLeave={onMouseLeaveStar}
-              className="mr-1 focus:outline-none"
-              aria-label={isStarred ? 'Unstar station' : 'Star station'}
-              title={
+            <Tippy
+              content={
                 isStarred
                   ? 'Hover to spotlight on map'
                   : 'Click to enable spotlight'
               }
-              style={{
-                width: '22px',
-                height: '22px',
-                flexShrink: 0,
-                borderRadius: '50%',
-                background: '#fff',
-                border: 0,
-                padding: 0,
-                boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                cursor: 'pointer',
-              }}
+              placement="top-start"
             >
-              <FontAwesomeIcon
-                icon={faStar}
-                style={{
-                  color: isStarred ? '#FFD700' : '#9ca3af',
-                  fontSize: '14px',
+              <button
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  onStarClick()
                 }}
-              />
-            </button>
+                onMouseEnter={onMouseEnterStar}
+                onMouseLeave={onMouseLeaveStar}
+                className="mr-1 focus:outline-none"
+                aria-label={isStarred ? 'Unstar station' : 'Star station'}
+                style={{
+                  width: '22px',
+                  height: '22px',
+                  flexShrink: 0,
+                  borderRadius: '50%',
+                  background: '#fff',
+                  border: 0,
+                  padding: 0,
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                }}
+              >
+                <FontAwesomeIcon
+                  icon={faStar}
+                  style={{
+                    color: isStarred ? '#FFD700' : '#9ca3af',
+                    fontSize: '14px',
+                  }}
+                />
+              </button>
+            </Tippy>
           )}
           <span className="text-sm font-medium">{label}</span>
           {onCenterClick !== undefined && (
-            <button
-              onClick={(e) => {
-                e.preventDefault()
-                e.stopPropagation()
-                onCenterClick()
-              }}
-              className="ml-2 focus:outline-none"
-              aria-label="Center map on station"
-              title="Center map on this station"
-              style={{
-                width: '22px',
-                height: '22px',
-                flexShrink: 0,
-                borderRadius: '3px',
-                background: '#fff',
-                border: 0,
-                padding: 0,
-                boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                cursor: 'pointer',
-              }}
-            >
-              <FontAwesomeIcon
-                icon={faArrowsToCircle}
-                style={{ color: '#6b7280', fontSize: '16px' }}
-              />
-            </button>
+            <Tippy content="Center map on this station" placement="top-start">
+              <button
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  onCenterClick()
+                }}
+                className="ml-2 focus:outline-none"
+                aria-label="Center map on station"
+                style={{
+                  width: '26px',
+                  height: '26px',
+                  flexShrink: 0,
+                  borderRadius: '3px',
+                  background: '#fff',
+                  border: 0,
+                  padding: 0,
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                }}
+              >
+                <FontAwesomeIcon
+                  icon={faArrowsToCircle}
+                  style={{ color: '#6b7280', fontSize: '16px' }}
+                />
+              </button>
+            </Tippy>
           )}
         </label>
       </div>

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -9,6 +9,7 @@ import {
   faMapMarkerAlt,
   faCircle,
   faStar,
+  faExpand,
 } from '@fortawesome/free-solid-svg-icons'
 import { useSelectedStations } from './SelectedStationContext'
 import { useMarkers } from './MarkerContext'
@@ -33,6 +34,7 @@ interface TreeItemProps {
   onStarClick?: () => void
   onMouseEnterStar?: () => void
   onMouseLeaveStar?: () => void
+  onCenterClick?: () => void
 }
 
 const TreeItem: React.FC<TreeItemProps> = ({
@@ -49,6 +51,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
   onStarClick,
   onMouseEnterStar,
   onMouseLeaveStar,
+  onCenterClick,
 }) => {
   const hasChildren = React.Children.count(children) > 0
 
@@ -167,6 +170,37 @@ const TreeItem: React.FC<TreeItemProps> = ({
             </button>
           )}
           <span className="text-sm font-medium">{label}</span>
+          {onCenterClick !== undefined && (
+            <button
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                onCenterClick()
+              }}
+              className="ml-2 focus:outline-none"
+              aria-label="Center map on station"
+              title="Center map on this station"
+              style={{
+                width: '22px',
+                height: '22px',
+                flexShrink: 0,
+                borderRadius: '50%',
+                background: '#fff',
+                border: 0,
+                padding: 0,
+                boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+              }}
+            >
+              <FontAwesomeIcon
+                icon={faExpand}
+                style={{ color: '#6b7280', fontSize: '10px' }}
+              />
+            </button>
+          )}
         </label>
       </div>
 
@@ -200,6 +234,7 @@ export const MapLayersListModal: React.FC<{
     starredStations,
     toggleStarStation,
     setHighlightedStationName,
+    setFlyToRequest,
   } = useSelectedStations()
   const {
     markers,
@@ -506,6 +541,12 @@ export const MapLayersListModal: React.FC<{
                     }
                   }}
                   onMouseLeaveStar={() => setHighlightedStationName(null)}
+                  onCenterClick={() =>
+                    setFlyToRequest({
+                      lat: station.geojson.geometry.coordinates[1],
+                      lon: station.geojson.geometry.coordinates[0],
+                    })
+                  }
                 />
               ))}
               {Object.keys(stationGroups).length === 0 ? (

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -147,7 +147,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
                 height: '22px',
                 flexShrink: 0,
                 borderRadius: '50%',
-                background: 'transparent',
+                background: '#fff',
                 border: 0,
                 padding: 0,
                 boxShadow: '0 1px 3px rgba(0,0,0,0.35)',

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -138,7 +138,11 @@ const TreeItem: React.FC<TreeItemProps> = ({
               onMouseLeave={onMouseLeaveStar}
               className="ml-2 focus:outline-none"
               aria-label={isStarred ? 'Unstar station' : 'Star station'}
-              title={isStarred ? 'Remove spotlight' : 'Spotlight on map'}
+              title={
+                isStarred
+                  ? 'Hover to spotlight on map'
+                  : 'Click to enable spotlight'
+              }
             >
               <FontAwesomeIcon
                 icon={faStar}
@@ -482,9 +486,11 @@ export const MapLayersListModal: React.FC<{
                   }}
                   isStarred={starredStations.includes(station.name)}
                   onStarClick={() => toggleStarStation(station.name)}
-                  onMouseEnterStar={() =>
-                    setHighlightedStationName(station.name)
-                  }
+                  onMouseEnterStar={() => {
+                    if (starredStations.includes(station.name)) {
+                      setHighlightedStationName(station.name)
+                    }
+                  }}
                   onMouseLeaveStar={() => setHighlightedStationName(null)}
                 />
               ))}

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -263,7 +263,26 @@ export const MapLayersListModal: React.FC<{
   const [modalPosition, setModalPosition] = useState<
     { top: number; left: number } | undefined
   >(anchorPosition)
+  const [isFadingOut, setIsFadingOut] = useState(false)
   const modalRef = useRef<HTMLDivElement>(null)
+
+  const handleClose = useCallback(() => {
+    setIsFadingOut(true)
+    setTimeout(() => {
+      onClose()
+    }, 250)
+  }, [onClose])
+
+  // Click-outside to dismiss
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        handleClose()
+      }
+    }
+    document.addEventListener('mousedown', handleMouseDown)
+    return () => document.removeEventListener('mousedown', handleMouseDown)
+  }, [handleClose])
 
   useEffect(() => {
     if (!anchorPosition || !modalRef.current) return
@@ -410,188 +429,193 @@ export const MapLayersListModal: React.FC<{
 
   return (
     <>
-      <Modal
-        title={
-          <div>
-            <div className="md text-align-center font-italic bg-white text-sm text-gray-400">
-              <i>Select the map layers to display</i>
-              <br />
-              <br />
-              <br />
-            </div>
-            <div className="flex items-center justify-between">
-              <div className="stations text-align-center mb-2 bg-white text-lg font-bold underline">
-                MAP LAYERS
+      <div ref={modalRef}>
+        <Modal
+          title={
+            <div>
+              <div className="md text-align-center font-italic bg-white text-sm text-gray-400">
+                <i>Select the map layers to display</i>
+                <br />
+                <br />
+                <br />
+              </div>
+              <div className="flex items-center justify-between">
+                <div className="stations text-align-center mb-2 bg-white text-lg font-bold underline">
+                  MAP LAYERS
+                </div>
               </div>
             </div>
-          </div>
-        }
-        confirmButtonText="Close"
-        onClose={onClose}
-        snapTo={!modalPosition ? 'top-left' : undefined}
-        open
-        fullWidthBody={true}
-        style={{
-          maxHeight: '70vh',
-          background: '#ffffff',
-          color: 'blue',
-          position: modalPosition ? 'fixed' : undefined,
-          top: modalPosition ? `${modalPosition.top}px` : undefined,
-          left: modalPosition ? `${modalPosition.left}px` : undefined,
-          zIndex: 1000,
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-          width: 'auto',
-          minWidth: '350px',
-          paddingBottom: '0px',
-          paddingTop: '10px',
-          marginBottom: '0px',
-          marginTop: '0px',
-        }}
-        className="m-0 p-0"
-      >
-        <div
-          ref={modalRef}
-          className="custom-scrollbar flex-grow"
+          }
+          confirmButtonText="Close"
+          onClose={handleClose}
+          snapTo={!modalPosition ? 'top-left' : undefined}
+          open
+          fullWidthBody={true}
           style={{
-            overflowY: 'auto',
-            background: '#e3f2fd',
-            padding: '10px',
-            width: '100%',
-            margin: '0px 0px 20px 0px',
-            borderRadius: '4px',
-            minHeight: '0',
-            maxHeight: 'calc(70vh - 160px)',
-          }}
-        >
-          {/* Main tree structure */}
-          <div className="tree-view">
-            {/* Markers Section */}
-            <TreeItem
-              label="Markers"
-              isExpanded={expandedSections.markers}
-              isChecked={
-                selectedMarkers.length === layerMarkers.length &&
-                layerMarkers.length > 0
-              }
-              onToggleExpand={() => toggleExpanded('markers')}
-              onToggleCheck={
-                layerMarkers.length > 0
-                  ? handleToggleSelectAllMarkers
-                  : undefined
-              }
-              icon={faMapMarkerAlt}
-              iconColor="red"
-              disabled={layerMarkers.length === 0}
-            >
-              {layerMarkers.map((marker) => (
-                <TreeItem
-                  key={`marker-${marker.id}`}
-                  label={marker.label || `Marker ${marker.id}`}
-                  isChecked={marker.visible !== false}
-                  onToggleCheck={() =>
-                    toggleMarkerVisibility(marker.id.toString())
-                  }
-                  icon={faMapMarkerAlt}
-                  iconColor="red"
-                />
-              ))}
-              {layerMarkers.length === 0 && (
-                <div className="py-2 pl-10 text-sm italic text-gray-500">
-                  No markers saved to layers
-                </div>
-              )}
-            </TreeItem>
-
-            {/* Stations Section */}
-            <TreeItem
-              label="Stations"
-              isExpanded={expandedSections.stations}
-              isChecked={
-                selectedStations.length === stations?.length &&
-                stations?.length > 0
-              }
-              onToggleExpand={() => toggleExpanded('stations')}
-              onToggleCheck={handleToggleSelectAllStations}
-              icon={faCircle}
-              iconColor="white"
-            >
-              {/* Render individual stations without the grouping layer */}
-              {stations?.map((station) => (
-                <TreeItem
-                  key={`station-${station.name}`}
-                  label={station.name}
-                  isChecked={isStationSelected(station.name)}
-                  onToggleCheck={() => {
-                    if (isStationSelected(station.name)) {
-                      setSelectedStations(
-                        selectedStations.filter((s) => s.name !== station.name)
-                      )
-                    } else {
-                      setSelectedStations([
-                        ...selectedStations,
-                        {
-                          name: station.name,
-                          geojson: station.geojson,
-                          lat: station.geojson.geometry.coordinates[1],
-                          lon: station.geojson.geometry.coordinates[0],
-                        },
-                      ])
-                    }
-                  }}
-                  isStarred={starredStations.includes(station.name)}
-                  onStarClick={() => toggleStarStation(station.name)}
-                  onMouseEnterStar={() => {
-                    if (starredStations.includes(station.name)) {
-                      setHighlightedStationName(station.name)
-                    }
-                  }}
-                  onMouseLeaveStar={() => setHighlightedStationName(null)}
-                  onCenterClick={() =>
-                    setFlyToRequest({
-                      lat: station.geojson.geometry.coordinates[1],
-                      lon: station.geojson.geometry.coordinates[0],
-                    })
-                  }
-                />
-              ))}
-              {Object.keys(stationGroups).length === 0 ? (
-                <div className="py-2 pl-10 text-sm italic text-gray-500">
-                  No stations available
-                </div>
-              ) : null}
-            </TreeItem>
-          </div>
-        </div>
-        {/* Footer placed inside the modal content */}
-        <div
-          className="border-t border-gray-200 bg-white"
-          style={{
-            padding: '8px 0',
+            maxHeight: '70vh',
+            background: '#ffffff',
+            color: 'blue',
+            position: modalPosition ? 'fixed' : undefined,
+            top: modalPosition ? `${modalPosition.top}px` : undefined,
+            left: modalPosition ? `${modalPosition.left}px` : undefined,
+            zIndex: 1000,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
             width: 'auto',
-            background: '#e3f2fd',
-            marginRight: '0px',
-            marginLeft: '0px',
-            marginBottom: '0',
-            borderRadius: '4px',
-            flexShrink: 0,
-            height: '60px',
+            minWidth: '350px',
+            paddingBottom: '0px',
+            paddingTop: '10px',
+            opacity: isFadingOut ? 0 : 1,
+            transition: 'opacity 0.25s ease-out',
+            marginBottom: '0px',
+            marginTop: '0px',
           }}
+          className="m-0 p-0"
         >
-          <div className="flex justify-end pr-3">
-            <button
-              onClick={onClose}
-              className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-800"
-              style={{
-                marginRight: '20px',
-              }}
-            >
-              Close
-            </button>
+          <div
+            className="custom-scrollbar flex-grow"
+            style={{
+              overflowY: 'auto',
+              background: '#e3f2fd',
+              padding: '10px',
+              width: '100%',
+              margin: '0px 0px 20px 0px',
+              borderRadius: '4px',
+              minHeight: '0',
+              maxHeight: 'calc(70vh - 160px)',
+            }}
+          >
+            {/* Main tree structure */}
+            <div className="tree-view">
+              {/* Markers Section */}
+              <TreeItem
+                label="Markers"
+                isExpanded={expandedSections.markers}
+                isChecked={
+                  selectedMarkers.length === layerMarkers.length &&
+                  layerMarkers.length > 0
+                }
+                onToggleExpand={() => toggleExpanded('markers')}
+                onToggleCheck={
+                  layerMarkers.length > 0
+                    ? handleToggleSelectAllMarkers
+                    : undefined
+                }
+                icon={faMapMarkerAlt}
+                iconColor="red"
+                disabled={layerMarkers.length === 0}
+              >
+                {layerMarkers.map((marker) => (
+                  <TreeItem
+                    key={`marker-${marker.id}`}
+                    label={marker.label || `Marker ${marker.id}`}
+                    isChecked={marker.visible !== false}
+                    onToggleCheck={() =>
+                      toggleMarkerVisibility(marker.id.toString())
+                    }
+                    icon={faMapMarkerAlt}
+                    iconColor="red"
+                  />
+                ))}
+                {layerMarkers.length === 0 && (
+                  <div className="py-2 pl-10 text-sm italic text-gray-500">
+                    No markers saved to layers
+                  </div>
+                )}
+              </TreeItem>
+
+              {/* Stations Section */}
+              <TreeItem
+                label="Stations"
+                isExpanded={expandedSections.stations}
+                isChecked={
+                  selectedStations.length === stations?.length &&
+                  stations?.length > 0
+                }
+                onToggleExpand={() => toggleExpanded('stations')}
+                onToggleCheck={handleToggleSelectAllStations}
+                icon={faCircle}
+                iconColor="white"
+              >
+                {/* Render individual stations without the grouping layer */}
+                {stations?.map((station) => (
+                  <TreeItem
+                    key={`station-${station.name}`}
+                    label={station.name}
+                    isChecked={isStationSelected(station.name)}
+                    onToggleCheck={() => {
+                      if (isStationSelected(station.name)) {
+                        setSelectedStations(
+                          selectedStations.filter(
+                            (s) => s.name !== station.name
+                          )
+                        )
+                      } else {
+                        setSelectedStations([
+                          ...selectedStations,
+                          {
+                            name: station.name,
+                            geojson: station.geojson,
+                            lat: station.geojson.geometry.coordinates[1],
+                            lon: station.geojson.geometry.coordinates[0],
+                          },
+                        ])
+                      }
+                    }}
+                    isStarred={starredStations.includes(station.name)}
+                    onStarClick={() => toggleStarStation(station.name)}
+                    onMouseEnterStar={() => {
+                      if (starredStations.includes(station.name)) {
+                        setHighlightedStationName(station.name)
+                      }
+                    }}
+                    onMouseLeaveStar={() => setHighlightedStationName(null)}
+                    onCenterClick={() =>
+                      setFlyToRequest({
+                        lat: station.geojson.geometry.coordinates[1],
+                        lon: station.geojson.geometry.coordinates[0],
+                      })
+                    }
+                  />
+                ))}
+                {Object.keys(stationGroups).length === 0 ? (
+                  <div className="py-2 pl-10 text-sm italic text-gray-500">
+                    No stations available
+                  </div>
+                ) : null}
+              </TreeItem>
+            </div>
           </div>
-        </div>
-      </Modal>
+          {/* Footer placed inside the modal content */}
+          <div
+            className="border-t border-gray-200 bg-white"
+            style={{
+              padding: '8px 0',
+              width: 'auto',
+              background: '#e3f2fd',
+              marginRight: '0px',
+              marginLeft: '0px',
+              marginBottom: '0',
+              borderRadius: '4px',
+              flexShrink: 0,
+              height: '60px',
+            }}
+          >
+            <div className="flex justify-end pr-3">
+              <button
+                onClick={onClose}
+                className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-800"
+                style={{
+                  marginRight: '20px',
+                }}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </Modal>
+      </div>
     </>
   )
 }

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -163,7 +163,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
               <FontAwesomeIcon
                 icon={faStar}
                 style={{
-                  color: isStarred ? '#F57C00' : '#9ca3af',
+                  color: isStarred ? '#FFD700' : '#9ca3af',
                   fontSize: '14px',
                 }}
               />

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -142,17 +142,15 @@ const TreeItem: React.FC<TreeItemProps> = ({
                   ? 'Hover to spotlight on map'
                   : 'Click to enable spotlight'
               }
-              style={{ width: '16px', height: '16px', flexShrink: 0 }}
+              style={{ width: '20px', height: '20px', flexShrink: 0 }}
             >
               <span
                 style={{
                   position: 'absolute',
                   inset: 0,
                   borderRadius: '50%',
-                  border: `2px solid ${isStarred ? '#FFD700' : '#9ca3af'}`,
-                  backgroundColor: isStarred
-                    ? 'rgba(255,215,0,0.15)'
-                    : 'transparent',
+                  border: '2px solid #000',
+                  backgroundColor: 'white',
                 }}
               />
               <FontAwesomeIcon
@@ -163,7 +161,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
                   left: '50%',
                   transform: 'translate(-50%, -50%)',
                   color: isStarred ? '#FFD700' : '#9ca3af',
-                  fontSize: '8px',
+                  fontSize: '10px',
                 }}
               />
             </button>

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -150,7 +150,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
                   inset: 0,
                   borderRadius: '50%',
                   border: '2px solid #000',
-                  backgroundColor: 'white',
+                  backgroundColor: '#f0f0f0',
                 }}
               />
               <FontAwesomeIcon

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -9,7 +9,7 @@ import {
   faMapMarkerAlt,
   faCircle,
   faStar,
-  faCrosshairs,
+  faCompress,
 } from '@fortawesome/free-solid-svg-icons'
 import { useSelectedStations } from './SelectedStationContext'
 import { useMarkers } from './MarkerContext'
@@ -196,7 +196,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
               }}
             >
               <FontAwesomeIcon
-                icon={faCrosshairs}
+                icon={faCompress}
                 style={{ color: '#6b7280', fontSize: '12px' }}
               />
             </button>

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -130,7 +130,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
               />
             )
           ) : null}
-          {onStarClick !== undefined && (
+          {onStarClick !== undefined && !disabled && (
             <Tippy
               content={
                 isStarred

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -150,6 +150,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
                 onMouseLeave={onMouseLeaveStar}
                 className="mr-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
                 aria-label={isStarred ? 'Unstar station' : 'Star station'}
+                aria-pressed={isStarred}
                 style={{
                   width: '22px',
                   height: '22px',

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -9,7 +9,7 @@ import {
   faMapMarkerAlt,
   faCircle,
   faStar,
-  faCompress,
+  faArrowsToCircle,
 } from '@fortawesome/free-solid-svg-icons'
 import { useSelectedStations } from './SelectedStationContext'
 import { useMarkers } from './MarkerContext'
@@ -196,7 +196,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
               }}
             >
               <FontAwesomeIcon
-                icon={faCompress}
+                icon={faArrowsToCircle}
                 style={{ color: '#6b7280', fontSize: '16px' }}
               />
             </button>

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -9,7 +9,7 @@ import {
   faMapMarkerAlt,
   faCircle,
   faStar,
-  faExpand,
+  faCrosshairs,
 } from '@fortawesome/free-solid-svg-icons'
 import { useSelectedStations } from './SelectedStationContext'
 import { useMarkers } from './MarkerContext'
@@ -184,7 +184,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
                 width: '22px',
                 height: '22px',
                 flexShrink: 0,
-                borderRadius: '50%',
+                borderRadius: '3px',
                 background: '#fff',
                 border: 0,
                 padding: 0,
@@ -196,8 +196,8 @@ const TreeItem: React.FC<TreeItemProps> = ({
               }}
             >
               <FontAwesomeIcon
-                icon={faExpand}
-                style={{ color: '#6b7280', fontSize: '10px' }}
+                icon={faCrosshairs}
+                style={{ color: '#6b7280', fontSize: '12px' }}
               />
             </button>
           )}

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -609,7 +609,7 @@ export const MapLayersListModal: React.FC<{
                               (s) => s.name !== station.name
                             )
                           )
-                        } else {
+                        } else if (hasValidCoords) {
                           setSelectedStations([
                             ...selectedStations,
                             {

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -126,7 +126,6 @@ const TreeItem: React.FC<TreeItemProps> = ({
               />
             )
           ) : null}
-          <span className="text-sm font-medium">{label}</span>
           {onStarClick !== undefined && (
             <button
               onClick={(e) => {
@@ -136,23 +135,40 @@ const TreeItem: React.FC<TreeItemProps> = ({
               }}
               onMouseEnter={onMouseEnterStar}
               onMouseLeave={onMouseLeaveStar}
-              className="ml-2 focus:outline-none"
+              className="relative mr-2 focus:outline-none"
               aria-label={isStarred ? 'Unstar station' : 'Star station'}
               title={
                 isStarred
                   ? 'Hover to spotlight on map'
                   : 'Click to enable spotlight'
               }
+              style={{ width: '16px', height: '16px', flexShrink: 0 }}
             >
+              <span
+                style={{
+                  position: 'absolute',
+                  inset: 0,
+                  borderRadius: '50%',
+                  border: `2px solid ${isStarred ? '#FFD700' : '#9ca3af'}`,
+                  backgroundColor: isStarred
+                    ? 'rgba(255,215,0,0.15)'
+                    : 'transparent',
+                }}
+              />
               <FontAwesomeIcon
                 icon={faStar}
                 style={{
+                  position: 'absolute',
+                  top: '50%',
+                  left: '50%',
+                  transform: 'translate(-50%, -50%)',
                   color: isStarred ? '#FFD700' : '#9ca3af',
-                  fontSize: '12px',
+                  fontSize: '8px',
                 }}
               />
             </button>
           )}
+          <span className="text-sm font-medium">{label}</span>
         </label>
       </div>
 

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -135,32 +135,31 @@ const TreeItem: React.FC<TreeItemProps> = ({
               }}
               onMouseEnter={onMouseEnterStar}
               onMouseLeave={onMouseLeaveStar}
-              className="relative mr-2 focus:outline-none"
+              className="mr-1 focus:outline-none"
               aria-label={isStarred ? 'Unstar station' : 'Star station'}
               title={
                 isStarred
                   ? 'Hover to spotlight on map'
                   : 'Click to enable spotlight'
               }
-              style={{ width: '20px', height: '20px', flexShrink: 0 }}
+              style={{
+                width: '20px',
+                height: '20px',
+                flexShrink: 0,
+                borderRadius: '50%',
+                background: 'transparent',
+                border: 0,
+                padding: 0,
+                boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                cursor: 'pointer',
+              }}
             >
-              <span
-                style={{
-                  position: 'absolute',
-                  inset: 0,
-                  borderRadius: '50%',
-                  border: 'none',
-                  backgroundColor: '#f0f0f0',
-                  boxShadow: '0 2px 4px rgba(0,0,0,0.4)',
-                }}
-              />
               <FontAwesomeIcon
                 icon={faStar}
                 style={{
-                  position: 'absolute',
-                  top: '50%',
-                  left: '50%',
-                  transform: 'translate(-50%, -50%)',
                   color: isStarred ? '#FFD700' : '#9ca3af',
                   fontSize: '10px',
                 }}

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -138,6 +138,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
                   : 'Click to enable spotlight'
               }
               placement="top-start"
+              appendTo="parent"
             >
               <button
                 type="button"
@@ -178,7 +179,11 @@ const TreeItem: React.FC<TreeItemProps> = ({
           )}
           <span className="text-sm font-medium">{label}</span>
           {onCenterClick !== undefined && (
-            <Tippy content="Center map on this station" placement="top-start">
+            <Tippy
+              content="Center map on this station"
+              placement="top-start"
+              appendTo="parent"
+            >
               <button
                 type="button"
                 onClick={(e) => {
@@ -322,13 +327,14 @@ export const MapLayersListModal: React.FC<{
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
         // Don't stop propagation here so Leaflet can begin a pan/drag on the
         // same gesture. Flag the paired click so IT gets consumed instead.
-        // If the gesture becomes a drag, the browser won't fire a click and
-        // justClosedRef would stay true — clear it via a short timeout so
-        // subsequent unrelated clicks are not incorrectly consumed.
+        // Clear via mouseup (gesture end) rather than a fixed timeout so we
+        // don't miss long-press or delayed-click scenarios.
         justClosedRef.current = true
-        window.setTimeout(() => {
+        const clearJustClosed = () => {
           justClosedRef.current = false
-        }, 300)
+          document.removeEventListener('mouseup', clearJustClosed, true)
+        }
+        document.addEventListener('mouseup', clearJustClosed, true)
         handleClose()
       }
     }

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -110,6 +110,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
             type="checkbox"
             checked={isChecked}
             onChange={onToggleCheck}
+            readOnly={!onToggleCheck}
             disabled={disabled}
             className="mapLayersCheckbox mr-2"
             style={{
@@ -390,17 +391,15 @@ export const MapLayersListModal: React.FC<{
 
   // Existing handlers for stations
   const handleSelectAllStations = useCallback(() => {
-    if (stations) {
-      setSelectedStations(
-        stations.map((station) => ({
-          name: station.name,
-          geojson: station.geojson,
-          lat: station.geojson.geometry.coordinates[1],
-          lon: station.geojson.geometry.coordinates[0],
-        }))
-      )
-    }
-  }, [stations, setSelectedStations])
+    setSelectedStations(
+      validStations.map((station) => ({
+        name: station.name,
+        geojson: station.geojson,
+        lat: station.geojson.geometry.coordinates[1],
+        lon: station.geojson.geometry.coordinates[0],
+      }))
+    )
+  }, [validStations, setSelectedStations])
 
   // Deselect all stations
   const handleDeselectAllStations = useCallback(() => {
@@ -409,14 +408,17 @@ export const MapLayersListModal: React.FC<{
 
   // Toggle select all stations
   const handleToggleSelectAllStations = useCallback(() => {
-    if (selectedStations.length === stations?.length) {
+    const selectedValidCount = selectedStations.filter((s) =>
+      validStations.some((v) => v.name === s.name)
+    ).length
+    if (selectedValidCount === validStations.length) {
       handleDeselectAllStations()
     } else {
       handleSelectAllStations()
     }
   }, [
     selectedStations,
-    stations,
+    validStations,
     handleSelectAllStations,
     handleDeselectAllStations,
   ])
@@ -481,6 +483,20 @@ export const MapLayersListModal: React.FC<{
       })
       .map(({ station }) => station)
   }, [stations, starredSet])
+
+  // Pre-computed list of stations with valid coordinates — used by select-all
+  // logic and the header checkbox so stations with invalid coords are excluded.
+  const validStations = useMemo(
+    () =>
+      (stations ?? []).filter((station) => {
+        const coords = station.geojson?.geometry?.coordinates
+        return (
+          Number.isFinite(coords?.[1] as number) &&
+          Number.isFinite(coords?.[0] as number)
+        )
+      }),
+    [stations]
+  )
 
   return (
     <>
@@ -592,8 +608,10 @@ export const MapLayersListModal: React.FC<{
                 label="Stations"
                 isExpanded={expandedSections.stations}
                 isChecked={
-                  selectedStations.length === stations?.length &&
-                  stations?.length > 0
+                  validStations.length > 0 &&
+                  selectedStations.filter((s) =>
+                    validStations.some((v) => v.name === s.name)
+                  ).length === validStations.length
                 }
                 onToggleExpand={() => toggleExpanded('stations')}
                 onToggleCheck={handleToggleSelectAllStations}

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -187,8 +187,8 @@ const TreeItem: React.FC<TreeItemProps> = ({
                 className="ml-2 focus:outline-none"
                 aria-label="Center map on station"
                 style={{
-                  width: '26px',
-                  height: '26px',
+                  width: '20px',
+                  height: '20px',
                   flexShrink: 0,
                   borderRadius: '3px',
                   background: '#fff',
@@ -203,7 +203,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
               >
                 <FontAwesomeIcon
                   icon={faArrowsToCircle}
-                  style={{ color: '#6b7280', fontSize: '16px' }}
+                  style={{ color: '#6b7280', fontSize: '13px' }}
                 />
               </button>
             </Tippy>

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -286,13 +286,26 @@ export const MapLayersListModal: React.FC<{
 
   // Click-outside to dismiss
   useEffect(() => {
-    const handleMouseDown = (e: MouseEvent) => {
+    const handleOutsideCapture = (e: MouseEvent) => {
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        e.preventDefault()
+        e.stopPropagation()
         handleClose()
       }
     }
-    document.addEventListener('mousedown', handleMouseDown)
-    return () => document.removeEventListener('mousedown', handleMouseDown)
+
+    document.addEventListener('mousedown', handleOutsideCapture, {
+      capture: true,
+    })
+    document.addEventListener('click', handleOutsideCapture, { capture: true })
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideCapture, {
+        capture: true,
+      })
+      document.removeEventListener('click', handleOutsideCapture, {
+        capture: true,
+      })
+    }
   }, [handleClose])
 
   useEffect(() => {

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -130,7 +130,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
               />
             )
           ) : null}
-          {onStarClick !== undefined && !disabled && (
+          {onStarClick !== undefined && (!disabled || isStarred) && (
             <Tippy
               content={
                 isStarred
@@ -254,7 +254,7 @@ export const MapLayersListModal: React.FC<{
     markers,
     selectedMarkers,
     toggleMarkerVisibility,
-    selectAllMarkers, // Make sure these are imported
+    selectAllMarkers,
     deselectAllMarkers,
   } = useMarkers()
   // Track expansion state of tree nodes

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -323,7 +323,13 @@ export const MapLayersListModal: React.FC<{
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
         // Don't stop propagation here so Leaflet can begin a pan/drag on the
         // same gesture. Flag the paired click so IT gets consumed instead.
+        // If the gesture becomes a drag, the browser won't fire a click and
+        // justClosedRef would stay true — clear it via a short timeout so
+        // subsequent unrelated clicks are not incorrectly consumed.
         justClosedRef.current = true
+        window.setTimeout(() => {
+          justClosedRef.current = false
+        }, 300)
         handleClose()
       }
     }

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -251,8 +251,6 @@ export const MapLayersListModal: React.FC<{
     selectAllMarkers, // Make sure these are imported
     deselectAllMarkers,
   } = useMarkers()
-  const [searchTerm, setSearchTerm] = useState('')
-
   // Track expansion state of tree nodes
   const [expandedSections, setExpandedSections] = useState<
     Record<SectionName, boolean>
@@ -441,15 +439,6 @@ export const MapLayersListModal: React.FC<{
     deselectAllMarkers,
   ])
 
-  // Group stations by name
-  const stationGroups =
-    stations?.reduce((acc, station) => {
-      const groupName = station.name || String(station)
-      const group = acc[groupName] || []
-      group.push(station)
-      return { ...acc, [groupName]: group }
-    }, {} as Record<string, any[]>) ?? {}
-
   // Check if a station is selected
   const isStationSelected = (stationName: string): boolean => {
     return selectedStations.some((s) => s.name === stationName)
@@ -479,41 +468,6 @@ export const MapLayersListModal: React.FC<{
       })
       .map(({ station }) => station)
   }, [stations, starredSet])
-
-  // Check if all stations in a group are selected
-  const areAllStationsInGroupSelected = (groupName: string): boolean => {
-    const groupStations = stationGroups[groupName] || []
-    return groupStations.every((station) =>
-      selectedStations.some((s) => s.name === station.name)
-    )
-  }
-
-  // Toggle selection for a station group
-  const toggleStationGroupSelection = (groupName: string): void => {
-    if (areAllStationsInGroupSelected(groupName)) {
-      // If all selected, deselect all in group
-      setSelectedStations(
-        selectedStations.filter(
-          (s) =>
-            !stationGroups[groupName].some((station) => station.name === s.name)
-        )
-      )
-    } else {
-      // If not all selected, select all in group
-      const groupStationsToAdd = stationGroups[groupName]
-        .filter(
-          (station) => !selectedStations.some((s) => s.name === station.name)
-        )
-        .map((station) => ({
-          name: station.name,
-          geojson: station.geojson,
-          lat: station.geojson.geometry.coordinates[1],
-          lon: station.geojson.geometry.coordinates[0],
-        }))
-
-      setSelectedStations([...selectedStations, ...groupStationsToAdd])
-    }
-  }
 
   return (
     <>

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -488,7 +488,6 @@ export const MapLayersListModal: React.FC<{
               </div>
             </div>
           }
-          confirmButtonText="Close"
           onClose={handleClose}
           snapTo={!modalPosition ? 'top-left' : undefined}
           open

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -8,6 +8,7 @@ import {
   faCaretRight,
   faMapMarkerAlt,
   faCircle,
+  faStar,
 } from '@fortawesome/free-solid-svg-icons'
 import { useSelectedStations } from './SelectedStationContext'
 import { useMarkers } from './MarkerContext'
@@ -28,6 +29,10 @@ interface TreeItemProps {
   iconColor?: string
   children?: React.ReactNode
   disabled?: boolean
+  isStarred?: boolean
+  onStarClick?: () => void
+  onMouseEnterStar?: () => void
+  onMouseLeaveStar?: () => void
 }
 
 const TreeItem: React.FC<TreeItemProps> = ({
@@ -40,6 +45,10 @@ const TreeItem: React.FC<TreeItemProps> = ({
   iconColor,
   children,
   disabled = false,
+  isStarred,
+  onStarClick,
+  onMouseEnterStar,
+  onMouseLeaveStar,
 }) => {
   const hasChildren = React.Children.count(children) > 0
 
@@ -118,6 +127,28 @@ const TreeItem: React.FC<TreeItemProps> = ({
             )
           ) : null}
           <span className="text-sm font-medium">{label}</span>
+          {onStarClick !== undefined && (
+            <button
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                onStarClick()
+              }}
+              onMouseEnter={onMouseEnterStar}
+              onMouseLeave={onMouseLeaveStar}
+              className="ml-2 focus:outline-none"
+              aria-label={isStarred ? 'Unstar station' : 'Star station'}
+              title={isStarred ? 'Remove spotlight' : 'Spotlight on map'}
+            >
+              <FontAwesomeIcon
+                icon={faStar}
+                style={{
+                  color: isStarred ? '#FFD700' : '#9ca3af',
+                  fontSize: '12px',
+                }}
+              />
+            </button>
+          )}
         </label>
       </div>
 
@@ -145,7 +176,13 @@ export const MapLayersListModal: React.FC<{
 }> = ({ onClose, anchorPosition, ...modalProps }) => {
   // Move all hooks to the top level
   const { data: stations } = useStations()
-  const { selectedStations, setSelectedStations } = useSelectedStations()
+  const {
+    selectedStations,
+    setSelectedStations,
+    starredStations,
+    toggleStarStation,
+    setHighlightedStationName,
+  } = useSelectedStations()
   const {
     markers,
     selectedMarkers,
@@ -443,6 +480,12 @@ export const MapLayersListModal: React.FC<{
                       ])
                     }
                   }}
+                  isStarred={starredStations.includes(station.name)}
+                  onStarClick={() => toggleStarStation(station.name)}
+                  onMouseEnterStar={() =>
+                    setHighlightedStationName(station.name)
+                  }
+                  onMouseLeaveStar={() => setHighlightedStationName(null)}
                 />
               ))}
               {Object.keys(stationGroups).length === 0 ? (

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -650,7 +650,12 @@ export const MapLayersListModal: React.FC<{
                     onStarClick={() => {
                       const isCurrentlyStarred = starredSet.has(station.name)
                       if (isCurrentlyStarred) {
+                        // Un-starring: clear any active spotlight
                         setHighlightedStationName(null)
+                      } else {
+                        // Starring while hovering: immediately show spotlight
+                        // so the user doesn't need to mouse-out and back
+                        setHighlightedStationName(station.name)
                       }
                       toggleStarStation(station.name)
                     }}

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -611,9 +611,14 @@ export const MapLayersListModal: React.FC<{
                   ).length === validStations.length
                 }
                 onToggleExpand={() => toggleExpanded('stations')}
-                onToggleCheck={handleToggleSelectAllStations}
+                onToggleCheck={
+                  validStations.length > 0
+                    ? handleToggleSelectAllStations
+                    : undefined
+                }
                 icon={faCircle}
                 iconColor="white"
+                disabled={validStations.length === 0}
               >
                 {/* Starred stations first (alphabetical), then unstarred in original API order */}
                 {sortedStations.map((station) => {

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -539,47 +539,57 @@ export const MapLayersListModal: React.FC<{
                 icon={faCircle}
                 iconColor="white"
               >
-                {/* Render individual stations without the grouping layer */}
-                {stations?.map((station) => (
-                  <TreeItem
-                    key={`station-${station.name}`}
-                    label={station.name}
-                    isChecked={isStationSelected(station.name)}
-                    onToggleCheck={() => {
-                      if (isStationSelected(station.name)) {
-                        setSelectedStations(
-                          selectedStations.filter(
-                            (s) => s.name !== station.name
+                {/* Starred stations first (alphabetical), then unstarred in original API order */}
+                {[...(stations ?? [])]
+                  .sort((a, b) => {
+                    const aStarred = starredStations.includes(a.name)
+                    const bStarred = starredStations.includes(b.name)
+                    if (aStarred && bStarred)
+                      return a.name.localeCompare(b.name)
+                    if (aStarred) return -1
+                    if (bStarred) return 1
+                    return 0
+                  })
+                  .map((station) => (
+                    <TreeItem
+                      key={`station-${station.name}`}
+                      label={station.name}
+                      isChecked={isStationSelected(station.name)}
+                      onToggleCheck={() => {
+                        if (isStationSelected(station.name)) {
+                          setSelectedStations(
+                            selectedStations.filter(
+                              (s) => s.name !== station.name
+                            )
                           )
-                        )
-                      } else {
-                        setSelectedStations([
-                          ...selectedStations,
-                          {
-                            name: station.name,
-                            geojson: station.geojson,
-                            lat: station.geojson.geometry.coordinates[1],
-                            lon: station.geojson.geometry.coordinates[0],
-                          },
-                        ])
+                        } else {
+                          setSelectedStations([
+                            ...selectedStations,
+                            {
+                              name: station.name,
+                              geojson: station.geojson,
+                              lat: station.geojson.geometry.coordinates[1],
+                              lon: station.geojson.geometry.coordinates[0],
+                            },
+                          ])
+                        }
+                      }}
+                      isStarred={starredStations.includes(station.name)}
+                      onStarClick={() => toggleStarStation(station.name)}
+                      onMouseEnterStar={() => {
+                        if (starredStations.includes(station.name)) {
+                          setHighlightedStationName(station.name)
+                        }
+                      }}
+                      onMouseLeaveStar={() => setHighlightedStationName(null)}
+                      onCenterClick={() =>
+                        setFlyToRequest({
+                          lat: station.geojson.geometry.coordinates[1],
+                          lon: station.geojson.geometry.coordinates[0],
+                        })
                       }
-                    }}
-                    isStarred={starredStations.includes(station.name)}
-                    onStarClick={() => toggleStarStation(station.name)}
-                    onMouseEnterStar={() => {
-                      if (starredStations.includes(station.name)) {
-                        setHighlightedStationName(station.name)
-                      }
-                    }}
-                    onMouseLeaveStar={() => setHighlightedStationName(null)}
-                    onCenterClick={() =>
-                      setFlyToRequest({
-                        lat: station.geojson.geometry.coordinates[1],
-                        lon: station.geojson.geometry.coordinates[0],
-                      })
-                    }
-                  />
-                ))}
+                    />
+                  ))}
                 {Object.keys(stationGroups).length === 0 ? (
                   <div className="py-2 pl-10 text-sm italic text-gray-500">
                     No stations available

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -389,6 +389,20 @@ export const MapLayersListModal: React.FC<{
     }))
   }, [])
 
+  // Pre-computed list of stations with valid coordinates — used by select-all
+  // logic and the header checkbox so stations with invalid coords are excluded.
+  const validStations = useMemo(
+    () =>
+      (stations ?? []).filter((station) => {
+        const coords = station.geojson?.geometry?.coordinates
+        return (
+          Number.isFinite(coords?.[1] as number) &&
+          Number.isFinite(coords?.[0] as number)
+        )
+      }),
+    [stations]
+  )
+
   // Existing handlers for stations
   const handleSelectAllStations = useCallback(() => {
     setSelectedStations(
@@ -483,20 +497,6 @@ export const MapLayersListModal: React.FC<{
       })
       .map(({ station }) => station)
   }, [stations, starredSet])
-
-  // Pre-computed list of stations with valid coordinates — used by select-all
-  // logic and the header checkbox so stations with invalid coords are excluded.
-  const validStations = useMemo(
-    () =>
-      (stations ?? []).filter((station) => {
-        const coords = station.geojson?.geometry?.coordinates
-        return (
-          Number.isFinite(coords?.[1] as number) &&
-          Number.isFinite(coords?.[0] as number)
-        )
-      }),
-    [stations]
-  )
 
   return (
     <>

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -455,18 +455,24 @@ export const MapLayersListModal: React.FC<{
     () => new Set(starredStations ?? []),
     [starredStations]
   )
-  const sortedStations = useMemo(
-    () =>
-      [...(stations ?? [])].sort((a, b) => {
-        const aStarred = starredSet.has(a.name)
-        const bStarred = starredSet.has(b.name)
-        if (aStarred && bStarred) return a.name.localeCompare(b.name)
+  const sortedStations = useMemo(() => {
+    const list = stations ?? []
+    // Decorate with original index so unstarred stations always preserve
+    // API order regardless of JS engine sort stability guarantees.
+    return list
+      .map((station, index) => ({ station, index }))
+      .sort((a, b) => {
+        const aStarred = starredSet.has(a.station.name)
+        const bStarred = starredSet.has(b.station.name)
+        if (aStarred && bStarred)
+          return a.station.name.localeCompare(b.station.name)
         if (aStarred) return -1
         if (bStarred) return 1
-        return 0
-      }),
-    [stations, starredSet]
-  )
+        // Both unstarred: preserve original API order
+        return a.index - b.index
+      })
+      .map(({ station }) => station)
+  }, [stations, starredSet])
 
   // Check if all stations in a group are selected
   const areAllStationsInGroupSelected = (groupName: string): boolean => {

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -556,6 +556,7 @@ export const MapLayersListModal: React.FC<{
             paddingBottom: '0px',
             paddingTop: '10px',
             opacity: isFadingOut ? 0 : 1,
+            pointerEvents: isFadingOut ? 'none' : 'auto',
             transition: 'opacity 0.25s ease-out',
             marginBottom: '0px',
             marginTop: '0px',

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -281,6 +281,9 @@ export const MapLayersListModal: React.FC<{
   // gesture is still consumed (preventing map click-actions on close), then
   // cleared. Subsequent gestures during the fade pass through freely.
   const justClosedRef = useRef(false)
+  // Tracked so effect cleanup can remove it if the component unmounts while
+  // the mouse is still held down (before mouseup fires).
+  const clearJustClosedRef = useRef<(() => void) | null>(null)
 
   const handleClose = useCallback(() => {
     if (isFadingOutRef.current) return
@@ -333,12 +336,16 @@ export const MapLayersListModal: React.FC<{
         // be consumed by handleOutsideCapture below.
         justClosedRef.current = true
         const clearJustClosed = () => {
-          document.removeEventListener('mouseup', clearJustClosed, true)
+          clearJustClosedRef.current = null
           setTimeout(() => {
             justClosedRef.current = false
           }, 0)
         }
-        document.addEventListener('mouseup', clearJustClosed, true)
+        clearJustClosedRef.current = clearJustClosed
+        document.addEventListener('mouseup', clearJustClosed, {
+          capture: true,
+          once: true,
+        })
         handleClose()
       }
     }
@@ -354,6 +361,14 @@ export const MapLayersListModal: React.FC<{
       document.removeEventListener('click', handleOutsideCapture, {
         capture: true,
       })
+      // Remove the pending mouseup listener if the component unmounts while
+      // the mouse is still held down (before mouseup fires).
+      if (clearJustClosedRef.current) {
+        document.removeEventListener('mouseup', clearJustClosedRef.current, {
+          capture: true,
+        })
+        clearJustClosedRef.current = null
+      }
     }
   }, [handleClose])
 

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -267,8 +267,12 @@ export const MapLayersListModal: React.FC<{
   const [isFadingOut, setIsFadingOut] = useState(false)
   const modalRef = useRef<HTMLDivElement>(null)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  // Ref mirror so event-handler closures always read the latest value
+  // Ref mirror so event-handler closures always read the latest fading state.
   const isFadingOutRef = useRef(false)
+  // Set to true by the closing mousedown so the paired click from the SAME
+  // gesture is still consumed (preventing map click-actions on close), then
+  // cleared. Subsequent gestures during the fade pass through freely.
+  const justClosedRef = useRef(false)
 
   const handleClose = useCallback(() => {
     if (isFadingOutRef.current) return
@@ -290,14 +294,19 @@ export const MapLayersListModal: React.FC<{
   // Click-outside to dismiss
   useEffect(() => {
     const handleOutsideCapture = (e: MouseEvent) => {
-      // If already fading out, let events through immediately so the map is
-      // interactive again during the 250 ms fade window.
+      // The mousedown from the closing gesture set justClosedRef. Consume this
+      // paired click to prevent map click-actions, then clear the flag so all
+      // subsequent clicks during the fade pass through to the map.
+      if (justClosedRef.current) {
+        justClosedRef.current = false
+        e.preventDefault()
+        e.stopPropagation()
+        return
+      }
+      // Already fading from a prior gesture — let events through so the map
+      // is fully interactive during the 250 ms fade window.
       if (isFadingOutRef.current) return
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-        // Stop propagation on click to prevent map click-actions (waypoint
-        // placement, custom markers, etc.) firing alongside the dismiss.
-        // mousedown is intentionally NOT stopped so Leaflet can still begin
-        // a pan/drag gesture on the same gesture that closes the modal.
         e.preventDefault()
         e.stopPropagation()
         handleClose()
@@ -305,12 +314,12 @@ export const MapLayersListModal: React.FC<{
     }
 
     const handleOutsideMouseDown = (e: MouseEvent) => {
-      // If already fading out, let events through immediately so the map is
-      // interactive again during the 250 ms fade window.
+      // Already fading — let all subsequent gestures reach the map.
       if (isFadingOutRef.current) return
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
-        // Dismiss on mousedown (without blocking propagation) so the user
-        // can immediately start panning the map on the same gesture.
+        // Don't stop propagation here so Leaflet can begin a pan/drag on the
+        // same gesture. Flag the paired click so IT gets consumed instead.
+        justClosedRef.current = true
         handleClose()
       }
     }

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -149,8 +149,9 @@ const TreeItem: React.FC<TreeItemProps> = ({
                   position: 'absolute',
                   inset: 0,
                   borderRadius: '50%',
-                  border: '2px solid #000',
+                  border: 'none',
                   backgroundColor: '#f0f0f0',
+                  boxShadow: '0 2px 4px rgba(0,0,0,0.4)',
                 }}
               />
               <FontAwesomeIcon

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -288,18 +288,30 @@ export const MapLayersListModal: React.FC<{
   useEffect(() => {
     const handleOutsideCapture = (e: MouseEvent) => {
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        // Stop propagation on click to prevent map click-actions (waypoint
+        // placement, custom markers, etc.) firing alongside the dismiss.
+        // mousedown is intentionally NOT stopped so Leaflet can still begin
+        // a pan/drag gesture on the same gesture that closes the modal.
         e.preventDefault()
         e.stopPropagation()
         handleClose()
       }
     }
 
-    document.addEventListener('mousedown', handleOutsideCapture, {
+    const handleOutsideMouseDown = (e: MouseEvent) => {
+      if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+        // Dismiss on mousedown (without blocking propagation) so the user
+        // can immediately start panning the map on the same gesture.
+        handleClose()
+      }
+    }
+
+    document.addEventListener('mousedown', handleOutsideMouseDown, {
       capture: true,
     })
     document.addEventListener('click', handleOutsideCapture, { capture: true })
     return () => {
-      document.removeEventListener('mousedown', handleOutsideCapture, {
+      document.removeEventListener('mousedown', handleOutsideMouseDown, {
         capture: true,
       })
       document.removeEventListener('click', handleOutsideCapture, {
@@ -622,7 +634,7 @@ export const MapLayersListModal: React.FC<{
                       }
                     />
                   ))}
-                {Object.keys(stationGroups).length === 0 ? (
+                {stations !== undefined && stations.length === 0 ? (
                   <div className="py-2 pl-10 text-sm italic text-gray-500">
                     No stations available
                   </div>

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -181,8 +181,8 @@ const TreeItem: React.FC<TreeItemProps> = ({
               aria-label="Center map on station"
               title="Center map on this station"
               style={{
-                width: '22px',
-                height: '22px',
+                width: '26px',
+                height: '26px',
                 flexShrink: 0,
                 borderRadius: '3px',
                 background: '#fff',
@@ -197,7 +197,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
             >
               <FontAwesomeIcon
                 icon={faCompress}
-                style={{ color: '#6b7280', fontSize: '12px' }}
+                style={{ color: '#6b7280', fontSize: '16px' }}
               />
             </button>
           )}

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -203,7 +203,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
               >
                 <FontAwesomeIcon
                   icon={faArrowsToCircle}
-                  style={{ color: '#6b7280', fontSize: '13px' }}
+                  style={{ color: '#6b7280', fontSize: '14.5px' }}
                 />
               </button>
             </Tippy>

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -14,9 +14,6 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { useSelectedStations } from './SelectedStationContext'
 import { useMarkers } from './MarkerContext'
-import { createLogger } from '@mbari/utils'
-
-const logger = createLogger('MapLayersListModal')
 
 type SectionName = 'stations' | 'markers' | `station-${string}`
 

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useState, useRef, useEffect, useMemo } from 'react'
 import Tippy from '@tippyjs/react'
-import 'tippy.js/dist/tippy.css'
 import { useStations } from '@mbari/api-client'
 import { Modal } from '@mbari/react-ui'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -141,6 +140,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
               placement="top-start"
             >
               <button
+                type="button"
                 onClick={(e) => {
                   e.preventDefault()
                   e.stopPropagation()
@@ -179,6 +179,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
           {onCenterClick !== undefined && (
             <Tippy content="Center map on this station" placement="top-start">
               <button
+                type="button"
                 onClick={(e) => {
                   e.preventDefault()
                   e.stopPropagation()

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -233,7 +233,7 @@ const TreeItem: React.FC<TreeItemProps> = ({
 export const MapLayersListModal: React.FC<{
   onClose: () => void
   anchorPosition?: { top: number; left: number }
-}> = ({ onClose, anchorPosition, ...modalProps }) => {
+}> = ({ onClose, anchorPosition }) => {
   // Move all hooks to the top level
   const { data: stations } = useStations()
   const {
@@ -267,15 +267,18 @@ export const MapLayersListModal: React.FC<{
   const [isFadingOut, setIsFadingOut] = useState(false)
   const modalRef = useRef<HTMLDivElement>(null)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // Ref mirror so event-handler closures always read the latest value
+  const isFadingOutRef = useRef(false)
 
   const handleClose = useCallback(() => {
-    if (isFadingOut) return
+    if (isFadingOutRef.current) return
+    isFadingOutRef.current = true
     setIsFadingOut(true)
     setHighlightedStationName(null)
     closeTimerRef.current = setTimeout(() => {
       onClose()
     }, 250)
-  }, [isFadingOut, onClose, setHighlightedStationName])
+  }, [onClose, setHighlightedStationName])
 
   // Cleanup timer on unmount
   useEffect(() => {
@@ -287,6 +290,9 @@ export const MapLayersListModal: React.FC<{
   // Click-outside to dismiss
   useEffect(() => {
     const handleOutsideCapture = (e: MouseEvent) => {
+      // If already fading out, let events through immediately so the map is
+      // interactive again during the 250 ms fade window.
+      if (isFadingOutRef.current) return
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
         // Stop propagation on click to prevent map click-actions (waypoint
         // placement, custom markers, etc.) firing alongside the dismiss.
@@ -299,6 +305,9 @@ export const MapLayersListModal: React.FC<{
     }
 
     const handleOutsideMouseDown = (e: MouseEvent) => {
+      // If already fading out, let events through immediately so the map is
+      // interactive again during the 250 ms fade window.
+      if (isFadingOutRef.current) return
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
         // Dismiss on mousedown (without blocking propagation) so the user
         // can immediately start panning the map on the same gesture.

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -628,57 +628,69 @@ export const MapLayersListModal: React.FC<{
                 iconColor="white"
               >
                 {/* Starred stations first (alphabetical), then unstarred in original API order */}
-                {sortedStations.map((station) => (
-                  <TreeItem
-                    key={`station-${station.name}`}
-                    label={station.name}
-                    isChecked={isStationSelected(station.name)}
-                    onToggleCheck={() => {
-                      if (isStationSelected(station.name)) {
-                        setSelectedStations(
-                          selectedStations.filter(
-                            (s) => s.name !== station.name
+                {sortedStations.map((station) => {
+                  const coords = station.geojson?.geometry?.coordinates
+                  const stationLon = coords?.[0]
+                  const stationLat = coords?.[1]
+                  const hasValidCoords =
+                    Number.isFinite(stationLat as number) &&
+                    Number.isFinite(stationLon as number)
+
+                  return (
+                    <TreeItem
+                      key={`station-${station.name}`}
+                      label={station.name}
+                      isChecked={isStationSelected(station.name)}
+                      onToggleCheck={() => {
+                        if (isStationSelected(station.name)) {
+                          setSelectedStations(
+                            selectedStations.filter(
+                              (s) => s.name !== station.name
+                            )
                           )
-                        )
-                      } else {
-                        setSelectedStations([
-                          ...selectedStations,
-                          {
-                            name: station.name,
-                            geojson: station.geojson,
-                            lat: station.geojson.geometry.coordinates[1],
-                            lon: station.geojson.geometry.coordinates[0],
-                          },
-                        ])
+                        } else {
+                          setSelectedStations([
+                            ...selectedStations,
+                            {
+                              name: station.name,
+                              geojson: station.geojson,
+                              lat: stationLat as number,
+                              lon: stationLon as number,
+                            },
+                          ])
+                        }
+                      }}
+                      isStarred={starredSet.has(station.name)}
+                      onStarClick={() => {
+                        const isCurrentlyStarred = starredSet.has(station.name)
+                        if (isCurrentlyStarred) {
+                          // Un-starring: clear any active spotlight
+                          setHighlightedStationName(null)
+                        } else {
+                          // Starring while hovering: immediately show spotlight
+                          // so the user doesn't need to mouse-out and back
+                          setHighlightedStationName(station.name)
+                        }
+                        toggleStarStation(station.name)
+                      }}
+                      onMouseEnterStar={() => {
+                        if (starredSet.has(station.name)) {
+                          setHighlightedStationName(station.name)
+                        }
+                      }}
+                      onMouseLeaveStar={() => setHighlightedStationName(null)}
+                      onCenterClick={
+                        hasValidCoords
+                          ? () =>
+                              setFlyToRequest({
+                                lat: stationLat as number,
+                                lon: stationLon as number,
+                              })
+                          : undefined
                       }
-                    }}
-                    isStarred={starredSet.has(station.name)}
-                    onStarClick={() => {
-                      const isCurrentlyStarred = starredSet.has(station.name)
-                      if (isCurrentlyStarred) {
-                        // Un-starring: clear any active spotlight
-                        setHighlightedStationName(null)
-                      } else {
-                        // Starring while hovering: immediately show spotlight
-                        // so the user doesn't need to mouse-out and back
-                        setHighlightedStationName(station.name)
-                      }
-                      toggleStarStation(station.name)
-                    }}
-                    onMouseEnterStar={() => {
-                      if (starredSet.has(station.name)) {
-                        setHighlightedStationName(station.name)
-                      }
-                    }}
-                    onMouseLeaveStar={() => setHighlightedStationName(null)}
-                    onCenterClick={() =>
-                      setFlyToRequest({
-                        lat: station.geojson.geometry.coordinates[1],
-                        lon: station.geojson.geometry.coordinates[0],
-                      })
-                    }
-                  />
-                ))}
+                    />
+                  )
+                })}
                 {stations !== undefined && stations.length === 0 ? (
                   <div className="py-2 pl-10 text-sm italic text-gray-500">
                     No stations available

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -143,8 +143,8 @@ const TreeItem: React.FC<TreeItemProps> = ({
                   : 'Click to enable spotlight'
               }
               style={{
-                width: '20px',
-                height: '20px',
+                width: '22px',
+                height: '22px',
                 flexShrink: 0,
                 borderRadius: '50%',
                 background: 'transparent',
@@ -160,8 +160,8 @@ const TreeItem: React.FC<TreeItemProps> = ({
               <FontAwesomeIcon
                 icon={faStar}
                 style={{
-                  color: isStarred ? '#FFD700' : '#9ca3af',
-                  fontSize: '10px',
+                  color: isStarred ? '#F57C00' : '#9ca3af',
+                  fontSize: '14px',
                 }}
               />
             </button>

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -329,12 +329,16 @@ export const MapLayersListModal: React.FC<{
       if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
         // Don't stop propagation here so Leaflet can begin a pan/drag on the
         // same gesture. Flag the paired click so IT gets consumed instead.
-        // Clear via mouseup (gesture end) rather than a fixed timeout so we
-        // don't miss long-press or delayed-click scenarios.
+        // Remove the mouseup listener on gesture end, but defer the actual
+        // flag clear to the next macrotask so the paired click event (which
+        // fires after mouseup) can still observe justClosedRef as true and
+        // be consumed by handleOutsideCapture below.
         justClosedRef.current = true
         const clearJustClosed = () => {
-          justClosedRef.current = false
           document.removeEventListener('mouseup', clearJustClosed, true)
+          setTimeout(() => {
+            justClosedRef.current = false
+          }, 0)
         }
         document.addEventListener('mouseup', clearJustClosed, true)
         handleClose()

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -102,19 +102,21 @@ const TreeItem: React.FC<TreeItemProps> = ({
 
         <label
           className={`flex w-full ${
-            disabled ? 'cursor-null opacity-60' : 'cursor-pointer'
+            disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
           } items-center`}
+          title={disabled ? 'No valid coordinates' : undefined}
         >
           <input
             type="checkbox"
             checked={isChecked}
             onChange={onToggleCheck}
+            disabled={disabled}
             className="mapLayersCheckbox mr-2"
             style={{
               width: '18px',
               height: '18px',
               accentColor: '#3182ce',
-              cursor: disabled ? 'none' : 'pointer',
+              cursor: disabled ? 'not-allowed' : 'pointer',
             }}
           />
           {icon ? (
@@ -607,6 +609,7 @@ export const MapLayersListModal: React.FC<{
                     <TreeItem
                       key={`station-${station.name}`}
                       label={station.name}
+                      disabled={!hasValidCoords}
                       isChecked={isStationSelected(station.name)}
                       onToggleCheck={() => {
                         if (isStationSelected(station.name)) {

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -266,6 +266,10 @@ export const MapLayersListModal: React.FC<{
   >(anchorPosition)
   const [isFadingOut, setIsFadingOut] = useState(false)
   const modalRef = useRef<HTMLDivElement>(null)
+  // Separate ref for the dialog content element — used for getBoundingClientRect
+  // measurements. modalRef wraps the fixed-position overlay and would report 0x0;
+  // dialogRef points to the actual sized panel inside so position clamping works.
+  const dialogRef = useRef<HTMLDivElement>(null)
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   // Ref mirror so event-handler closures always read the latest fading state.
   const isFadingOutRef = useRef(false)
@@ -339,10 +343,9 @@ export const MapLayersListModal: React.FC<{
   }, [handleClose])
 
   useEffect(() => {
-    if (!anchorPosition || !modalRef.current) return
+    if (!anchorPosition || !dialogRef.current) return
 
-    const modalElement = modalRef.current
-    const modalRect = modalElement.getBoundingClientRect()
+    const modalRect = dialogRef.current.getBoundingClientRect()
     const viewportHeight = window.innerHeight
     const viewportWidth = window.innerWidth
 
@@ -547,6 +550,12 @@ export const MapLayersListModal: React.FC<{
           }}
           className="m-0 p-0"
         >
+          {/* Invisible inner anchor for getBoundingClientRect — the outer
+              wrapper div is position:fixed and may report 0x0 */}
+          <div
+            ref={dialogRef}
+            style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}
+          />
           <div
             className="custom-scrollbar flex-grow"
             style={{

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -181,8 +181,8 @@ const TreeItem: React.FC<TreeItemProps> = ({
               aria-label="Center map on station"
               title="Center map on this station"
               style={{
-                width: '26px',
-                height: '26px',
+                width: '22px',
+                height: '22px',
                 flexShrink: 0,
                 borderRadius: '3px',
                 background: '#fff',

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -450,6 +450,7 @@ export const MapLayersListModal: React.FC<{
           onClose={handleClose}
           snapTo={!modalPosition ? 'top-left' : undefined}
           open
+          allowPointerEventsOnChildren
           fullWidthBody={true}
           style={{
             maxHeight: '70vh',

--- a/apps/lrauv-dash2/components/MapLayersListModal.tsx
+++ b/apps/lrauv-dash2/components/MapLayersListModal.tsx
@@ -265,13 +265,23 @@ export const MapLayersListModal: React.FC<{
   >(anchorPosition)
   const [isFadingOut, setIsFadingOut] = useState(false)
   const modalRef = useRef<HTMLDivElement>(null)
+  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const handleClose = useCallback(() => {
+    if (isFadingOut) return
     setIsFadingOut(true)
-    setTimeout(() => {
+    setHighlightedStationName(null)
+    closeTimerRef.current = setTimeout(() => {
       onClose()
     }, 250)
-  }, [onClose])
+  }, [isFadingOut, onClose, setHighlightedStationName])
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+    }
+  }, [])
 
   // Click-outside to dismiss
   useEffect(() => {
@@ -575,7 +585,15 @@ export const MapLayersListModal: React.FC<{
                         }
                       }}
                       isStarred={starredStations.includes(station.name)}
-                      onStarClick={() => toggleStarStation(station.name)}
+                      onStarClick={() => {
+                        const isCurrentlyStarred = starredStations.includes(
+                          station.name
+                        )
+                        if (isCurrentlyStarred) {
+                          setHighlightedStationName(null)
+                        }
+                        toggleStarStation(station.name)
+                      }}
                       onMouseEnterStar={() => {
                         if (starredStations.includes(station.name)) {
                           setHighlightedStationName(station.name)
@@ -615,7 +633,7 @@ export const MapLayersListModal: React.FC<{
           >
             <div className="flex justify-end pr-3">
               <button
-                onClick={onClose}
+                onClick={handleClose}
                 className="rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-800"
                 style={{
                   marginRight: '20px',

--- a/apps/lrauv-dash2/components/SelectedStationContext.tsx
+++ b/apps/lrauv-dash2/components/SelectedStationContext.tsx
@@ -30,6 +30,10 @@ export interface SelectedStationsContextProps {
   toggleStarStation: (name: string) => void
   highlightedStationName: string | null
   setHighlightedStationName: React.Dispatch<React.SetStateAction<string | null>>
+  flyToRequest: { lat: number; lon: number } | null
+  setFlyToRequest: React.Dispatch<
+    React.SetStateAction<{ lat: number; lon: number } | null>
+  >
   debug: {
     providerId: string
     instanceCount: number
@@ -79,6 +83,11 @@ export const SelectedStationsProvider: React.FC<{
   const [highlightedStationName, setHighlightedStationName] = useState<
     string | null
   >(null)
+
+  const [flyToRequest, setFlyToRequest] = useState<{
+    lat: number
+    lon: number
+  } | null>(null)
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -225,6 +234,8 @@ export const SelectedStationsProvider: React.FC<{
         toggleStarStation,
         highlightedStationName,
         setHighlightedStationName,
+        flyToRequest,
+        setFlyToRequest,
         debug: {
           providerId,
           instanceCount: instanceCounter,

--- a/apps/lrauv-dash2/components/SelectedStationContext.tsx
+++ b/apps/lrauv-dash2/components/SelectedStationContext.tsx
@@ -26,6 +26,10 @@ export interface SelectedStationsContextProps {
   selectedStations: Station[]
   setSelectedStations: React.Dispatch<React.SetStateAction<Station[]>>
   toggleStation: (station: Station) => void
+  starredStations: string[]
+  toggleStarStation: (name: string) => void
+  highlightedStationName: string | null
+  setHighlightedStationName: React.Dispatch<React.SetStateAction<string | null>>
   debug: {
     providerId: string
     instanceCount: number
@@ -40,6 +44,7 @@ const SelectedStationsContext = createContext<
 let instanceCounter = 0
 // Key for localStorage
 const STORAGE_KEY = 'selectedStations'
+const STARRED_STORAGE_KEY = 'starredStations'
 
 export const SelectedStationsProvider: React.FC<{
   children: React.ReactNode
@@ -58,6 +63,34 @@ export const SelectedStationsProvider: React.FC<{
     }
     return []
   })
+
+  const [starredStations, setStarredStations] = useState<string[]>(() => {
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = localStorage.getItem(STARRED_STORAGE_KEY)
+        return stored ? JSON.parse(stored) : []
+      } catch {
+        return []
+      }
+    }
+    return []
+  })
+
+  const [highlightedStationName, setHighlightedStationName] = useState<
+    string | null
+  >(null)
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STARRED_STORAGE_KEY, JSON.stringify(starredStations))
+    }
+  }, [starredStations])
+
+  const toggleStarStation = (name: string) => {
+    setStarredStations((prev) =>
+      prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]
+    )
+  }
 
   const providerId = useRef(
     `provider-${Date.now()}-${++instanceCounter}`
@@ -188,6 +221,10 @@ export const SelectedStationsProvider: React.FC<{
         selectedStations,
         setSelectedStations,
         toggleStation,
+        starredStations,
+        toggleStarStation,
+        highlightedStationName,
+        setHighlightedStationName,
         debug: {
           providerId,
           instanceCount: instanceCounter,

--- a/apps/lrauv-dash2/components/SelectedStationContext.tsx
+++ b/apps/lrauv-dash2/components/SelectedStationContext.tsx
@@ -99,6 +99,46 @@ export const SelectedStationsProvider: React.FC<{
     }
   }, [starredStations])
 
+  // Sync starredStations across tabs and on tab re-focus (mirrors the
+  // selectedStations cross-tab sync logic already present in this provider).
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const parseStarred = (raw: string | null): string[] => {
+      try {
+        if (!raw) return []
+        const parsed = JSON.parse(raw)
+        return Array.isArray(parsed) ? parsed : []
+      } catch {
+        return []
+      }
+    }
+
+    const handleStorageChange = (e: StorageEvent) => {
+      if (e.key !== STARRED_STORAGE_KEY) return
+      const next = parseStarred(e.newValue)
+      setStarredStations((current) =>
+        JSON.stringify(current) === JSON.stringify(next) ? current : next
+      )
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        const next = parseStarred(localStorage.getItem(STARRED_STORAGE_KEY))
+        setStarredStations((current) =>
+          JSON.stringify(current) === JSON.stringify(next) ? current : next
+        )
+      }
+    }
+
+    window.addEventListener('storage', handleStorageChange)
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+    return () => {
+      window.removeEventListener('storage', handleStorageChange)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [])
+
   const toggleStarStation = (name: string) => {
     setStarredStations((prev) =>
       prev.includes(name) ? prev.filter((n) => n !== name) : [...prev, name]

--- a/apps/lrauv-dash2/components/SelectedStationContext.tsx
+++ b/apps/lrauv-dash2/components/SelectedStationContext.tsx
@@ -72,7 +72,11 @@ export const SelectedStationsProvider: React.FC<{
     if (typeof window !== 'undefined') {
       try {
         const stored = localStorage.getItem(STARRED_STORAGE_KEY)
-        return stored ? JSON.parse(stored) : []
+        if (!stored) {
+          return []
+        }
+        const parsed = JSON.parse(stored)
+        return Array.isArray(parsed) ? parsed : []
       } catch {
         return []
       }

--- a/apps/lrauv-dash2/components/StationMarker.tsx
+++ b/apps/lrauv-dash2/components/StationMarker.tsx
@@ -72,7 +72,8 @@ const StationMarker: React.FC<StationMarkerProps> = ({
             />
           </>
         )}
-        {/* Geographic radius circle — rendered in meters on the map */}
+        {/* Geographic radius circle — non-interactive so it doesn't block
+            pan/drag or create a huge hover target; tooltip lives on center dot */}
         <Circle
           center={[lat, lng]}
           radius={radiusMeters}
@@ -80,10 +81,10 @@ const StationMarker: React.FC<StationMarkerProps> = ({
           weight={2}
           fillColor={CIRCLE_STATION_COLOR}
           fillOpacity={0.08}
-        >
-          {tooltip}
-        </Circle>
-        {/* Small center dot so the station is still click/hover-able */}
+          interactive={false}
+          pathOptions={{ interactive: false }}
+        />
+        {/* Small center dot — the only interactive element; carries the tooltip */}
         <CircleMarker
           center={[lat, lng]}
           radius={4}

--- a/apps/lrauv-dash2/components/StationMarker.tsx
+++ b/apps/lrauv-dash2/components/StationMarker.tsx
@@ -26,7 +26,8 @@ const StationMarker: React.FC<StationMarkerProps> = ({
             color="red"
             weight={2}
             fillOpacity={0}
-            pathOptions={{ dashArray: '6 5' }}
+            pathOptions={{ dashArray: '6 5', interactive: false }}
+            interactive={false}
           />
           {/* Inner yellow dashed spotlight ring */}
           <CircleMarker
@@ -36,7 +37,8 @@ const StationMarker: React.FC<StationMarkerProps> = ({
             color="#FFD700"
             weight={2}
             fillOpacity={0}
-            pathOptions={{ dashArray: '6 5' }}
+            pathOptions={{ dashArray: '6 5', interactive: false }}
+            interactive={false}
           />
         </>
       )}

--- a/apps/lrauv-dash2/components/StationMarker.tsx
+++ b/apps/lrauv-dash2/components/StationMarker.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { CircleMarker, Tooltip } from 'react-leaflet'
+import { Circle, CircleMarker, Tooltip } from 'react-leaflet'
+
+// Matches names like "MARS 1km Circle", "MARS 2km Circle", "Foo 0.5km Circle"
+const KM_CIRCLE_PATTERN = /(\d+(?:\.\d+)?)\s*km\s*circle/i
+
+const CIRCLE_STATION_COLOR = '#cc44cc'
 
 interface StationMarkerProps {
   name: string
@@ -14,6 +19,85 @@ const StationMarker: React.FC<StationMarkerProps> = ({
   lng,
   isHighlighted = false,
 }) => {
+  const kmMatch = name.match(KM_CIRCLE_PATTERN)
+  const radiusMeters = kmMatch ? parseFloat(kmMatch[1]) * 1000 : null
+
+  const tooltip = (
+    <Tooltip>
+      <span>
+        {name}
+        <br />
+        Latitude: {lat}
+        <br />
+        Longitude: {lng}
+        {radiusMeters != null && (
+          <>
+            <br />
+            Radius:{' '}
+            {radiusMeters >= 1000
+              ? `${radiusMeters / 1000} km`
+              : `${radiusMeters} m`}
+          </>
+        )}
+      </span>
+    </Tooltip>
+  )
+
+  if (radiusMeters != null) {
+    return (
+      <>
+        {isHighlighted && (
+          <>
+            {/* Outer red dashed spotlight ring */}
+            <CircleMarker
+              center={[lat, lng]}
+              radius={28}
+              fillColor="transparent"
+              color="red"
+              weight={2}
+              fillOpacity={0}
+              pathOptions={{ dashArray: '6 5', interactive: false }}
+              interactive={false}
+            />
+            {/* Inner yellow dashed spotlight ring */}
+            <CircleMarker
+              center={[lat, lng]}
+              radius={14}
+              fillColor="transparent"
+              color="#FFD700"
+              weight={2}
+              fillOpacity={0}
+              pathOptions={{ dashArray: '6 5', interactive: false }}
+              interactive={false}
+            />
+          </>
+        )}
+        {/* Geographic radius circle — rendered in meters on the map */}
+        <Circle
+          center={[lat, lng]}
+          radius={radiusMeters}
+          color={CIRCLE_STATION_COLOR}
+          weight={2}
+          fillColor={CIRCLE_STATION_COLOR}
+          fillOpacity={0.08}
+        >
+          {tooltip}
+        </Circle>
+        {/* Small center dot so the station is still click/hover-able */}
+        <CircleMarker
+          center={[lat, lng]}
+          radius={4}
+          color={CIRCLE_STATION_COLOR}
+          fillColor={CIRCLE_STATION_COLOR}
+          fillOpacity={0.9}
+          weight={1}
+        >
+          {tooltip}
+        </CircleMarker>
+      </>
+    )
+  }
+
   return (
     <>
       {isHighlighted && (
@@ -43,22 +127,13 @@ const StationMarker: React.FC<StationMarkerProps> = ({
         </>
       )}
       <CircleMarker
-        key={name}
         center={[lat, lng]}
         radius={5}
         fillColor="transparent"
         color="yellow"
         fillOpacity={1}
       >
-        <Tooltip>
-          <span>
-            {name}
-            <br />
-            Latitude: {lat}
-            <br />
-            Longitude: {lng}
-          </span>
-        </Tooltip>
+        {tooltip}
       </CircleMarker>
     </>
   )

--- a/apps/lrauv-dash2/components/StationMarker.tsx
+++ b/apps/lrauv-dash2/components/StationMarker.tsx
@@ -28,12 +28,12 @@ const StationMarker: React.FC<StationMarkerProps> = ({
             fillOpacity={0}
             pathOptions={{ dashArray: '6 5' }}
           />
-          {/* Inner orange dashed spotlight ring */}
+          {/* Inner yellow dashed spotlight ring */}
           <CircleMarker
             center={[lat, lng]}
             radius={14}
             fillColor="transparent"
-            color="#F57C00"
+            color="#FFD700"
             weight={2}
             fillOpacity={0}
             pathOptions={{ dashArray: '6 5' }}

--- a/apps/lrauv-dash2/components/StationMarker.tsx
+++ b/apps/lrauv-dash2/components/StationMarker.tsx
@@ -5,28 +5,60 @@ interface StationMarkerProps {
   name: string
   lat: number
   lng: number
+  isHighlighted?: boolean
 }
 
-const StationMarker: React.FC<StationMarkerProps> = ({ name, lat, lng }) => {
+const StationMarker: React.FC<StationMarkerProps> = ({
+  name,
+  lat,
+  lng,
+  isHighlighted = false,
+}) => {
   return (
-    <CircleMarker
-      key={name}
-      center={[lat, lng]}
-      radius={5}
-      fillColor="transparent"
-      color="yellow"
-      fillOpacity={1}
-    >
-      <Tooltip>
-        <span>
-          {name}
-          <br />
-          Latitude: {lat}
-          <br />
-          Longitude: {lng}
-        </span>
-      </Tooltip>
-    </CircleMarker>
+    <>
+      {isHighlighted && (
+        <>
+          {/* Outer red dashed spotlight ring */}
+          <CircleMarker
+            center={[lat, lng]}
+            radius={28}
+            fillColor="transparent"
+            color="red"
+            weight={2}
+            fillOpacity={0}
+            pathOptions={{ dashArray: '6 5' }}
+          />
+          {/* Inner yellow dashed spotlight ring */}
+          <CircleMarker
+            center={[lat, lng]}
+            radius={14}
+            fillColor="transparent"
+            color="#FFD700"
+            weight={2}
+            fillOpacity={0}
+            pathOptions={{ dashArray: '6 5' }}
+          />
+        </>
+      )}
+      <CircleMarker
+        key={name}
+        center={[lat, lng]}
+        radius={5}
+        fillColor="transparent"
+        color="yellow"
+        fillOpacity={1}
+      >
+        <Tooltip>
+          <span>
+            {name}
+            <br />
+            Latitude: {lat}
+            <br />
+            Longitude: {lng}
+          </span>
+        </Tooltip>
+      </CircleMarker>
+    </>
   )
 }
 

--- a/apps/lrauv-dash2/components/StationMarker.tsx
+++ b/apps/lrauv-dash2/components/StationMarker.tsx
@@ -28,12 +28,12 @@ const StationMarker: React.FC<StationMarkerProps> = ({
             fillOpacity={0}
             pathOptions={{ dashArray: '6 5' }}
           />
-          {/* Inner yellow dashed spotlight ring */}
+          {/* Inner orange dashed spotlight ring */}
           <CircleMarker
             center={[lat, lng]}
             radius={14}
             fillColor="transparent"
-            color="#FFD700"
+            color="#F57C00"
             weight={2}
             fillOpacity={0}
             pathOptions={{ dashArray: '6 5' }}

--- a/apps/lrauv-dash2/package.json
+++ b/apps/lrauv-dash2/package.json
@@ -20,6 +20,7 @@
     "@mbari/api-client": "*",
     "@mbari/react-ui": "*",
     "@react-google-maps/api": "^2.18.1",
+    "@tippyjs/react": "^4.2.0",
     "@tiptap/core": "3.13.0",
     "@tiptap/extension-color": "3.13.0",
     "@tiptap/extension-highlight": "3.13.0",

--- a/apps/lrauv-dash2/package.json
+++ b/apps/lrauv-dash2/package.json
@@ -21,6 +21,7 @@
     "@mbari/react-ui": "*",
     "@react-google-maps/api": "^2.18.1",
     "@tippyjs/react": "^4.2.0",
+    "tippy.js": "^6.3.7",
     "@tiptap/core": "3.13.0",
     "@tiptap/extension-color": "3.13.0",
     "@tiptap/extension-highlight": "3.13.0",

--- a/apps/lrauv-dash2/pages/_app.tsx
+++ b/apps/lrauv-dash2/pages/_app.tsx
@@ -1,5 +1,6 @@
 import '@mbari/react-ui/dist/mbari-ui.css'
 import 'react-quill/dist/quill.snow.css'
+import 'tippy.js/dist/tippy.css'
 import { config } from '@fortawesome/fontawesome-svg-core'
 import '@fortawesome/fontawesome-svg-core/styles.css'
 import 'leaflet/dist/leaflet.css'


### PR DESCRIPTION
## Summary

Adds Dash4 parity features to the Map Layers panel for Stations:

- **Star toggle** — each station row has a circular star badge (white circle, drop shadow, matching Dash4 style). Click to turn it gold/yellow (starred); click again to gray out (unstarred). Starred state persists in `localStorage`.
- **Spotlight on hover** — hovering over a **gold** star highlights that station on the map with two dashed rings: inner yellow and outer red, both centered on the station. Hovering a gray (unstarred) star does nothing.
- **Center-map button** — a rectangular button with `faArrowsToCircle` icon appears after each station name. Clicking it smoothly `flyTo`s the map to that station's coordinates (zooms to at least level 13).
- **Starred stations sort to top** — when a star is activated, that station immediately floats to the top of the list sorted alphabetically among starred stations. Un-starring returns it to its original API order below.
- **Click-outside to dismiss** — clicking anywhere outside the Layers panel fades it closed (0.25s opacity transition). The closing `mousedown` lets Leaflet begin a pan/drag immediately; the paired `click` is consumed to prevent accidental map actions (waypoint placement, etc.). Subsequent gestures during the fade pass through freely.
- **Tippy tooltips** — both buttons show context-sensitive tooltips anchored top-start.
- **Geographic radius circles for "X km Circle" stations** — stations whose names match the pattern `"X km Circle"` (e.g. `MARS 1km Circle`, `MARS 2km Circle`) are rendered as a geographic `Circle` overlay (purple, correct radius in meters) centered on the station coordinates rather than as a plain dot. This matches the Dash4 behavior where these stations appear as concentric purple rings around M1/MARS Node on the map. A small center dot is also drawn for hover/tooltip access. All other stations render as before.

## Files changed

- `apps/lrauv-dash2/components/SelectedStationContext.tsx` — added `starredStations`, `toggleStarStation`, `highlightedStationName`, `setHighlightedStationName`, `flyToRequest`, `setFlyToRequest`
- `apps/lrauv-dash2/components/MapLayersListModal.tsx` — star badge, center button, sort logic, click-outside fade-close
- `apps/lrauv-dash2/components/StationMarker.tsx` — `isHighlighted` spotlight rings; km-circle geographic rendering
- `apps/lrauv-dash2/components/DeploymentMap.tsx` — passes `isHighlighted`, adds dynamic `MapFlyTo` child component
- `apps/lrauv-dash2/components/MapFlyTo.tsx` — new file; extracted from `DeploymentMap` as a separate `dynamic({ssr:false})` component to avoid SSR Leaflet import at module scope
- `apps/lrauv-dash2/package.json` — adds `@tippyjs/react` as an explicit direct dependency

## Test plan
- [ ] Open Layers panel → expand Stations → verify star badge appears before each name
- [ ] Click a star → turns gold → station moves to top of list
- [ ] Hover gold star → double dashed rings appear on map at that station
- [ ] Hover gray star → no rings appear
- [ ] Click center button → map smoothly flies to that station
- [ ] Check **MARS 1km Circle** and **MARS 2km Circle** → purple geographic circles appear on map at correct scale
- [ ] Click outside the Layers panel → modal fades closed, map is immediately interactive (can pan on same gesture)
- [ ] Reload page → starred stations persist and appear at top

Closes #520
