### PR TITLE
fix(#563): keep Schedule History search/filter row visible on no-match search

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -610,9 +610,10 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
 
   const scheduledCells = missions?.filter(isAboveSeparator)
 
-  const historicCells = missions
-    ?.filter((v) => !isAboveSeparator(v))
-    .filter(
+  const allHistoricCells = missions?.filter((v) => !isAboveSeparator(v))
+
+  const historicCells = allHistoricCells
+    ?.filter(
       (v) =>
         !scheduleFilter ||
         scheduleFilter === 'all' ||
@@ -628,7 +629,11 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     )
     .sort((a, b) => (b.event.unixTime ?? 0) - (a.event.unixTime ?? 0))
 
-  const hasPastSchedule = (historicCells?.length ?? 0) > 0
+  // Base hasPastSchedule on unfiltered history so the Schedule History header
+  // row (which contains the search input) is never hidden by an active search
+  // or filter — otherwise a no-match search removes the input itself, trapping
+  // the user with no way to clear or retry.
+  const hasPastSchedule = (allHistoricCells?.length ?? 0) > 0
   const staticFilterCellOffset = hasPastSchedule ? 1 : 0
 
   const results = [scheduledCells, historicCells].flat()

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -469,6 +469,8 @@ test('Schedule History header and search input stay visible when search matches 
     )
   )
 
+  const user = userEvent.setup()
+
   render(
     <MockProviders queryClient={new QueryClient()}>
       <ScheduleSection {...props} currentDeploymentId={1} />
@@ -481,7 +483,7 @@ test('Schedule History header and search input stay visible when search matches 
   })
 
   // Type a term that matches nothing — previously this removed the header row.
-  await userEvent.type(screen.getByPlaceholderText('Search'), 'xyzzy-no-match')
+  await user.type(screen.getByPlaceholderText('Search'), 'xyzzy-no-match')
 
   // The header row (including the search input) must survive a zero-match search.
   await waitFor(() => {

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -442,6 +442,54 @@ test('Cancel this Directive calls DELETE /commands/queue when confirmed', async 
   })
 })
 
+test('Schedule History header and search input stay visible when search matches nothing', async () => {
+  // Set up a completed historic mission: profile_station is older than the
+  // currently-running keepstation, so the mission timeline marks it completed.
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            {
+              data: 'load Science/profile_station.tl;run',
+              unixTime: Date.now() - 120 * 1000,
+              eventId: 101,
+              eventType: 'run',
+              text: null,
+              note: null,
+              user: 'test-user',
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: missionStartedWithHistory }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection {...props} currentDeploymentId={1} />
+    </MockProviders>
+  )
+
+  // Wait for the Schedule History header to appear (completed item present).
+  await waitFor(() => {
+    expect(screen.getByText(/schedule history/i)).toBeInTheDocument()
+  })
+
+  // Type a term that matches nothing — previously this removed the header row.
+  await userEvent.type(screen.getByPlaceholderText('Search'), 'xyzzy-no-match')
+
+  // The header row (including the search input) must survive a zero-match search.
+  await waitFor(() => {
+    expect(screen.getByText(/schedule history/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('Search')).toBeInTheDocument()
+  })
+})
+
 test('Cancel this Directive does not call DELETE when confirm is dismissed', async () => {
   let deleteCalled = false
   server.use(


### PR DESCRIPTION
## Summary

- `hasPastSchedule` was derived from `historicCells` (the filter+search-narrowed list), so entering a search term with no matches collapsed the Schedule History header row — removing the search input itself and leaving the user with no way to clear or retry.
- Fix: split into `allHistoricCells` (pre-filter) and base `hasPastSchedule` on that instead. `historicCells` (filtered/searched) is still used for the actual rendered rows.

## Test plan

- [ ] Open a vehicle with past schedule history
- [ ] Type a search term that matches nothing — verify the Schedule History header row (with Filter select and Search input) stays visible
- [ ] Clear the search — verify results return to normal
- [ ] Apply a filter that matches nothing — same expectation: header row stays

Part of #563