### PR TITLE
fix: backport Copilot review fixes from main to develop

### DIFF
--- a/packages/react-ui/src/Map/MapDepthDisplay.tsx
+++ b/packages/react-ui/src/Map/MapDepthDisplay.tsx
@@ -50,7 +50,7 @@ const MapDepthDisplay: React.FC<MapDepthDisplayProps> = ({
   const onRequestDepth = useCallback(
     (lat: number, lng: number) =>
       handleDepthRequestWithFeedback(lat, lng).then(
-        (r: { depth: number | null }) => r.depth ?? 0
+        (r: { depth: number | null }) => r.depth
       ),
     [handleDepthRequestWithFeedback]
   )

--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -23,7 +23,7 @@ const formatCoordinate = (latitude: number) => {
 }
 
 export interface MouseCoordinatesProps {
-  onRequestDepth?: (lat: number, lng: number) => Promise<number>
+  onRequestDepth?: (lat: number, lng: number) => Promise<number | null>
 }
 
 const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
@@ -31,7 +31,7 @@ const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
 }) => {
   const [mousePoint, setMousePoint] = useState(null as null | L.LatLng)
   const [depth, setDepth] = useState(
-    null as null | { depth: number; coordinate: string }
+    null as null | { depth: number | null; coordinate: string }
   )
 
   const formattedCoordinates =

--- a/packages/react-ui/src/Toolbars/OverviewToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/OverviewToolbar.tsx
@@ -179,14 +179,6 @@ export const OverviewToolbar: React.FC<OverviewToolbarProps> = ({
             />
           </li>
         ) : null}
-        {recovered && (
-          <li
-            className="ml-3 rounded-full bg-green-100 px-3 py-1 text-xs font-semibold text-green-800"
-            title={recoveredAt ? `Recovered ${recoveredAt}` : 'Recovered'}
-          >
-            Recovered
-          </li>
-        )}
       </ul>
       <ul className={styles.rightWrapper}>
         {onRoleReassign && (

--- a/packages/utils/src/useDepthRequest.tsx
+++ b/packages/utils/src/useDepthRequest.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react'
 import toast from 'react-hot-toast'
-import { createLogger } from './index' // Adjust import path as needed
+import { createLogger } from './logger'
 
 const logger = createLogger('useDepthRequest')
 


### PR DESCRIPTION
## Summary

Backports 3 bug fixes that were applied to `main` during the v5.1.14 production release process, so `develop` (staging) stays in sync and doesn't regress on the next version bump.

### Changes

- **OverviewToolbar**: remove duplicate inline `Recovered` pill — `<RecoveredPill>` is the single render path
- **MapDepthDisplay / MouseCoordinates**: preserve `null` depth instead of coercing to `0`; UI correctly hides depth when data is unavailable
- **useDepthRequest**: fix circular dependency by importing `createLogger` directly from `./logger` instead of the `./index` barrel

Cherry-picked from `b042612` on `main`.