### PR TITLE
fix(#574): fix stale ResizeObserver closure and add rAF invalidateSize guards

### DIFF
--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -111,7 +111,8 @@ interface MarkerData {
 // OverviewMap component
 const OverViewMap: React.FC<{
   trackedVehicles: { name: string; id?: string }[]
-}> = ({ trackedVehicles }) => {
+  invalidateSizeRef?: React.MutableRefObject<(() => void) | null>
+}> = ({ trackedVehicles, invalidateSizeRef }) => {
   // Add mapRef to store the Leaflet map instance
   const mapRef = useRef<L.Map | null>(null)
   const mapContainerRef = useRef<HTMLDivElement | null>(null)
@@ -124,6 +125,15 @@ const OverViewMap: React.FC<{
       mapRef.current.invalidateSize()
     }
   }, [size])
+
+  // Fallback: after mount, call invalidateSize at 1 s to catch any Allotment
+  // layout pass that settled after the map was created.
+  useEffect(() => {
+    const id = setTimeout(() => {
+      mapRef.current?.invalidateSize()
+    }, 1000)
+    return () => clearTimeout(id)
+  }, [])
   const router = useRouter()
   const { handleDepthRequest, elevationAvailable } = useGoogleElevator()
   const [center, setCenter] = useState<undefined | [number, number]>()
@@ -656,6 +666,11 @@ const OverViewMap: React.FC<{
               }
             }
 
+            // Expose a stable invalidate handle for external callers (e.g. Allotment onChange)
+            if (invalidateSizeRef) {
+              invalidateSizeRef.current = invalidateIfCurrent
+            }
+
             let firstRafId: number | null = null
             let secondRafId: number | null = null
             let timeoutId: ReturnType<typeof setTimeout> | null = null
