### PR TITLE
fix(api-client): wrap matchAll in Array.from to fix es5 target iteration error

### DIFF
--- a/packages/api-client/src/axios/Util/extractOverrides.ts
+++ b/packages/api-client/src/axios/Util/extractOverrides.ts
@@ -80,7 +80,7 @@ export const extractOverrides = (
   const regex = /(?:set\s+)?([\w]+)[.:]([\w.]+)\s+([^;"']+)/g
   const commands: Override[] = []
 
-  for (const [, , name, value] of missionData.matchAll(regex)) {
+  for (const [, , name, value] of Array.from(missionData.matchAll(regex))) {
     const tokens = value.trim().split(/\s+/)
     const cleaned = tokens[0]
     const unit = tokens[1] ?? undefined


### PR DESCRIPTION
## Summary

- `String.prototype.matchAll` returns a `RegExpStringIterator` which cannot be used in `for...of` when tsconfig targets `es5` without `downlevelIteration`
- Wrapping in `Array.from()` resolves the iterator to a plain array before iterating — no config changes needed
- All 13 `extractOverrides` tests pass

## Root cause

`apps/lrauv-dash2/tsconfig.json` extends `tsconfig/nextjs.json` which sets `"target": "es5"`. Next.js 15 type-checks across workspace package source files, surfacing this pre-existing issue in `extractOverrides.ts`.