### PR TITLE
fix: show Cancelled status for operator-cancelled missions in Schedule

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.test.tsx
@@ -121,3 +121,49 @@ test('pending items remain pending in deployment-logs view when isRecovered is f
     expect(screen.queryByTitle('completed')).not.toBeInTheDocument()
   })
 })
+
+test('items with a server-side cancellation note render as cancelled', async () => {
+  // Override /events to return a cancellation note for event 99001 when
+  // the noteMatches param is set, mimicking TethysDash backend behaviour.
+  server.use(
+    rest.get('/events', (req, res, ctx) => {
+      const noteMatches = req.url.searchParams.get('noteMatches')
+      if (noteMatches?.includes('Cancelled request')) {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            result: [
+              {
+                eventId: 89999,
+                eventType: 'note',
+                unixTime: 1656368200000,
+                note: "Cancelled request 99001 for 'example': 'load Science/profiles.xml'",
+                user: 'test-user',
+              },
+            ],
+          })
+        )
+      }
+      return res(ctx.status(200), ctx.json({ result: [] }))
+    })
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection {...props} />
+    </MockProviders>
+  )
+
+  // Switch to deployment-logs-only mode so the item comes from commandStatuses
+  await userEvent.click(
+    await screen.findByRole('button', { name: /displaying all logs/i })
+  )
+
+  // The cancellation override must stamp the item as 'cancelled' regardless
+  // of what the timeline inferred (pending → cancelled via note eventId match).
+  await waitFor(() => {
+    expect(screen.getByTitle('cancelled')).toBeInTheDocument()
+    expect(screen.queryByTitle('pending')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('completed')).not.toBeInTheDocument()
+  })
+})

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -224,7 +224,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       from: 0,
       limit: 500,
     },
-    { enabled: !!vehicleName }
+    { enabled: !!vehicleName, staleTime: 30 * 1000, refetchInterval: 30 * 1000 }
   )
 
   // Build a Set of eventIds that were explicitly cancelled by an operator.
@@ -398,7 +398,12 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     const currentMissionEntry = missionTimeline[0]
     if (currentMissionEntry) {
       const currentMissionPath = normalizeMissionPath(currentMissionEntry.name)
-      if (!currentMissionPath) return enriched
+      if (!currentMissionPath)
+        return enriched.map((item) =>
+          cancelledEventIds.has(item.event.eventId)
+            ? { ...item, status: 'cancelled' as const }
+            : item
+        )
 
       const matchingMissionIndex = enriched.reduce((bestIdx, item, idx) => {
         const fromDataPath = missionPathFromEventData(item.event.data)

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -1155,7 +1155,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 },
               },
               {
-                label: 'Delete from Queue',
+                label: 'Cancel this Directive',
                 onSelect: () => {
                   handleDelete({
                     eventId: currentMoreMenu?.eventId as number,

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -20,6 +20,7 @@ import {
   EventType,
   GetEventsResponse,
   useDeploymentCommandStatus,
+  useEvents,
   useInfiniteEvents,
   useMissionStartedEvent,
   getVia,
@@ -210,6 +211,31 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     { vehicle: vehicleName, limit: 50 },
     { enabled: !!vehicleName, staleTime: 15 * 1000, refetchInterval: 30 * 1000 }
   )
+
+  // Fetch note events that record operator cancellations so we can stamp
+  // schedule items as 'cancelled' instead of incorrectly showing 'completed'.
+  // The TethysDash backend writes a note with text matching:
+  //   "Cancelled request {eventId} for '{vehicle}': ..."
+  const cancellationNotesResponse = useEvents(
+    {
+      vehicles: [vehicleName],
+      eventTypes: ['note'] as EventType[],
+      noteMatches: 'Cancelled request',
+      from: 0,
+      limit: 500,
+    },
+    { enabled: !!vehicleName }
+  )
+
+  // Build a Set of eventIds that were explicitly cancelled by an operator.
+  const cancelledEventIds = useMemo(() => {
+    const ids = new Set<number>()
+    cancellationNotesResponse.data?.forEach((note) => {
+      const match = note.note?.match(/Cancelled request (\d+)/)
+      if (match) ids.add(parseInt(match[1], 10))
+    })
+    return ids
+  }, [cancellationNotesResponse.data])
 
   // Build a timeline: each entry knows its own start time and when it ended
   // (= the start time of the mission that replaced it, or undefined if running).
@@ -482,11 +508,17 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     // will never execute — treat them as completed so the history is clean.
     // Must run AFTER enrichment so statuses are resolved from 'TBD' first.
     if (isRecovered) {
-      return enriched.map((item) =>
-        item.status === 'pending' || item.status === 'TBD'
-          ? { ...item, status: 'completed' }
-          : item
-      )
+      return enriched
+        .map((item) =>
+          item.status === 'pending' || item.status === 'TBD'
+            ? { ...item, status: 'completed' }
+            : item
+        )
+        .map((item) =>
+          cancelledEventIds.has(item.event.eventId)
+            ? { ...item, status: 'cancelled' as const }
+            : item
+        )
     }
 
     // Inject Default mission rows from missionTimeline.
@@ -520,11 +552,21 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     }
 
     if (isRecovered) {
-      return enriched.map((item) =>
-        item.status === 'pending' ? { ...item, status: 'completed' } : item
-      )
+      return enriched
+        .map((item) =>
+          item.status === 'pending' ? { ...item, status: 'completed' } : item
+        )
+        .map((item) =>
+          cancelledEventIds.has(item.event.eventId)
+            ? { ...item, status: 'cancelled' as const }
+            : item
+        )
     }
-    return enriched
+    return enriched.map((item) =>
+      cancelledEventIds.has(item.event.eventId)
+        ? { ...item, status: 'cancelled' as const }
+        : item
+    )
   }, [
     deploymentLogsOnly,
     deploymentResponse.data,
@@ -532,6 +574,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     missionTimeline,
     missionStartedResponse.data,
     isRecovered,
+    cancelledEventIds,
   ])
 
   const scheduledTypes = ['pending', 'running']


### PR DESCRIPTION
## Problem

When an operator cancelled a mission request through TethysDash (e.g. "Cancelled request 26980384 for 'daphne'"), the Schedule section was incorrectly showing the item as **Completed** instead of **Cancelled**.

### Root cause

Two compounding issues:

1. **`missionTimeline` has no concept of cancellation** — it only produces `running` (current) or `completed` (past) status based on vehicle telemetry (mission-started events). A cancelled mission that briefly started still gets classified as `completed`.

2. **Cancellation notes were never fetched** — `ScheduleSection` only queries `eventTypes: ['command', 'run']`. Cancellation records are `note` type events written by TethysDash with text like:
   > `Cancelled request 26980384 for 'daphne': 'sched asap "load Engineering/..."'`
   These were invisible to the schedule enrichment pipeline.

## Fix

- Fetch `note` events matching `'Cancelled request'` for the vehicle
- Parse the `eventId` from each note text using the pattern `Cancelled request (\d+)`
- Build a `cancelledEventIds` Set
- Apply a final override pass on all return paths in the `missions` useMemo: any item whose `eventId` is in `cancelledEventIds` is stamped `status: 'cancelled'`, overriding any incorrect `completed` inferred from the timeline

## Test

Reproduce using event ID 26980384 for vehicle `daphne` (Apr 23, 2026 12:42:56–12:43:02). After this fix the Schedule modal should show **Cancelled** instead of **Completed**.