### PR TITLE
fix(#563): distinguish mission param updates from vehicle configSet commands

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -839,7 +839,7 @@ export const ScheduleEventDetailsModal: React.FC<
             {event.isConfigSetUpdate && (
               <span
                 className="ml-2 text-xs normal-case italic"
-                style={{ color: '#475569' }}
+                style={{ color: '#1e40af' }}
               >
                 (vehicle config update)
               </span>

--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -572,8 +572,8 @@ export const ScheduleEventDetailsModal: React.FC<
                       <strong>Paused</strong>: schedule execution is paused.
                     </p>
                     <p className="mt-1 normal-case">
-                      <strong>Sent</strong>: one-shot config update — no run
-                      interval.
+                      <strong>Sent</strong>: mission parameter update or vehicle
+                      config update — dispatched with no run interval.
                     </p>
                     <p className="mt-1 normal-case">
                       <strong>Received</strong>: vehicle acknowledged receipt of
@@ -671,6 +671,7 @@ export const ScheduleEventDetailsModal: React.FC<
                 // instantaneous — no meaningful end time, so skip TBD entirely.
                 const isInstantaneous =
                   event.isParamUpdate ||
+                  event.isConfigSetUpdate ||
                   (event.commandType === 'command' &&
                     ['ack', 'timeout', 'sent'].includes(s))
                 if (
@@ -832,7 +833,15 @@ export const ScheduleEventDetailsModal: React.FC<
                 className="ml-2 text-xs normal-case italic"
                 style={{ color: '#b45309' }}
               >
-                (config update for associated mission)
+                (parameter update for associated mission)
+              </span>
+            )}
+            {event.isConfigSetUpdate && (
+              <span
+                className="ml-2 text-xs normal-case italic"
+                style={{ color: '#475569' }}
+              >
+                (vehicle config update)
               </span>
             )}
           </p>

--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -576,8 +576,8 @@ export const ScheduleEventDetailsModal: React.FC<
                       config update — dispatched with no run interval.
                     </p>
                     <p className="mt-1 normal-case">
-                      <strong>Received</strong>: vehicle acknowledged receipt of
-                      the command or mission.
+                      <strong>Received</strong>: delivery confirmed via comms
+                      network — vehicle will execute upon receipt.
                     </p>
                     <p className="mt-1 normal-case">
                       <strong>Timeout</strong>: no confirmation received within

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mbari/react-ui'
 import { DateTime } from 'luxon'
 import { formatElapsedTime } from '@mbari/utils'
-import { faPlus } from '@fortawesome/free-solid-svg-icons'
+import { faPlus, faGear } from '@fortawesome/free-solid-svg-icons'
 import clsx from 'clsx'
 import { Select } from '@mbari/react-ui/dist/Fields/Select'
 import {
@@ -132,12 +132,24 @@ export const isMissionCommand = (
 }
 
 // Detects parameter update commands: "set <missionName>.<paramName> <value>"
+// These are ephemeral, mission-scoped tweaks to a currently-running mission.
 export const isParamCommand = (
   commandData?: string,
   commandText?: string
 ): boolean => {
   const text = commandData ?? commandText ?? ''
   return /^\s*set\s+\w+\.\w+/i.test(text)
+}
+
+// Detects vehicle configuration commands: "configSet <subsystem>.<param> <value> [persist]"
+// Unlike mission param updates (set <x>.<y>), these modify the vehicle's persistent
+// config store and are independent of any running mission — a vehicle-level change.
+export const isConfigSetCommand = (
+  commandData?: string,
+  commandText?: string
+): boolean => {
+  const text = commandData ?? commandText ?? ''
+  return /^\s*configSet\s+\w+\.\w+/i.test(text)
 }
 
 export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
@@ -844,6 +856,10 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       isMissionCommand(mission?.event?.data, mission?.event?.text)
     const isParam =
       !isMission && isParamCommand(mission?.event?.data, mission?.event?.text)
+    const isConfigSet =
+      !isMission &&
+      !isParam &&
+      isConfigSetCommand(mission?.event?.data, mission?.event?.text)
     const cellCommandType: 'mission' | 'command' = isMission
       ? 'mission'
       : 'command'
@@ -856,7 +872,14 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       : undefined
     const cellStatus: ScheduleCellStatus = (() => {
       if (isParam) {
-        // Params are always dispatched — use comms lookup to upgrade to ack/timeout
+        // Params and vehicle configSets are always dispatched — use comms lookup
+        // to upgrade to ack/timeout
+        const commsStatus = commsLookup.get(mission.event.eventId)
+        if (commsStatus === 'ack') return 'ack'
+        if (commsStatus === 'timeout') return 'timeout'
+        return 'sent'
+      }
+      if (isConfigSet) {
         const commsStatus = commsLookup.get(mission.event.eventId)
         if (commsStatus === 'ack') return 'ack'
         if (commsStatus === 'timeout') return 'timeout'
@@ -945,23 +968,24 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
           const timeStr = isToday
             ? dt.toFormat('H:mm')
             : dt.toFormat('MMM d, H:mm')
-          const verb = isParam
-            ? 'Sent'
-            : cellStatus === 'pending'
-            ? scheduleDate && scheduleDate !== 'asap'
-              ? 'Queued'
+          const verb =
+            isParam || isConfigSet
+              ? 'Sent'
+              : cellStatus === 'pending'
+              ? scheduleDate && scheduleDate !== 'asap'
+                ? 'Queued'
+                : isMission
+                ? 'Scheduled'
+                : 'Sent'
+              : cellStatus === 'running'
+              ? 'Started'
               : isMission
-              ? 'Scheduled'
-              : 'Sent'
-            : cellStatus === 'running'
-            ? 'Started'
-            : isMission
-            ? 'Started'
-            : 'Ran'
+              ? 'Started'
+              : 'Ran'
           return `${verb} ${timeStr}${relativePart}`
         })()}
         description2={
-          isParam
+          isParam || isConfigSet
             ? undefined
             : cellStatus === 'pending' &&
               scheduleDate &&
@@ -982,8 +1006,15 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         badge={
           isParam
             ? {
+                text: 'param',
+                tooltip: 'Mission parameter update — sent to vehicle',
+              }
+            : isConfigSet
+            ? {
                 text: 'config',
-                tooltip: 'Config update — sent to vehicle',
+                tooltip: 'Vehicle config update — persisted on vehicle',
+                icon: faGear,
+                variant: 'slate' as const,
               }
             : undefined
         }
@@ -1010,6 +1041,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 scheduleDate,
                 via: getVia(mission.event.note) ?? undefined,
                 isParamUpdate: isParam,
+                isConfigSetUpdate: isConfigSet,
                 commsStatus: commsLookup.get(mission.event.eventId),
               },
             },

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -1012,7 +1012,8 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
             : isConfigSet
             ? {
                 text: 'config',
-                tooltip: 'Vehicle config update — persisted on vehicle',
+                tooltip:
+                  'Vehicle config update — modifies a vehicle subsystem setting',
                 icon: faGear,
                 variant: 'slate' as const,
               }

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -141,15 +141,18 @@ export const isParamCommand = (
   return /^\s*set\s+\w+\.\w+/i.test(text)
 }
 
-// Detects vehicle configuration commands: "configSet <subsystem>.<param> <value> [persist]"
+// Detects vehicle configuration commands: "configSet <pathOrSubsystem...> <value> [persist]"
 // Unlike mission param updates (set <x>.<y>), these modify the vehicle's persistent
 // config store and are independent of any running mission — a vehicle-level change.
+// Treat any configSet invocation with arguments as a config update, except "configSet list"
+// (which is a read-only query, not a write).
 export const isConfigSetCommand = (
   commandData?: string,
   commandText?: string
 ): boolean => {
   const text = commandData ?? commandText ?? ''
-  return /^\s*configSet\s+\w+\.\w+/i.test(text)
+  if (/^\s*configSet\s+list\s*$/i.test(text)) return false
+  return /^\s*configSet\s+\S+/i.test(text)
 }
 
 export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
@@ -871,15 +874,8 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       ? schedDateMatch[1]
       : undefined
     const cellStatus: ScheduleCellStatus = (() => {
-      if (isParam) {
-        // Params and vehicle configSets are always dispatched — use comms lookup
-        // to upgrade to ack/timeout
-        const commsStatus = commsLookup.get(mission.event.eventId)
-        if (commsStatus === 'ack') return 'ack'
-        if (commsStatus === 'timeout') return 'timeout'
-        return 'sent'
-      }
-      if (isConfigSet) {
+      if (isParam || isConfigSet) {
+        // Dispatched one-shots — use comms lookup to upgrade to ack/timeout.
         const commsStatus = commsLookup.get(mission.event.eventId)
         if (commsStatus === 'ack') return 'ack'
         if (commsStatus === 'timeout') return 'timeout'

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mbari/react-ui'
 import { DateTime } from 'luxon'
 import { formatElapsedTime } from '@mbari/utils'
-import { faPlus, faGear } from '@fortawesome/free-solid-svg-icons'
+import { faPlus, faWrench } from '@fortawesome/free-solid-svg-icons'
 import clsx from 'clsx'
 import { Select } from '@mbari/react-ui/dist/Fields/Select'
 import {
@@ -1014,8 +1014,8 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 text: 'config',
                 tooltip:
                   'Vehicle config update — modifies a vehicle subsystem setting',
-                icon: faGear,
-                variant: 'slate' as const,
+                icon: faWrench,
+                variant: 'blue' as const,
               }
             : undefined
         }

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -1012,8 +1012,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
             : isConfigSet
             ? {
                 text: 'config',
-                tooltip:
-                  'Vehicle config update — modifies a vehicle subsystem setting',
+                tooltip: 'Vehicle config update — sent to vehicle',
                 icon: faWrench,
                 variant: 'blue' as const,
               }

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -631,9 +631,9 @@ test('configSet command row shows Sent status and config badge tooltip', async (
     expect(screen.getByText(/^Sent /i)).toBeInTheDocument()
   })
 
-  // The slate-variant badge renders the faGear icon (data-icon="gear")
+  // The blue-variant badge renders the faWrench icon (data-icon="wrench")
   await waitFor(() => {
-    const gearIcon = document.querySelector('svg[data-icon="gear"]')
-    expect(gearIcon).toBeInTheDocument()
+    const wrenchIcon = document.querySelector('svg[data-icon="wrench"]')
+    expect(wrenchIcon).toBeInTheDocument()
   })
 })

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -585,12 +585,22 @@ test('isConfigSetCommand returns true for "configSet <subsystem>.<param>"', () =
   ).toBe(true)
 })
 
-test('isConfigSetCommand returns false for non-configSet commands', () => {
+test('isConfigSetCommand returns true for non-dotted configSet commands', () => {
+  expect(
+    isConfigSetCommand(
+      'configSet Express linearApproximation acoustic_receive_time ampere_hour persist'
+    )
+  ).toBe(true)
+})
+
+test('isConfigSetCommand returns false for non-configSet commands and configSet list', () => {
   expect(isConfigSetCommand('set profile_station.YoYoMaxDepth 40 meter')).toBe(
     false
   )
   expect(isConfigSetCommand('load Science/profile_station.tl;run')).toBe(false)
   expect(isConfigSetCommand('sched resume')).toBe(false)
+  expect(isConfigSetCommand('configSet list')).toBe(false)
+  expect(isConfigSetCommand('  configSet list  ')).toBe(false)
 })
 
 // ── configSet integration test ───────────────────────────────────────────────

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -5,6 +5,8 @@ import '@testing-library/jest-dom'
 import {
   ScheduleSection,
   ScheduleSectionProps,
+  isParamCommand,
+  isConfigSetCommand,
 } from '../components/ScheduleSection'
 import { QueryClient } from 'react-query'
 import { rest } from 'msw'
@@ -544,4 +546,94 @@ test('Cancel this Directive does not call DELETE when confirm is dismissed', asy
     expect(screen.queryByText('Cancel this Directive')).not.toBeInTheDocument()
   )
   expect(deleteCalled).toBe(false)
+})
+
+// ── isParamCommand unit tests ────────────────────────────────────────────────
+
+test('isParamCommand returns true for "set <mission>.<param> <value>"', () => {
+  expect(isParamCommand('set profile_station.YoYoMaxDepth 40 meter')).toBe(true)
+  expect(isParamCommand('set sci2.Lat1 36.87 degree')).toBe(true)
+  expect(isParamCommand('  set keepstation.Radius 200 meter')).toBe(true)
+})
+
+test('isParamCommand returns false for non-param commands', () => {
+  expect(
+    isParamCommand(
+      'configSet VerticalControl.massDefault -16 millimeter persist'
+    )
+  ).toBe(false)
+  expect(isParamCommand('load Science/profile_station.tl;run')).toBe(false)
+  expect(isParamCommand('sched resume')).toBe(false)
+  expect(isParamCommand('gfscan')).toBe(false)
+})
+
+// ── isConfigSetCommand unit tests ────────────────────────────────────────────
+
+test('isConfigSetCommand returns true for "configSet <subsystem>.<param>"', () => {
+  expect(
+    isConfigSetCommand(
+      'configSet VerticalControl.massDefault -16 millimeter persist'
+    )
+  ).toBe(true)
+  expect(
+    isConfigSetCommand('configSet CTD_Seabird.loadAtStartup 1 bool persist')
+  ).toBe(true)
+  expect(
+    isConfigSetCommand(
+      '  configSet RDI_Pathfinder.loadAtStartup 1 bool persist'
+    )
+  ).toBe(true)
+})
+
+test('isConfigSetCommand returns false for non-configSet commands', () => {
+  expect(isConfigSetCommand('set profile_station.YoYoMaxDepth 40 meter')).toBe(
+    false
+  )
+  expect(isConfigSetCommand('load Science/profile_station.tl;run')).toBe(false)
+  expect(isConfigSetCommand('sched resume')).toBe(false)
+})
+
+// ── configSet integration test ───────────────────────────────────────────────
+
+test('configSet command row shows Sent status and config badge tooltip', async () => {
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            {
+              data: 'configSet VerticalControl.massDefault -16 millimeter persist',
+              unixTime: Date.now() - 60 * 1000,
+              eventId: 300,
+              eventType: 'command',
+              text: null,
+              note: null,
+              user: 'test-engineer',
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection {...props} currentDeploymentId={1} />
+    </MockProviders>
+  )
+
+  // configSet is an instantaneous one-shot — its verb must be 'Sent', not 'Ran'
+  await waitFor(() => {
+    expect(screen.getByText(/^Sent /i)).toBeInTheDocument()
+  })
+
+  // The slate-variant badge renders the faGear icon (data-icon="gear")
+  await waitFor(() => {
+    const gearIcon = document.querySelector('svg[data-icon="gear"]')
+    expect(gearIcon).toBeInTheDocument()
+  })
 })

--- a/apps/lrauv-dash2/lib/useGlobalModalId.ts
+++ b/apps/lrauv-dash2/lib/useGlobalModalId.ts
@@ -62,6 +62,7 @@ export interface GlobalModalMetaData {
     scheduleDate?: string
     via?: 'cell' | 'sat' | 'cellsat'
     isParamUpdate?: boolean
+    isConfigSetUpdate?: boolean
     /** Raw comms status from the Comms Queue — 'queued'|'sent'|'ack'|'timeout' */
     commsStatus?: string
     /** True for automatic Default mission rows (not operator-commanded) */

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -11,7 +11,7 @@ import {
   faPersonRunning,
   faStarOfLife,
   faExclamationTriangle,
-  faGear,
+  faWrench,
 } from '@fortawesome/free-solid-svg-icons'
 import { faClock } from '@fortawesome/free-regular-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
@@ -47,8 +47,8 @@ export interface ScheduleCellProps {
     tooltip?: string
     /** FontAwesome icon to render inside the badge (default: faStarOfLife) */
     icon?: IconProp
-    /** Color scheme: 'amber' for mission param updates, 'slate' for vehicle config updates */
-    variant?: 'amber' | 'slate'
+    /** Color scheme: 'amber' for mission param updates, 'blue' for vehicle config updates */
+    variant?: 'amber' | 'blue'
   }
   /** Override the native tooltip shown on the status icon */
   statusTooltip?: string
@@ -195,8 +195,8 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
                 <span
                   className={clsx(
                     'shrink-0 rounded-full px-2 py-0.5 text-xs font-semibold ring-1',
-                    badge.variant === 'slate'
-                      ? 'bg-slate-100 text-slate-700 ring-slate-300'
+                    badge.variant === 'blue'
+                      ? 'bg-blue-100 text-blue-800 ring-blue-300'
                       : 'bg-amber-100 text-amber-700 ring-amber-300'
                   )}
                 >

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -11,6 +11,7 @@ import {
   faPersonRunning,
   faStarOfLife,
   faExclamationTriangle,
+  faGear,
 } from '@fortawesome/free-solid-svg-icons'
 import { faClock } from '@fortawesome/free-regular-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
@@ -41,7 +42,14 @@ export interface ScheduleCellProps {
   description: string
   description2?: string
   description3?: string
-  badge?: { text: string; tooltip?: string }
+  badge?: {
+    text: string
+    tooltip?: string
+    /** FontAwesome icon to render inside the badge (default: faStarOfLife) */
+    icon?: IconProp
+    /** Color scheme: 'amber' for mission param updates, 'slate' for vehicle config updates */
+    variant?: 'amber' | 'slate'
+  }
   /** Override the native tooltip shown on the status icon */
   statusTooltip?: string
   onSelect: () => void
@@ -184,8 +192,18 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
                 placement="top"
                 disabled={!badge.tooltip && !badge.text}
               >
-                <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700 ring-1 ring-amber-300">
-                  <FontAwesomeIcon icon={faStarOfLife} className="text-xs" />
+                <span
+                  className={clsx(
+                    'shrink-0 rounded-full px-2 py-0.5 text-xs font-semibold ring-1',
+                    badge.variant === 'slate'
+                      ? 'bg-slate-100 text-slate-700 ring-slate-300'
+                      : 'bg-amber-100 text-amber-700 ring-amber-300'
+                  )}
+                >
+                  <FontAwesomeIcon
+                    icon={badge.icon ?? faStarOfLife}
+                    className="text-xs"
+                  />
                 </span>
               </Tippy>
             )}

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -11,7 +11,6 @@ import {
   faPersonRunning,
   faStarOfLife,
   faExclamationTriangle,
-  faWrench,
 } from '@fortawesome/free-solid-svg-icons'
 import { faClock } from '@fortawesome/free-regular-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'


### PR DESCRIPTION
## Summary

The `set <mission>.<param>` pattern was mislabeled as a "config update" throughout the Schedule UI. These are two meaningfully different operations and should be presented differently:

| Command | What it is | Scope | Persists? |
|---|---|---|---|
| `set profile_station.YoYoMaxDepth 40 meter` | Mission parameter update | Running mission | No — ephemeral |
| `configSet VerticalControl.massDefault -16 mm persist` | Vehicle config update | Vehicle subsystem | Yes — survives reboots |

## Changes

### Fix mislabeling of `set <x>.<y>` rows
- Badge text: `'config'` → `'param'`
- Badge tooltip: `'Config update — sent to vehicle'` → `'Mission parameter update — sent to vehicle'`
- Modal annotation: `'(config update for associated mission)'` → `'(parameter update for associated mission)'`
- Status tooltip: updated "Sent" and "Received" descriptions for accuracy
- Modal annotation color: amber (`#b45309`) — matches the amber badge on the row

### Add `configSet` detection (`isConfigSetCommand`)
- Matches any `configSet <arg>` except `configSet list` (read-only query, not a write)
- Catches both dotted (`configSet VerticalControl.massDefault ...`) and non-dotted (`configSet Express linearApproximation ...`) forms
- `configSet` rows now get:
  - **Sent** status with comms ack/timeout upgrade (same treatment as param updates)
  - **`faWrench` icon with blue variant** (`bg-blue-100 text-blue-800`) — visually distinct from the amber `faStarOfLife` used for param updates; gear was replaced with wrench after review because `faGear` rendered as an indistinct circle at `text-xs` size
  - No "Ended" line (instantaneous, like param updates)
  - Modal annotation: `(vehicle config update)` in blue (`#1e40af`) — matches the badge color

### `ScheduleCell` badge extension
- `badge.icon?: IconProp` — override the default `faStarOfLife`
- `badge.variant?: 'amber' | 'blue'` — `'amber'` for mission param updates, `'blue'` for vehicle config updates

### Comms status deduplication
- Merged duplicate `isParam` / `isConfigSet` comms-status branches into a single combined guard

## Test plan

- [ ] Open a vehicle with `set <mission>.<param>` rows — verify amber `faStarOfLife` badge and tooltip reads "Mission parameter update — sent to vehicle"
- [ ] Open the details modal for a param row — verify annotation reads "(parameter update for associated mission)" in amber
- [ ] Open a vehicle with `configSet` rows — verify blue `faWrench` badge and "Sent" verb (not "Ran")
- [ ] Open the details modal for a configSet row — verify annotation reads "(vehicle config update)" in blue
- [ ] Verify neither type shows an "Ended:" line in the schedule cell

Part of #563