### PR TITLE
feat: add Center Map on button to TrackDB platform list

### DIFF
--- a/apps/lrauv-dash2/components/MapLayersTreeItem.tsx
+++ b/apps/lrauv-dash2/components/MapLayersTreeItem.tsx
@@ -10,6 +10,48 @@ import {
   faCircle,
 } from '@fortawesome/free-solid-svg-icons'
 
+export interface CenterMapButtonProps {
+  label: string
+  onClick: () => void
+}
+
+export const CenterMapButton: React.FC<CenterMapButtonProps> = ({
+  label,
+  onClick,
+}) => (
+  <Tippy content={label} placement="top-start" appendTo="parent">
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        onClick()
+      }}
+      className="ml-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+      aria-label={label}
+      style={{
+        width: '20px',
+        height: '20px',
+        flexShrink: 0,
+        borderRadius: '3px',
+        background: '#fff',
+        border: 0,
+        padding: 0,
+        boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'pointer',
+      }}
+    >
+      <FontAwesomeIcon
+        icon={faArrowsToCircle}
+        style={{ color: '#6b7280', fontSize: '14.5px' }}
+      />
+    </button>
+  </Tippy>
+)
+
 export interface TreeItemProps {
   label: string
   isExpanded?: boolean
@@ -173,41 +215,7 @@ export const TreeItem: React.FC<TreeItemProps> = ({
           )}
           <span className="text-sm font-medium">{label}</span>
           {onCenterClick !== undefined && (
-            <Tippy
-              content={centerLabel}
-              placement="top-start"
-              appendTo="parent"
-            >
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.preventDefault()
-                  e.stopPropagation()
-                  onCenterClick()
-                }}
-                className="ml-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
-                aria-label={centerLabel}
-                style={{
-                  width: '20px',
-                  height: '20px',
-                  flexShrink: 0,
-                  borderRadius: '3px',
-                  background: '#fff',
-                  border: 0,
-                  padding: 0,
-                  boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
-                  display: 'inline-flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  cursor: 'pointer',
-                }}
-              >
-                <FontAwesomeIcon
-                  icon={faArrowsToCircle}
-                  style={{ color: '#6b7280', fontSize: '14.5px' }}
-                />
-              </button>
-            </Tippy>
+            <CenterMapButton label={centerLabel} onClick={onCenterClick} />
           )}
         </label>
       </div>

--- a/apps/lrauv-dash2/components/PlatformSection.tsx
+++ b/apps/lrauv-dash2/components/PlatformSection.tsx
@@ -1,13 +1,10 @@
 import React, { useMemo } from 'react'
 import clsx from 'clsx'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faArrowsToCircle,
-  faCaretRight,
-} from '@fortawesome/free-solid-svg-icons'
-import Tippy from '@tippyjs/react'
+import { faCaretRight } from '@fortawesome/free-solid-svg-icons'
 import Image from 'next/image'
 import { GetPlatformsResponse } from '@mbari/api-client'
+import { CenterMapButton } from './MapLayersTreeItem'
 
 export interface PlatformSectionProps {
   name: string
@@ -143,41 +140,10 @@ export const PlatformSection: React.FC<PlatformSectionProps> = ({
                       </span>
                     </span>
                     {onCenterClick !== undefined && (
-                      <Tippy
-                        content={`Center map on ${item.name}`}
-                        placement="top-start"
-                        appendTo="parent"
-                      >
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.preventDefault()
-                            e.stopPropagation()
-                            onCenterClick(item._id)
-                          }}
-                          className="ml-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
-                          aria-label={`Center map on ${item.name}`}
-                          style={{
-                            width: '20px',
-                            height: '20px',
-                            flexShrink: 0,
-                            borderRadius: '3px',
-                            background: '#fff',
-                            border: 0,
-                            padding: 0,
-                            boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
-                            display: 'inline-flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            cursor: 'pointer',
-                          }}
-                        >
-                          <FontAwesomeIcon
-                            icon={faArrowsToCircle}
-                            style={{ color: '#6b7280', fontSize: '14.5px' }}
-                          />
-                        </button>
-                      </Tippy>
+                      <CenterMapButton
+                        label={`Center map on ${item.name}`}
+                        onClick={() => onCenterClick(item._id)}
+                      />
                     )}
                   </label>
                 </li>

--- a/apps/lrauv-dash2/components/PlatformSection.tsx
+++ b/apps/lrauv-dash2/components/PlatformSection.tsx
@@ -1,7 +1,11 @@
 import React, { useMemo } from 'react'
 import clsx from 'clsx'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCaretRight } from '@fortawesome/free-solid-svg-icons'
