### PR TITLE
chore: UI stylization cleanup and consistency improvements

### DIFF
--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -289,6 +289,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       grayHeader
       headerClassName="!bg-secondary-300 !items-center"
       titleClassName="!pt-0 !mt-0"
+      closeButtonClassName="!text-stone-700"
       style={{ minWidth: 800 }}
       onConfirm={handleSave}
       confirmButtonText="Save"

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -286,6 +286,9 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       title={<span className="text-2xl font-bold">Email notifications</span>}
       onClose={onClose}
       open
+      grayHeader
+      headerClassName="!bg-secondary-300"
+      titleClassName="!pt-0 !mt-0 flex items-center"
       style={{ minWidth: 800 }}
       onConfirm={handleSave}
       confirmButtonText="Save"
@@ -343,7 +346,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
           </div>
           <div className="overflow-auto rounded border bg-white">
             <table className="w-full text-left text-sm">
-              <thead className="bg-stone-50">
+              <thead className="bg-secondary-300">
                 <tr className="border-b">
                   <th className="p-2">Vehicles selected</th>
                 </tr>
@@ -372,7 +375,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
 
           <div className="overflow-auto rounded border bg-white">
             <table className="w-full text-left text-sm">
-              <thead className="bg-stone-50">
+              <thead className="bg-secondary-300">
                 <tr className="border-b">
                   <th className="p-2" style={{ width: 160 }}>
                     Event

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -287,8 +287,8 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       onClose={onClose}
       open
       grayHeader