@@ -842,6 +857,10 @@ const OverviewPage: NextPage = () => {
   const { setGlobalModalId } = useGlobalModalId()
   const [mobileView, setMobileView] = useState<MobileView>('map')
   const isDesktop = useIsDesktop()
+  // Shared ref populated by OverViewMap once the Leaflet map is ready.
+  // Allotment's onChange fires it so the map re-measures after every
+  // layout pass, including the initial one where pane sizes are first set.
+  const mapInvalidateSizeRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     if (!mounted.current) {
@@ -862,6 +881,7 @@ const OverviewPage: NextPage = () => {
             trackedVehicles={trackedVehicles.map((vehicle) => ({
               name: vehicle,
             }))}
+            invalidateSizeRef={mapInvalidateSizeRef}
           />
         )}
       </div>
@@ -904,6 +924,9 @@ const OverviewPage: NextPage = () => {
                                   snap
                                   defaultSizes={[75, 25]}
                                   proportionalLayout
+                                  onChange={() =>
+                                    mapInvalidateSizeRef.current?.()
+                                  }
                                 >
                                   <Allotment.Pane>
                                     {primarySection}

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -649,16 +649,34 @@ const OverViewMap: React.FC<{
           onMapReady={(map) => {
             logger.debug('🌍 Map ready callback triggered in OverViewMap')
             mapRef.current = map
-            map.invalidateSize()
+
+            const invalidateIfCurrent = () => {
+              if (mapRef.current === map) {
+                map.invalidateSize()
+              }
+            }
+
+            let firstRafId: number | null = null
+            let secondRafId: number | null = null
+            let timeoutId: ReturnType<typeof setTimeout> | null = null
+
+            const cancelScheduled = () => {
+              if (firstRafId !== null) cancelAnimationFrame(firstRafId)
+              if (secondRafId !== null) cancelAnimationFrame(secondRafId)
+              if (timeoutId !== null) clearTimeout(timeoutId)
+            }
+
+            invalidateIfCurrent()
             // Allotment computes pane sizes asynchronously after mount. Call
             // invalidateSize again on the next two animation frames and after a
             // short timeout so Leaflet always measures the final container
             // dimensions, regardless of when the split-pane layout settles.
-            requestAnimationFrame(() => {
-              map.invalidateSize()
-              requestAnimationFrame(() => map.invalidateSize())
+            firstRafId = requestAnimationFrame(() => {
+              invalidateIfCurrent()
+              secondRafId = requestAnimationFrame(() => invalidateIfCurrent())
             })
-            setTimeout(() => map.invalidateSize(), 300)
+            timeoutId = setTimeout(() => invalidateIfCurrent(), 300)
+            map.once('unload', cancelScheduled)
           }}
           trackedVehicles={trackedVehicles?.map((vehicle) => ({
             ...vehicle,

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -650,6 +650,15 @@ const OverViewMap: React.FC<{
             logger.debug('🌍 Map ready callback triggered in OverViewMap')
             mapRef.current = map
             map.invalidateSize()
+            // Allotment computes pane sizes asynchronously after mount. Call
+            // invalidateSize again on the next two animation frames and after a
+            // short timeout so Leaflet always measures the final container
+            // dimensions, regardless of when the split-pane layout settles.
+            requestAnimationFrame(() => {
+              map.invalidateSize()
+              requestAnimationFrame(() => map.invalidateSize())
+            })
+            setTimeout(() => map.invalidateSize(), 300)
           }}
           trackedVehicles={trackedVehicles?.map((vehicle) => ({
             ...vehicle,

--- a/packages/utils/src/useResizeObserver.test.tsx
+++ b/packages/utils/src/useResizeObserver.test.tsx
@@ -1,22 +1,28 @@
 /**
  * @jest-environment jsdom
+ *
+ * jest.mock() factories are hoisted above all imports and let-bindings.
+ * Any variable referenced from inside a factory must be prefixed with
+ * "mock" — Jest allows only those names to cross the hoist boundary safely.
  */
 
 // ---------------------------------------------------------------------------
-// Module mocks — jest.mock is hoisted above imports, so these run first.
+// Hoist-safe mock state  (must be prefixed with "mock" per Jest rules)
 // ---------------------------------------------------------------------------
-
-// Captures the latest observer callback and instance methods so tests can
-// drive them directly without relying on DOM events.
 // ---------------------------------------------------------------------------
-// Imports must come after jest.mock declarations
+// Imports must follow jest.mock declarations
 // ---------------------------------------------------------------------------
 import { act, renderHook } from '@testing-library/react'
 import { useResizeObserver } from './useResizeObserver'
 
-let latestDisconnect: jest.Mock
-let latestCancel: jest.Mock
-let triggerResize: (width: number, height: number) => void
+let mockDisconnect = jest.fn()
+let mockCancel = jest.fn()
+// Populated by the ResizeObserver mock constructor; undefined until first render
+let mockTriggerResize: ((width: number, height: number) => void) | undefined
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
 
 jest.mock('resize-observer-polyfill', () =>
   jest
@@ -24,9 +30,11 @@ jest.mock('resize-observer-polyfill', () =>
     .mockImplementation(
       (cb: (entries: Partial<ResizeObserverEntry>[]) => void) => {
         let observedEl: Element | null = null
-        latestDisconnect = jest.fn()
+        // Fresh disconnect spy per observer instance; captured via module-scope
+        // mock-prefixed variable so tests can reference the latest instance.
+        mockDisconnect = jest.fn()
 
-        triggerResize = (width: number, height: number) => {
+        mockTriggerResize = (width: number, height: number) => {
           cb([
             {
               contentBoxSize: [{ inlineSize: width, blockSize: height }],
@@ -41,7 +49,7 @@ jest.mock('resize-observer-polyfill', () =>
             observedEl = el
           }),
           unobserve: jest.fn(),
-          disconnect: (...args: unknown[]) => latestDisconnect(...args),
+          disconnect: (...args: unknown[]) => mockDisconnect(...args),
         }
       }
     )
@@ -51,9 +59,9 @@ jest.mock('resize-observer-polyfill', () =>
 jest.mock('lodash', () => ({
   ...jest.requireActual('lodash'),
   throttle: (fn: (...args: unknown[]) => unknown) => {
-    latestCancel = jest.fn()
+    mockCancel = jest.fn()
     const passThrough: any = (...args: unknown[]) => fn(...args)
-    passThrough.cancel = (...args: unknown[]) => latestCancel(...args)
+    passThrough.cancel = (...args: unknown[]) => mockCancel(...args)
     passThrough.flush = jest.fn()
     return passThrough
   },
@@ -71,6 +79,14 @@ function renderWithDiv(wait?: number) {
   )
 }
 
+function fireResize(width: number, height: number) {
+  act(() => {
+    if (!mockTriggerResize)
+      throw new Error('ResizeObserver not yet instantiated')
+    mockTriggerResize(width, height)
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -83,44 +99,44 @@ describe('useResizeObserver', () => {
 
   it('updates size when the observer fires', () => {
     const { result } = renderWithDiv()
-    act(() => triggerResize(800, 600))
+    fireResize(800, 600)
     expect(result.current.size).toEqual({ width: 800, height: 600 })
   })
 
-  it('does not update size when dimensions are unchanged (no spurious re-renders)', () => {
+  it('does not trigger re-renders when dimensions are unchanged', () => {
     const { result } = renderWithDiv()
-    act(() => triggerResize(800, 600))
+    fireResize(800, 600)
     const sizeBefore = result.current.size
-    act(() => triggerResize(800, 600))
-    // Functional setState returns the same object reference when nothing changed
+    fireResize(800, 600)
+    // Functional setState must return the same reference when nothing changed
     expect(result.current.size).toBe(sizeBefore)
   })
 
   it('continues to report correct size after multiple resize events', () => {
     const { result } = renderWithDiv()
-    act(() => triggerResize(400, 300))
+    fireResize(400, 300)
     expect(result.current.size).toEqual({ width: 400, height: 300 })
-    act(() => triggerResize(1024, 768))
+    fireResize(1024, 768)
     expect(result.current.size).toEqual({ width: 1024, height: 768 })
   })
 
   it('disconnects unconditionally on unmount (ref may be null by then)', () => {
     const { unmount } = renderWithDiv()
-    const spy = latestDisconnect
+    const spy = mockDisconnect
     unmount()
     expect(spy).toHaveBeenCalled()
   })
 
   it('cancels any pending throttled invocation on unmount', () => {
     const { unmount } = renderWithDiv()
-    const spy = latestCancel
+    const spy = mockCancel
     unmount()
     expect(spy).toHaveBeenCalled()
   })
 
   it('disconnects the previous observer before creating a new one when wait changes', () => {
     const { rerender } = renderWithDiv(100)
-    const firstDisconnect = latestDisconnect
+    const firstDisconnect = mockDisconnect
     rerender({ w: 200 })
     expect(firstDisconnect).toHaveBeenCalled()
   })

--- a/packages/utils/src/useResizeObserver.test.tsx
+++ b/packages/utils/src/useResizeObserver.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// ---------------------------------------------------------------------------
+// Module mocks — jest.mock is hoisted above imports, so these run first.
+// ---------------------------------------------------------------------------
+
+// Captures the latest observer callback and instance methods so tests can
+// drive them directly without relying on DOM events.
+// ---------------------------------------------------------------------------
+// Imports must come after jest.mock declarations
+// ---------------------------------------------------------------------------
+import { act, renderHook } from '@testing-library/react'
+import { useResizeObserver } from './useResizeObserver'
+
+let latestDisconnect: jest.Mock
+let latestCancel: jest.Mock
+let triggerResize: (width: number, height: number) => void
+
+jest.mock('resize-observer-polyfill', () =>
+  jest
+    .fn()
+    .mockImplementation(
+      (cb: (entries: Partial<ResizeObserverEntry>[]) => void) => {
+        let observedEl: Element | null = null
+        latestDisconnect = jest.fn()
+
+        triggerResize = (width: number, height: number) => {
+          cb([
+            {
+              contentBoxSize: [{ inlineSize: width, blockSize: height }],
+              contentRect: { width, height } as DOMRectReadOnly,
+              target: observedEl!,
+            },
+          ])
+        }
+
+        return {
+          observe: jest.fn((el: Element) => {
+            observedEl = el
+          }),
+          unobserve: jest.fn(),
+          disconnect: (...args: unknown[]) => latestDisconnect(...args),
+        }
+      }
+    )
+)
+
+// Make throttle call through immediately so tests don't need fake timers.
+jest.mock('lodash', () => ({
+  ...jest.requireActual('lodash'),
+  throttle: (fn: (...args: unknown[]) => unknown) => {
+    latestCancel = jest.fn()
+    const passThrough: any = (...args: unknown[]) => fn(...args)
+    passThrough.cancel = (...args: unknown[]) => latestCancel(...args)
+    passThrough.flush = jest.fn()
+    return passThrough
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderWithDiv(wait?: number) {
+  const divRef = { current: document.createElement('div') }
+  return renderHook(
+    ({ w }: { w?: number }) => useResizeObserver({ element: divRef, wait: w }),
+    { initialProps: { w: wait } }
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useResizeObserver', () => {
+  it('starts with zero size', () => {
+    const { result } = renderWithDiv()
+    expect(result.current.size).toEqual({ width: 0, height: 0 })
+  })
+
+  it('updates size when the observer fires', () => {
+    const { result } = renderWithDiv()
+    act(() => triggerResize(800, 600))
+    expect(result.current.size).toEqual({ width: 800, height: 600 })
+  })
+
+  it('does not update size when dimensions are unchanged (no spurious re-renders)', () => {
+    const { result } = renderWithDiv()
+    act(() => triggerResize(800, 600))
+    const sizeBefore = result.current.size
+    act(() => triggerResize(800, 600))
+    // Functional setState returns the same object reference when nothing changed
+    expect(result.current.size).toBe(sizeBefore)
+  })
+
+  it('continues to report correct size after multiple resize events', () => {
+    const { result } = renderWithDiv()
+    act(() => triggerResize(400, 300))
+    expect(result.current.size).toEqual({ width: 400, height: 300 })
+    act(() => triggerResize(1024, 768))
+    expect(result.current.size).toEqual({ width: 1024, height: 768 })
+  })
+
+  it('disconnects unconditionally on unmount (ref may be null by then)', () => {
+    const { unmount } = renderWithDiv()
+    const spy = latestDisconnect
+    unmount()
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('cancels any pending throttled invocation on unmount', () => {
+    const { unmount } = renderWithDiv()
+    const spy = latestCancel
+    unmount()
+    expect(spy).toHaveBeenCalled()
+  })
+
+  it('disconnects the previous observer before creating a new one when wait changes', () => {
+    const { rerender } = renderWithDiv(100)
+    const firstDisconnect = latestDisconnect
+    rerender({ w: 200 })
+    expect(firstDisconnect).toHaveBeenCalled()
+  })
+})

--- a/packages/utils/src/useResizeObserver.ts
+++ b/packages/utils/src/useResizeObserver.ts
@@ -37,14 +37,17 @@ export const useResizeObserver = <T>({
             width = entry.contentRect.width
           }
         }
-        if (size.width !== width || size.height !== height) {
-          setSize({
-            height,
-            width,
-          })
-        }
+        setSize((prev) => {
+          if (prev.width !== width || prev.height !== height) {
+            return { height, width }
+          }
+          return prev
+        })
       }, wait),
-    [setSize, wait, size]
+    // Intentionally omit `size` — using functional setState avoids a stale
+    // closure that would cause the ResizeObserver to keep an outdated callback.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [setSize, wait]
   )
 
   useEffect(() => {
@@ -63,7 +66,7 @@ export const useResizeObserver = <T>({
         observerRef.current?.unobserve(element)
       }
     }
-  }, [elementRef, wait, observerRef])
+  }, [elementRef, wait, observerRef, callback])
 
   return { size }
 }

--- a/packages/utils/src/useResizeObserver.ts
+++ b/packages/utils/src/useResizeObserver.ts
@@ -44,10 +44,7 @@ export const useResizeObserver = <T>({
           return prev
         })
       }, wait),
-    // Intentionally omit `size` — using functional setState avoids a stale
-    // closure that would cause the ResizeObserver to keep an outdated callback.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [setSize, wait]
+    [wait]
   )
 
   useEffect(() => {
@@ -62,8 +59,9 @@ export const useResizeObserver = <T>({
     }
 
     return () => {
+      callback.cancel()
       if (elementRef.current) {
-        observerRef.current?.unobserve(element)
+        observerRef.current?.disconnect()
       }
     }
   }, [elementRef, wait, observerRef, callback])

--- a/packages/utils/src/useResizeObserver.ts
+++ b/packages/utils/src/useResizeObserver.ts
@@ -48,21 +48,22 @@ export const useResizeObserver = <T>({
   )
 
   useEffect(() => {
-    const element: Element = elementRef.current as any
-    if (elementRef.current) {
-      observerRef.current?.unobserve(element)
-    }
+    // Disconnect the previous observer before replacing it so no stale
+    // observer continues to fire after a callback/element/wait change.
+    observerRef.current?.disconnect()
+
     const ResizeObserverOrPolyfill = ResizeObserver
     observerRef.current = new ResizeObserverOrPolyfill(callback)
     if (elementRef.current) {
-      observerRef.current?.observe(element)
+      observerRef.current.observe(elementRef.current as unknown as Element)
     }
 
     return () => {
+      // Cancel any pending throttle invocation and disconnect unconditionally —
+      // React may null refs before cleanup runs, so we cannot rely on
+      // elementRef.current being truthy here.
       callback.cancel()
-      if (elementRef.current) {
-        observerRef.current?.disconnect()
-      }
+      observerRef.current?.disconnect()
     }
   }, [elementRef, wait, observerRef, callback])
 


### PR DESCRIPTION
Closes #574

## Summary

- **`packages/utils/src/useResizeObserver.ts`** — fix stale closure bug: switch to functional `setState(prev => ...)` so `size` is no longer captured in the throttled callback; add `callback` to the observer `useEffect` deps so the `ResizeObserver` always holds the current callback.
- **`apps/lrauv-dash2/pages/index.tsx`** — add two `requestAnimationFrame`-chained `invalidateSize` calls and a 300 ms fallback in `onMapReady` so Leaflet always re-measures the container after Allotment has finished its async proportional layout pass.

## Why this fixes it

The previous fix (#543) introduced `useResizeObserver` but left a closure bug: the observer always held the first-render callback (where `mapRef.current === null`). By the time the map mounted, Allotment had already fired its layout event so no further resize event arrived — `invalidateSize` via the observer path was never reached. The synchronous `invalidateSize` in `onMapReady` fired before Allotment finished computing pane dimensions, so Leaflet measured the wrong container size.

## Test plan

- [ ] Hard-refresh the Overview page — map fills its full container every time
- [ ] Navigate away and back — map still renders at full size
- [ ] Open browser console — no new React warnings introduced
- [ ] Resize the browser window — map tiles repaint correctly