+import {
+  faArrowsToCircle,
+  faCaretRight,
+} from '@fortawesome/free-solid-svg-icons'
+import Tippy from '@tippyjs/react'
 import Image from 'next/image'
 import { GetPlatformsResponse } from '@mbari/api-client'
 
@@ -15,6 +19,7 @@ export interface PlatformSectionProps {
   filterText?: string
   onlySelected?: boolean
   headerRight?: React.ReactNode
+  onCenterClick?: (platformId: string) => void
 }
 
 export const PlatformSection: React.FC<PlatformSectionProps> = ({
@@ -27,6 +32,7 @@ export const PlatformSection: React.FC<PlatformSectionProps> = ({
   filterText,
   onlySelected,
   headerRight,
+  onCenterClick,
 }) => {
   const odssApi = 'https://odss.mbari.org/odss'
 
@@ -136,6 +142,43 @@ export const PlatformSection: React.FC<PlatformSectionProps> = ({
                         ({item.abbreviation})
                       </span>
                     </span>
+                    {onCenterClick !== undefined && (
+                      <Tippy
+                        content={`Center map on ${item.name}`}
+                        placement="top-start"
+                        appendTo="parent"
+                      >
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.preventDefault()
+                            e.stopPropagation()
+                            onCenterClick(item._id)
+                          }}
+                          className="ml-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2"
+                          aria-label={`Center map on ${item.name}`}
+                          style={{
+                            width: '20px',
+                            height: '20px',
+                            flexShrink: 0,
+                            borderRadius: '3px',
+                            background: '#fff',
+                            border: 0,
+                            padding: 0,
+                            boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            cursor: 'pointer',
+                          }}
+                        >
+                          <FontAwesomeIcon
+                            icon={faArrowsToCircle}
+                            style={{ color: '#6b7280', fontSize: '14.5px' }}
+                          />
+                        </button>
+                      </Tippy>
+                    )}
                   </label>
                 </li>
               ))

--- a/apps/lrauv-dash2/components/PlatformsListModal.tsx
+++ b/apps/lrauv-dash2/components/PlatformsListModal.tsx
@@ -46,6 +46,7 @@ export const PlatformsListModal: React.FC<PlatformsListModalProps> = ({
   const handleCenterOnPlatform = useCallback(
     async (platformId: string) => {
       const odss2dashApi = siteConfig?.appConfig?.odss2dashApi
+      if (!odss2dashApi) return
       try {
         const now = new Date()
         const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
@@ -56,7 +57,7 @@ export const PlatformsListModal: React.FC<PlatformsListModalProps> = ({
             startDate: weekAgo.toISOString(),
             endDate: now.toISOString(),
           },
-          { instance: axiosInstance, baseURL: odss2dashApi ?? '' }
+          { instance: axiosInstance, baseURL: odss2dashApi }
         )
         const latest = data?.positions?.[0]
         if (

--- a/apps/lrauv-dash2/components/PlatformsListModal.tsx
+++ b/apps/lrauv-dash2/components/PlatformsListModal.tsx
@@ -5,6 +5,9 @@ import {
   getPlatformPositions,
   useTethysApiContext,
 } from '@mbari/api-client'
+import { createLogger } from '@mbari/utils'
+
+const logger = createLogger('PlatformsListModal')
 import { Modal } from '@mbari/react-ui'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretRight, faCheckCircle } from '@fortawesome/free-solid-svg-icons'
@@ -58,15 +61,13 @@ export const PlatformsListModal: React.FC<PlatformsListModalProps> = ({
         const latest = data?.positions?.[0]
         if (
           latest &&
-          latest.lat != null &&
-          latest.lon != null &&
-          !isNaN(latest.lat) &&
-          !isNaN(latest.lon)
+          Number.isFinite(latest.lat) &&
+          Number.isFinite(latest.lon)
         ) {
           setFlyToRequest({ lat: latest.lat, lon: latest.lon })
         }
-      } catch {
-        // silently ignore — platform may have no recent positions
+      } catch (err) {
+        logger.warn(`Failed to fetch position for platform ${platformId}:`, err)
       }
     },
     [axiosInstance, siteConfig, setFlyToRequest]

--- a/apps/lrauv-dash2/components/PlatformsListModal.tsx
+++ b/apps/lrauv-dash2/components/PlatformsListModal.tsx
@@ -1,10 +1,16 @@
 import React, { useState, useCallback, useMemo, useEffect } from 'react'
-import { usePlatforms, GetPlatformsResponse } from '@mbari/api-client'
+import {
+  usePlatforms,
+  GetPlatformsResponse,
+  getPlatformPositions,
+  useTethysApiContext,
+} from '@mbari/api-client'
 import { Modal } from '@mbari/react-ui'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretRight, faCheckCircle } from '@fortawesome/free-solid-svg-icons'
 import { usePlatformSelectionWorkflow } from '../lib/usePlatformSelectionWorkflow'
 import { PlatformSection } from './PlatformSection'
+import { useMapCamera } from './MapCameraContext'
 
 export interface PlatformsListModalProps {
   onClose: () => void
@@ -30,6 +36,41 @@ export const PlatformsListModal: React.FC<PlatformsListModalProps> = ({
     isLoading: platformsLoading,
     refetch: refetchPlatforms,
   } = usePlatforms({ refresh: true })
+
+  const { axiosInstance, siteConfig } = useTethysApiContext()
+  const { setFlyToRequest } = useMapCamera()
+
+  const handleCenterOnPlatform = useCallback(
+    async (platformId: string) => {
+      const odss2dashApi = siteConfig?.appConfig?.odss2dashApi
+      try {
+        const now = new Date()
+        const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+        const data = await getPlatformPositions(
+          {
+            platformId,
+            lastNumberOfFixes: 1,
+            startDate: weekAgo.toISOString(),
+            endDate: now.toISOString(),
+          },
+          { instance: axiosInstance, baseURL: odss2dashApi ?? '' }
+        )
+        const latest = data?.positions?.[0]
+        if (
+          latest &&
+          latest.lat != null &&
+          latest.lon != null &&
+          !isNaN(latest.lat) &&
+          !isNaN(latest.lon)
+        ) {
+          setFlyToRequest({ lat: latest.lat, lon: latest.lon })
+        }
+      } catch {
+        // silently ignore — platform may have no recent positions
+      }
+    },
+    [axiosInstance, siteConfig, setFlyToRequest]
+  )
 
   const [filterText, setFilterText] = useState('')
   const [onlySelected, setOnlySelected] = useState(false)
@@ -242,6 +283,7 @@ export const PlatformsListModal: React.FC<PlatformsListModalProps> = ({
                       onToggleExpand={() => toggleGroupExpanded(groupName)}
                       filterText={filterText}
                       onlySelected={onlySelected}
+                      onCenterClick={handleCenterOnPlatform}
                     />
                   ))
                 )}

--- a/apps/lrauv-dash2/components/PlatformsListModal.tsx
+++ b/apps/lrauv-dash2/components/PlatformsListModal.tsx
@@ -6,14 +6,14 @@ import {
   useTethysApiContext,
 } from '@mbari/api-client'
 import { createLogger } from '@mbari/utils'
-
-const logger = createLogger('PlatformsListModal')
 import { Modal } from '@mbari/react-ui'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faCaretRight, faCheckCircle } from '@fortawesome/free-solid-svg-icons'
 import { usePlatformSelectionWorkflow } from '../lib/usePlatformSelectionWorkflow'
 import { PlatformSection } from './PlatformSection'
 import { useMapCamera } from './MapCameraContext'
+
+const logger = createLogger('PlatformsListModal')
 
 export interface PlatformsListModalProps {
   onClose: () => void


### PR DESCRIPTION
## Summary

Closes #553

Adds a "Center Map on..." button to each platform row in the TrackDB modal, matching the behaviour already present in the Layers/Stations panel.

- `PlatformSection.tsx`: accepts a new optional `onCenterClick` prop and renders the `faArrowsToCircle` icon button (same icon/style as Stations) with a Tippy tooltip reading "Center map on {name}"
- `PlatformsListModal.tsx`: wires `useMapCamera` + `useTethysApiContext` to fetch the platform's latest position (`lastNumberOfFixes: 1`, 7-day window) on click and fires `setFlyToRequest` — silently no-ops if no recent position is available
- No star/spotlight behaviour — TrackDB platforms have no highlight concept

## Test plan

- [ ] Open TrackDB modal from the map
- [ ] Confirm each platform row shows the arrows-to-circle icon button
- [ ] Click the button on a platform that has recent positions — map should fly to it
- [ ] Confirm tooltip reads "Center map on {platform name}"
- [ ] Click the button on a platform with no recent positions — no error, no map movement