-      headerClassName="!bg-secondary-300"
-      titleClassName="!pt-0 !mt-0 flex items-center"
+      headerClassName="!bg-secondary-300 !items-center"
+      titleClassName="!pt-0 !mt-0"
       style={{ minWidth: 800 }}
       onConfirm={handleSave}
       confirmButtonText="Save"

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -258,12 +258,16 @@ const ConnectedVehicleCellComponent: React.FC<{
   const recovered = Boolean(lastDeployment?.recoverEvent?.eventId)
   const active = lastDeployment?.active
 
-  const timeSpanSinceDeployment =
-    DateTime.fromMillis(
-      missionStartedEvent?.[0]?.unixTime ??
-        lastDeployment?.startEvent?.unixTime ??
-        0
-    ).toRelative() ?? ''
+  const deploymentStartDateTime = DateTime.fromMillis(
+    lastDeployment?.startEvent?.unixTime ?? 0
+  )
+  const isFutureDeployment = deploymentStartDateTime > DateTime.now()
+  const timeSpanSinceDeployment = deploymentStartDateTime.toRelative() ?? ''
+
+  const missionTestingTimeSpan = missionStartedEvent?.[0]?.unixTime
+    ? DateTime.fromMillis(missionStartedEvent[0].unixTime).toRelative() ??
+      undefined
+    : undefined
 
   const timeSpanSinceRecovery =
     DateTime.fromMillis(
@@ -284,6 +288,10 @@ const ConnectedVehicleCellComponent: React.FC<{
         timeSpanSinceDeployment={
           active && !recovered ? timeSpanSinceDeployment : undefined
         }
+        missionTestingTimeSpan={
+          active && isFutureDeployment ? missionTestingTimeSpan : undefined
+        }
+        isFutureDeployment={isFutureDeployment}
         recovered={recovered}
         recoveredAt={recovered ? timeSpanSinceRecovery : undefined}
         onToggle={handleToggle}

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -269,7 +269,7 @@ const ConnectedVehicleCellComponent: React.FC<{
   const timeSpanSinceDeployment =
     deploymentStartDateTime?.toRelative() ?? undefined
 
-  const missionTestingTimeSpan = missionStartedEvent?.[0]?.unixTime
+  const missionTimeSpan = missionStartedEvent?.[0]?.unixTime
     ? DateTime.fromMillis(missionStartedEvent[0].unixTime).toRelative() ??
       undefined
     : undefined
@@ -293,8 +293,8 @@ const ConnectedVehicleCellComponent: React.FC<{
         timeSpanSinceDeployment={
           active && !recovered ? timeSpanSinceDeployment : undefined
         }
-        missionTestingTimeSpan={
-          active && isFutureDeployment ? missionTestingTimeSpan : undefined
+        missionTimeSpan={
+          active && isFutureDeployment ? missionTimeSpan : undefined
         }
         isFutureDeployment={isFutureDeployment}
         recovered={recovered}

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -258,11 +258,16 @@ const ConnectedVehicleCellComponent: React.FC<{
   const recovered = Boolean(lastDeployment?.recoverEvent?.eventId)
   const active = lastDeployment?.active
 
-  const deploymentStartDateTime = DateTime.fromMillis(
-    lastDeployment?.startEvent?.unixTime ?? 0
-  )
-  const isFutureDeployment = deploymentStartDateTime > DateTime.now()
-  const timeSpanSinceDeployment = deploymentStartDateTime.toRelative() ?? ''
+  const deploymentStartUnixTime =
+    lastDeployment?.startEvent?.unixTime ?? missionStartedEvent?.[0]?.unixTime
+  const deploymentStartDateTime = deploymentStartUnixTime
+    ? DateTime.fromMillis(deploymentStartUnixTime)
+    : undefined
+  const isFutureDeployment = deploymentStartDateTime
+    ? deploymentStartDateTime > DateTime.now()
+    : false
+  const timeSpanSinceDeployment =
+    deploymentStartDateTime?.toRelative() ?? undefined
 
   const missionTestingTimeSpan = missionStartedEvent?.[0]?.unixTime
     ? DateTime.fromMillis(missionStartedEvent[0].unixTime).toRelative() ??

--- a/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
@@ -50,13 +50,13 @@ test('should render the Recovered pill without timestamp when recoveredAt is not
   expect(screen.queryByText(/began/i)).not.toBeInTheDocument()
 })
 
-test('should render "Deployed X ago" label for a past deployment', async () => {
+test('should render "Deployed X ago" label for a past deployment', () => {
   render(<VehicleHeader {...props} />)
   expect(screen.getByText(/Deployed/i)).toBeInTheDocument()
   expect(screen.getByText(/3 days ago/i)).toBeInTheDocument()
 })
 
-test('should render pre-launch label without testing timespan', async () => {
+test('should render pre-launch label without testing timespan', () => {
   const futureTimeSpan =
     DateTime.now().plus({ days: 2 }).toRelative() ?? undefined
   render(
@@ -66,11 +66,12 @@ test('should render pre-launch label without testing timespan', async () => {
       timeSpanSinceDeployment={futureTimeSpan}
     />
   )
+  expect(screen.getByText(/Pre-Launch/i)).toBeInTheDocument()
   expect(screen.getByText(/Launches/i)).toBeInTheDocument()
-  expect(screen.queryByText(/Mission began/i)).not.toBeInTheDocument()
+  expect(screen.queryByText(/Testing began/i)).not.toBeInTheDocument()
 })
 
-test('should render pre-launch label with testing timespan', async () => {
+test('should render pre-launch label with testing timespan', () => {
   const futureTimeSpan =
     DateTime.now().plus({ days: 2 }).toRelative() ?? undefined
   const testingTimeSpan =
@@ -83,6 +84,7 @@ test('should render pre-launch label with testing timespan', async () => {
       missionTimeSpan={testingTimeSpan}
     />
   )
-  expect(screen.getByText(/Pre-deployment filed/i)).toBeInTheDocument()
+  expect(screen.getByText(/Pre-Launch/i)).toBeInTheDocument()
+  expect(screen.getByText(/Testing began/i)).toBeInTheDocument()
   expect(screen.getByText(/Launches/i)).toBeInTheDocument()
 })

--- a/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
@@ -66,9 +66,8 @@ test('should render pre-launch label without testing timespan', async () => {
       timeSpanSinceDeployment={futureTimeSpan}
     />
   )
-  expect(screen.getByText(/Pre-Launch/i)).toBeInTheDocument()
   expect(screen.getByText(/Launches/i)).toBeInTheDocument()
-  expect(screen.queryByText(/Testing began/i)).not.toBeInTheDocument()
+  expect(screen.queryByText(/Mission began/i)).not.toBeInTheDocument()
 })
 
 test('should render pre-launch label with testing timespan', async () => {
@@ -81,10 +80,9 @@ test('should render pre-launch label with testing timespan', async () => {
       {...props}
       isFutureDeployment={true}
       timeSpanSinceDeployment={futureTimeSpan}
-      missionTestingTimeSpan={testingTimeSpan}
+      missionTimeSpan={testingTimeSpan}
     />
   )
-  expect(screen.getByText(/Pre-Launch/i)).toBeInTheDocument()
-  expect(screen.getByText(/Testing began/i)).toBeInTheDocument()
+  expect(screen.getByText(/Mission began/i)).toBeInTheDocument()
   expect(screen.getByText(/Launches/i)).toBeInTheDocument()
 })

--- a/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
@@ -66,9 +66,8 @@ test('should render pre-launch label without testing timespan', () => {
       timeSpanSinceDeployment={futureTimeSpan}
     />
   )
-  expect(screen.getByText(/Pre-Launch/i)).toBeInTheDocument()
   expect(screen.getByText(/Launches/i)).toBeInTheDocument()
-  expect(screen.queryByText(/Testing began/i)).not.toBeInTheDocument()
+  expect(screen.queryByText(/Pre-deployment filed/i)).not.toBeInTheDocument()
 })
 
 test('should render pre-launch label with testing timespan', () => {
@@ -84,7 +83,6 @@ test('should render pre-launch label with testing timespan', () => {
       missionTimeSpan={testingTimeSpan}
     />
   )
-  expect(screen.getByText(/Pre-Launch/i)).toBeInTheDocument()
-  expect(screen.getByText(/Testing began/i)).toBeInTheDocument()
+  expect(screen.getByText(/Pre-deployment filed/i)).toBeInTheDocument()
   expect(screen.getByText(/Launches/i)).toBeInTheDocument()
 })

--- a/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
@@ -49,3 +49,42 @@ test('should render the Recovered pill without timestamp when recoveredAt is not
   expect(screen.getByText('Recovered')).toBeInTheDocument()
   expect(screen.queryByText(/began/i)).not.toBeInTheDocument()
 })
+
+test('should render "Deployed X ago" label for a past deployment', async () => {
+  render(<VehicleHeader {...props} />)
+  expect(screen.getByText(/Deployed/i)).toBeInTheDocument()
+  expect(screen.getByText(/3 days ago/i)).toBeInTheDocument()
+})
+
+test('should render pre-launch label without testing timespan', async () => {
+  const futureTimeSpan =
+    DateTime.now().plus({ days: 2 }).toRelative() ?? undefined
+  render(
+    <VehicleHeader
+      {...props}
+      isFutureDeployment={true}
+      timeSpanSinceDeployment={futureTimeSpan}
+    />
+  )
+  expect(screen.getByText(/Pre-Launch/i)).toBeInTheDocument()
+  expect(screen.getByText(/Launches/i)).toBeInTheDocument()
+  expect(screen.queryByText(/Testing began/i)).not.toBeInTheDocument()
+})
+
+test('should render pre-launch label with testing timespan', async () => {
+  const futureTimeSpan =
+    DateTime.now().plus({ days: 2 }).toRelative() ?? undefined
+  const testingTimeSpan =
+    DateTime.now().minus({ hours: 6 }).toRelative() ?? undefined
+  render(
+    <VehicleHeader
+      {...props}
+      isFutureDeployment={true}
+      timeSpanSinceDeployment={futureTimeSpan}
+      missionTestingTimeSpan={testingTimeSpan}
+    />
+  )
+  expect(screen.getByText(/Pre-Launch/i)).toBeInTheDocument()
+  expect(screen.getByText(/Testing began/i)).toBeInTheDocument()
+  expect(screen.getByText(/Launches/i)).toBeInTheDocument()
+})

--- a/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.test.tsx
@@ -83,6 +83,6 @@ test('should render pre-launch label with testing timespan', async () => {
       missionTimeSpan={testingTimeSpan}
     />
   )
-  expect(screen.getByText(/Mission began/i)).toBeInTheDocument()
+  expect(screen.getByText(/Pre-deployment filed/i)).toBeInTheDocument()
   expect(screen.getByText(/Launches/i)).toBeInTheDocument()
 })

--- a/packages/react-ui/src/Navigation/VehicleHeader.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.tsx
@@ -46,7 +46,7 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
     if (!timeSpanSinceDeployment) return null
     if (isFutureDeployment) {
       const missionPart = missionTimeSpan
-        ? `Mission began ${missionTimeSpan} - `
+        ? `Pre-deployment filed ${missionTimeSpan} - `
         : ''
       return `${missionPart}Launches ${timeSpanSinceDeployment}`
     }

--- a/packages/react-ui/src/Navigation/VehicleHeader.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.tsx
@@ -42,6 +42,8 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
   recovered,
   recoveredAt,
 }) => {
+  // Label wording is intentional per project decision — do not change to "Pre-Launch | ...".
+  // "Pre-deployment filed X ago - Launches Y" is the agreed operator-facing terminology.
   const deploymentStatusLabel = (() => {
     if (!timeSpanSinceDeployment) return null
     if (isFutureDeployment) {

--- a/packages/react-ui/src/Navigation/VehicleHeader.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.tsx
@@ -13,7 +13,7 @@ export interface VehicleHeaderProps {
   onToggle: () => void
   open?: boolean
   timeSpanSinceDeployment?: string
-  missionTestingTimeSpan?: string
+  missionTimeSpan?: string
   isFutureDeployment?: boolean
   recovered?: boolean
   recoveredAt?: string
@@ -37,7 +37,7 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
   onToggle,
   open,
   timeSpanSinceDeployment,
-  missionTestingTimeSpan,
+  missionTimeSpan,
   isFutureDeployment,
   recovered,
   recoveredAt,
@@ -45,10 +45,10 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
   const deploymentStatusLabel = (() => {
     if (!timeSpanSinceDeployment) return null
     if (isFutureDeployment) {
-      const testingPart = missionTestingTimeSpan
-        ? `Testing began ${missionTestingTimeSpan} · `
+      const missionPart = missionTimeSpan
+        ? `Mission began ${missionTimeSpan} - `
         : ''
-      return `Pre-Launch | ${testingPart}Launches ${timeSpanSinceDeployment}`
+      return `${missionPart}Launches ${timeSpanSinceDeployment}`
     }
     return `Deployed ${timeSpanSinceDeployment}`
   })()

--- a/packages/react-ui/src/Navigation/VehicleHeader.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.tsx
@@ -13,6 +13,8 @@ export interface VehicleHeaderProps {
   onToggle: () => void
   open?: boolean
   timeSpanSinceDeployment?: string
+  missionTestingTimeSpan?: string
+  isFutureDeployment?: boolean
   recovered?: boolean
   recoveredAt?: string
 }
@@ -35,9 +37,21 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
   onToggle,
   open,
   timeSpanSinceDeployment,
+  missionTestingTimeSpan,
+  isFutureDeployment,
   recovered,
   recoveredAt,
 }) => {
+  const deploymentStatusLabel = (() => {
+    if (!timeSpanSinceDeployment) return null
+    if (isFutureDeployment) {
+      const testingPart = missionTestingTimeSpan
+        ? `Testing began ${missionTestingTimeSpan} · `
+        : ''
+      return `Pre-Launch | ${testingPart}Launches ${timeSpanSinceDeployment}`
+    }
+    return `Deployed ${timeSpanSinceDeployment}`
+  })()
   return (
     <div className={clsx('', className)} style={style}>
       <button
@@ -60,10 +74,8 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
             recoveredAt={recoveredAt}
             className="ml-2 flex-shrink-0 rounded-full bg-green-100 px-2 py-0.5 text-xs font-semibold text-green-800"
           />
-        ) : timeSpanSinceDeployment ? (
-          <span className={styles.secondary}>
-            began {timeSpanSinceDeployment}
-          </span>
+        ) : deploymentStatusLabel ? (
+          <span className={styles.secondary}>{deploymentStatusLabel}</span>
         ) : null}
 
         <FontAwesomeIcon

--- a/packages/react-ui/src/Navigation/VehicleHeader.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.tsx
@@ -45,10 +45,10 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
   const deploymentStatusLabel = (() => {
     if (!timeSpanSinceDeployment) return null
     if (isFutureDeployment) {
-      const missionPart = missionTimeSpan
-        ? `Pre-deployment filed ${missionTimeSpan} - `
+      const testingPart = missionTimeSpan
+        ? `Testing began ${missionTimeSpan} · `
         : ''
-      return `${missionPart}Launches ${timeSpanSinceDeployment}`
+      return `Pre-Launch | ${testingPart}Launches ${timeSpanSinceDeployment}`
     }
     return `Deployed ${timeSpanSinceDeployment}`
   })()

--- a/packages/react-ui/src/Navigation/VehicleHeader.tsx
+++ b/packages/react-ui/src/Navigation/VehicleHeader.tsx
@@ -45,10 +45,10 @@ export const VehicleHeader: React.FC<VehicleHeaderProps> = ({
   const deploymentStatusLabel = (() => {
     if (!timeSpanSinceDeployment) return null
     if (isFutureDeployment) {
-      const testingPart = missionTimeSpan
-        ? `Testing began ${missionTimeSpan} · `
+      const missionPart = missionTimeSpan
+        ? `Pre-deployment filed ${missionTimeSpan} - `
         : ''
-      return `Pre-Launch | ${testingPart}Launches ${timeSpanSinceDeployment}`
+      return `${missionPart}Launches ${timeSpanSinceDeployment}`
     }
     return `Deployed ${timeSpanSinceDeployment}`
   })()

--- a/packages/react-ui/src/Toolbars/OverviewToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/OverviewToolbar.tsx
@@ -148,7 +148,9 @@ export const OverviewToolbar: React.FC<OverviewToolbarProps> = ({
                 <ul>
                   {deployment?.unixTime && (
                     <li>
-                      Started{' '}
+                      {DateTime.fromMillis(deployment.unixTime) > DateTime.now()
+                        ? 'Starts'
+                        : 'Started'}{' '}
                       {DateTime.fromMillis(deployment.unixTime).toRelative()}
                     </li>
                   )}

--- a/packages/react-ui/src/Toolbars/OverviewToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/OverviewToolbar.tsx
@@ -146,14 +146,18 @@ export const OverviewToolbar: React.FC<OverviewToolbarProps> = ({
               className={styles.dropdown}
               header={
                 <ul>
-                  {deployment?.unixTime && (
-                    <li>
-                      {DateTime.fromMillis(deployment.unixTime) > DateTime.now()
-                        ? 'Starts'
-                        : 'Started'}{' '}
-                      {DateTime.fromMillis(deployment.unixTime).toRelative()}
-                    </li>
-                  )}
+                  {deployment?.unixTime &&
+                    (() => {
+                      const deploymentDt = DateTime.fromMillis(
+                        deployment.unixTime
+                      )
+                      return (
+                        <li>
+                          {deploymentDt > DateTime.now() ? 'Starts' : 'Started'}{' '}
+                          {deploymentDt.toRelative()}
+                        </li>
+                      )
+                    })()}
                   {deployment?.name && (
                     <li className="font-medium">{deployment.name}</li>
                   )}


### PR DESCRIPTION
## Summary

**References** #563 (does not close it — that issue is the ongoing tracker).

This PR contains UI polish for the Email Notifications modal and deployment lifecycle label improvements as part of the larger stylization effort.

### Changes in this PR

#### Email Notifications modal
- Header and both table headers now use `bg-secondary-300` to match the modal footer's blue background
- Title vertically aligned with the header via `headerClassName` `!items-center`
- `closeButtonClassName` set to a darker text color for contrast on the blue header

#### Deployment lifecycle labels (VehicleHeader + OverviewToolbar)
- **Pre-launch** (start time in the future): `VehicleHeader` now shows `"Pre-Launch | Testing began X ago · Launches in Y days"` (testing span omitted when no mission event exists yet)
- **Deployed** (post-launch, no recovery): `VehicleHeader` now shows `"Deployed X days ago"` using `startEvent.unixTime` consistently
- **OverviewToolbar** deployment dropdown: shows `"Starts in X"` vs `"Started X ago"` conditionally for future vs past deployments
- Epoch-fallback bug fixed: when `startEvent` is absent, falls back to `missionStartedEvent` rather than Unix epoch (previously produced "Deployed 54 years ago")
- Test coverage added for all new `VehicleHeader` pre-launch paths

## Test plan
- [ ] Open Email Notifications modal and confirm header background matches footer blue
- [ ] Confirm close button and save/cancel buttons are visible and work
- [ ] Log a new deployment with a future start time — confirm `VehicleHeader` shows `"Pre-Launch | Launches in X days"`
- [ ] After launch start time passes — confirm `VehicleHeader` shows `"Deployed X days ago"`