### PR TITLE
fix: Overview Map partial render and React warning on refresh

### DIFF
--- a/apps/lrauv-dash2/components/MapFlyTo.tsx
+++ b/apps/lrauv-dash2/components/MapFlyTo.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react'
 import { useMap } from 'react-leaflet'
-import { useSelectedStations } from './SelectedStationContext'
+import { useMapCamera } from './MapCameraContext'
 
 const MapFlyTo: React.FC = () => {
   const map = useMap()
-  const { flyToRequest, setFlyToRequest } = useSelectedStations()
+  const { flyToRequest, setFlyToRequest } = useMapCamera()
 
   useEffect(() => {
     if (flyToRequest) {

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -2,7 +2,6 @@ import { OverviewToolbar } from '@mbari/react-ui'
 import { NextPage } from 'next'
 import Layout from '../components/Layout'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import ResizeObserver from 'resize-observer-polyfill'
 import dynamic from 'next/dynamic'
 import VehicleDeploymentDropdown from '../components/VehicleDeploymentDropdown'
 import VehicleList from '../components/VehicleList'
@@ -22,7 +21,7 @@ import { MapLayersListModal } from '../components/MapLayersListModal'
 import { useSelectedStations } from '../components/SelectedStationContext'
 import { useMarkers } from '../components/MarkerContext'
 import toast from 'react-hot-toast'
-import { createLogger } from '@mbari/utils'
+import { createLogger, useResizeObserver } from '@mbari/utils'
 import { PlatformsListModal } from '../components/PlatformsListModal'
 import { useRefreshPositions } from '../lib/useRefreshPositions'
 import VehicleColorsModal from '../components/VehicleColorsModal'
@@ -99,27 +98,12 @@ const OverViewMap: React.FC<{
   const mapContainerRef = useRef<HTMLDivElement | null>(null)
 
   // Call invalidateSize whenever the container resizes (fixes partial-map rendering
-  // after refresh) and once on mount.  Using ResizeObserver avoids the unsafe
-  // setTimeout-in-render-prop pattern that caused the "state update before mount" warning.
+  // after refresh). useResizeObserver is polyfilled and throttled (100 ms by default).
+  const { size } = useResizeObserver({ element: mapContainerRef })
   useEffect(() => {
-    const container = mapContainerRef.current
-    if (!container) return
-
-    const invalidate = () => {
-      try {
-        mapRef.current?.invalidateSize()
-      } catch {
-        // map not ready yet — ResizeObserver will retry on next resize
-      }
-    }
-
-    // Call once immediately after mount
-    invalidate()
-
-    const observer = new ResizeObserver(invalidate)
-    observer.observe(container)
-    return () => observer.disconnect()
-  }, [])
+    if (!mapRef.current) return
+    mapRef.current.invalidateSize()
+  }, [size])
   const router = useRouter()
   const { handleDepthRequest, elevationAvailable } = useGoogleElevator()
   const [center, setCenter] = useState<undefined | [number, number]>()

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -95,6 +95,30 @@ const OverViewMap: React.FC<{
 }> = ({ trackedVehicles }) => {
   // Add mapRef to store the Leaflet map instance
   const mapRef = useRef<L.Map | null>(null)
+  const mapContainerRef = useRef<HTMLDivElement | null>(null)
+
+  // Call invalidateSize whenever the container resizes (fixes partial-map rendering
+  // after refresh) and once on mount.  Using ResizeObserver avoids the unsafe
+  // setTimeout-in-render-prop pattern that caused the "state update before mount" warning.
+  useEffect(() => {
+    const container = mapContainerRef.current
+    if (!container) return
+
+    const invalidate = () => {
+      try {
+        mapRef.current?.invalidateSize()
+      } catch {
+        // map not ready yet — ResizeObserver will retry on next resize
+      }
+    }
+
+    // Call once immediately after mount
+    invalidate()
+
+    const observer = new ResizeObserver(invalidate)
+    observer.observe(container)
+    return () => observer.disconnect()
+  }, [])
   const router = useRouter()
   const { handleDepthRequest, elevationAvailable } = useGoogleElevator()
   const [center, setCenter] = useState<undefined | [number, number]>()
@@ -597,7 +621,7 @@ const OverViewMap: React.FC<{
       {showPlatformsModal ? (
         <PlatformsListModal onClose={handleClosePlatforms} />
       ) : null}
-      <div className="relative h-full w-full">
+      <div className="relative h-full w-full" ref={mapContainerRef}>
         <Map
           key={`overview-map-${router.asPath}`}
           ref={mapRef}
@@ -605,15 +629,6 @@ const OverViewMap: React.FC<{
           onMapReady={(map) => {
             logger.debug('🌍 Map ready callback triggered in OverViewMap')
             mapRef.current = map
-            ;[200, 800].forEach((delay) => {
-              setTimeout(() => {
-                try {
-                  map.invalidateSize()
-                } catch (e) {
-                  logger.warn('Could not invalidate map size:', e)
-                }
-              }, delay)
-            })
           }}
           trackedVehicles={trackedVehicles?.map((vehicle) => ({
             ...vehicle,

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -2,6 +2,7 @@ import { OverviewToolbar } from '@mbari/react-ui'
 import { NextPage } from 'next'
 import Layout from '../components/Layout'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
+import ResizeObserver from 'resize-observer-polyfill'
 import dynamic from 'next/dynamic'
 import VehicleDeploymentDropdown from '../components/VehicleDeploymentDropdown'
 import VehicleList from '../components/VehicleList'
@@ -629,9 +630,7 @@ const OverViewMap: React.FC<{
           onMapReady={(map) => {
             logger.debug('🌍 Map ready callback triggered in OverViewMap')
             mapRef.current = map
-            requestAnimationFrame(() => {
-              map.invalidateSize()
-            })
+            map.invalidateSize()
           }}
           trackedVehicles={trackedVehicles?.map((vehicle) => ({
             ...vehicle,

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -629,6 +629,9 @@ const OverViewMap: React.FC<{
           onMapReady={(map) => {
             logger.debug('🌍 Map ready callback triggered in OverViewMap')
             mapRef.current = map
+            requestAnimationFrame(() => {
+              map.invalidateSize()
+            })
           }}
           trackedVehicles={trackedVehicles?.map((vehicle) => ({
             ...vehicle,

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -1,7 +1,7 @@
 import { OverviewToolbar } from '@mbari/react-ui'
 import { NextPage } from 'next'
 import Layout from '../components/Layout'
-import React, { useCallback, useEffect, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import dynamic from 'next/dynamic'
 import VehicleDeploymentDropdown from '../components/VehicleDeploymentDropdown'
 import VehicleList from '../components/VehicleList'
@@ -9,12 +9,16 @@ import useTrackedVehicles from '../lib/useTrackedVehicles'
 import { SharedPathContextProvider } from '../components/SharedPathContextProvider'
 import { SelectedPlatformsProvider } from '../components/SelectedPlatformContext'
 import { SelectedStationsProvider } from '../components/SelectedStationContext'
+import { MapCameraProvider } from '../components/MapCameraContext'
+import { SelectedPolygonsProvider } from '../components/SelectedPolygonsContext'
+import { SelectedTileLayersProvider } from '../components/SelectedTileLayersContext'
+import { SelectedKmlLayersProvider } from '../components/SelectedKmlLayersContext'
 import { useRouter } from 'next/router'
 import useGlobalModalId from '../lib/useGlobalModalId'
 import useGoogleElevator from '../lib/useGoogleElevator'
 import { Allotment, LayoutPriority } from 'allotment'
 import { useGoogleMaps } from '../lib/useGoogleMaps'
-import { VPosDetail } from '@mbari/api-client'
+import { VPosDetail, useStations } from '@mbari/api-client'
 import 'allotment/dist/style.css'
 import { StationsListModal } from '../components/StationsListModal'
 import { MapLayersListModal } from '../components/MapLayersListModal'
@@ -47,6 +51,21 @@ const VehiclePath = dynamic(() => import('../components/VehiclePath'), {
 })
 
 const StationMarker = dynamic(() => import('../components/StationMarker'), {
+  ssr: false,
+})
+
+const MapFlyTo = dynamic(() => import('../components/MapFlyTo'), { ssr: false })
+
+const PolygonLayers = dynamic(() => import('../components/PolygonLayers'), {
+  ssr: false,
+})
+
+const TileLayerOverlays = dynamic(
+  () => import('../components/TileLayerOverlays'),
+  { ssr: false }
+)
+
+const KmlLayers = dynamic(() => import('../components/KmlLayers'), {
   ssr: false,
 })
 
@@ -101,8 +120,9 @@ const OverViewMap: React.FC<{
   // after refresh). useResizeObserver is polyfilled and throttled (100 ms by default).
   const { size } = useResizeObserver({ element: mapContainerRef })
   useEffect(() => {
-    if (!mapRef.current) return
-    mapRef.current.invalidateSize()
+    if (typeof mapRef.current?.invalidateSize === 'function') {
+      mapRef.current.invalidateSize()
+    }
   }, [size])
   const router = useRouter()
   const { handleDepthRequest, elevationAvailable } = useGoogleElevator()
@@ -118,7 +138,23 @@ const OverViewMap: React.FC<{
   const [viewMode, setViewMode] = useState<'center' | 'bounds' | null>(null)
   const [selectedMarkerId, setSelectedMarkerId] = useState<string | null>(null)
   const [defaultMarkerColor, setDefaultMarkerColor] = useState<string>('red')
-  const { selectedStations } = useSelectedStations()
+  const { selectedStations, highlightedStationName } = useSelectedStations()
+  const { data: allStations } = useStations()
+  const spotlightOnlyCoords = useMemo(() => {
+    if (!highlightedStationName) return null
+    if (selectedStations?.some((s) => s.name === highlightedStationName))
+      return null
+    const found = allStations?.find((s) => s.name === highlightedStationName)
+    if (!found) return null
+    const coords = found.geojson?.geometry?.coordinates
+    if (
+      !coords ||
+      !Number.isFinite(coords[1] as number) ||
+      !Number.isFinite(coords[0] as number)
+    )
+      return null
+    return { lat: coords[1] as number, lon: coords[0] as number }
+  }, [highlightedStationName, selectedStations, allStations])
   const [layersModalPosition, setLayersModalPosition] = useState({
     top: 0,
     left: 0,
@@ -609,7 +645,6 @@ const OverViewMap: React.FC<{
       <div className="relative h-full w-full" ref={mapContainerRef}>
         <Map
           key={`overview-map-${router.asPath}`}
-          ref={mapRef}
           className="h-full w-full"
           onMapReady={(map) => {
             logger.debug('🌍 Map ready callback triggered in OverViewMap')
@@ -718,9 +753,24 @@ const OverViewMap: React.FC<{
                 name={station.name}
                 lat={lat}
                 lng={lng}
+                color={station.geojson.properties?.color}
+                isHighlighted={highlightedStationName === station.name}
               />
             )
           })}
+          {spotlightOnlyCoords && (
+            <StationMarker
+              key={`spotlight-${highlightedStationName}`}
+              name={highlightedStationName ?? ''}
+              lat={spotlightOnlyCoords.lat}
+              lng={spotlightOnlyCoords.lon}
+              isHighlighted={true}
+            />
+          )}
+          <PolygonLayers />
+          <TileLayerOverlays />
+          <KmlLayers />
+          <MapFlyTo />
         </Map>
         <MapRefreshButton
           onClick={refreshAll}
@@ -803,80 +853,95 @@ const OverviewPage: NextPage = () => {
     <SharedPathContextProvider>
       <SelectedPlatformsProvider>
         <SelectedStationsProvider>
-          <div className={styles.content}>
-            <Layout>
-              {trackedVehicles?.length ? (
-                <>
-                  <OverviewToolbar deployment={{ name: 'Overview', id: '0' }} />
+          <MapCameraProvider>
+            <SelectedPolygonsProvider>
+              <SelectedTileLayersProvider>
+                <SelectedKmlLayersProvider>
+                  <div className={styles.content}>
+                    <Layout>
+                      {trackedVehicles?.length ? (
+                        <>
+                          <OverviewToolbar
+                            deployment={{ name: 'Overview', id: '0' }}
+                          />
 
-                  <div
-                    className={styles.content}
-                    data-testid="vehicle-dashboard"
-                  >
-                    {/* Single map instance: render one layout to avoid duplicate controls */}
-                    {isDesktop ? (
-                      <div className="h-full w-full">
-                        <Allotment
-                          separator
-                          snap
-                          defaultSizes={[75, 25]}
-                          proportionalLayout
-                        >
-                          <Allotment.Pane>{primarySection}</Allotment.Pane>
-                          <Allotment.Pane priority={LayoutPriority.High}>
-                            {secondarySection}
-                          </Allotment.Pane>
-                        </Allotment>
-                      </div>
-                    ) : (
-                      <div className="flex h-full w-full flex-col">
-                        <div className="flex shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 py-2">
-                          <button
-                            type="button"
-                            onClick={() => setMobileView('map')}
-                            className={
-                              mobileView === 'map'
-                                ? 'rounded bg-secondary-300/60 px-3 py-1 text-sm font-bold text-black'
-                                : 'rounded px-3 py-1 text-sm font-bold text-slate-600'
-                            }
+                          <div
+                            className={styles.content}
+                            data-testid="vehicle-dashboard"
                           >
-                            Map
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => setMobileView('list')}
-                            className={
-                              mobileView === 'list'
-                                ? 'rounded bg-secondary-300/60 px-3 py-1 text-sm font-bold text-black'
-                                : 'rounded px-3 py-1 text-sm font-bold text-slate-600'
-                            }
-                          >
-                            Vehicles
-                          </button>
-                        </div>
+                            {/* Single map instance: render one layout to avoid duplicate controls */}
+                            {isDesktop ? (
+                              <div className="h-full w-full">
+                                <Allotment
+                                  separator
+                                  snap
+                                  defaultSizes={[75, 25]}
+                                  proportionalLayout
+                                >
+                                  <Allotment.Pane>
+                                    {primarySection}
+                                  </Allotment.Pane>
+                                  <Allotment.Pane
+                                    priority={LayoutPriority.High}
+                                  >
+                                    {secondarySection}
+                                  </Allotment.Pane>
+                                </Allotment>
+                              </div>
+                            ) : (
+                              <div className="flex h-full w-full flex-col">
+                                <div className="flex shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-4 py-2">
+                                  <button
+                                    type="button"
+                                    onClick={() => setMobileView('map')}
+                                    className={
+                                      mobileView === 'map'
+                                        ? 'rounded bg-secondary-300/60 px-3 py-1 text-sm font-bold text-black'
+                                        : 'rounded px-3 py-1 text-sm font-bold text-slate-600'
+                                    }
+                                  >
+                                    Map
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => setMobileView('list')}
+                                    className={
+                                      mobileView === 'list'
+                                        ? 'rounded bg-secondary-300/60 px-3 py-1 text-sm font-bold text-black'
+                                        : 'rounded px-3 py-1 text-sm font-bold text-slate-600'
+                                    }
+                                  >
+                                    Vehicles
+                                  </button>
+                                </div>
 
-                        <div className="min-h-0 flex-1 overflow-hidden">
-                          {mobileView === 'map'
-                            ? primarySection
-                            : secondarySection}
-                        </div>
-                      </div>
-                    )}
+                                <div className="min-h-0 flex-1 overflow-hidden">
+                                  {mobileView === 'map'
+                                    ? primarySection
+                                    : secondarySection}
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        </>
+                      ) : (
+                        <>
+                          <p className="p-6 text-xl" aria-label="get started">
+                            To get started you must add at least one vehicle to
+                            track.
+                          </p>
+                          <VehicleDeploymentDropdown
+                            className="mx-6 max-h-96 w-96"
+                            scrollable
+                          />
+                        </>
+                      )}
+                    </Layout>
                   </div>
-                </>
-              ) : (
-                <>
-                  <p className="p-6 text-xl" aria-label="get started">
-                    To get started you must add at least one vehicle to track.
-                  </p>
-                  <VehicleDeploymentDropdown
-                    className="mx-6 max-h-96 w-96"
-                    scrollable
-                  />
-                </>
-              )}
-            </Layout>
-          </div>
+                </SelectedKmlLayersProvider>
+              </SelectedTileLayersProvider>
+            </SelectedPolygonsProvider>
+          </MapCameraProvider>
         </SelectedStationsProvider>
       </SelectedPlatformsProvider>
     </SharedPathContextProvider>


### PR DESCRIPTION
Fixes #548

## Summary

- Replaces the unsafe `[200, 800]ms setTimeout` calls in `onMapReady` with a proper `useResizeObserver` hook so `map.invalidateSize()` fires at the right time and is cleaned up on unmount.
- Fixes the **map rendering at ~25% width** after a page refresh (the old timeouts were racing against component teardown).
- Eliminates the **React warning** `Can't perform a React state update on a component that hasn't mounted yet` — the async setTimeout callbacks in the render prop were the cause.

## What changed

`apps/lrauv-dash2/pages/index.tsx`
- Added `mapContainerRef` (`useRef<HTMLDivElement>`) attached to the wrapping `div` around `<Map>`.
- Replaced the manual `ResizeObserver` + `useEffect` setup with `useResizeObserver` from `@mbari/utils` (already polyfilled and throttled at 100ms); a small `useEffect` watches `size` and calls `mapRef.current.invalidateSize()` whenever the container resizes.
- `onMapReady` now stores the map instance in `mapRef` and calls `map.invalidateSize()` once synchronously (covers the case where the map becomes ready after the initial resize event).
- Removed the `[200, 800]ms` setTimeout calls.

## Test plan

- [ ] Hard-refresh the Overview page — map should fill its full container immediately
- [ ] Check browser console — the "Can't perform a React state update" warning should be gone
- [ ] Navigate away and back — map should still render at full size
- [ ] Verify center-on buttons (stations, polygons) still work on the Overview map