### PR TITLE
fix: Overview map partial render on client-side navigation (offsetWidth poller)

### DIFF
--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -165,7 +165,9 @@ const OverViewMap: React.FC<{
     return () => {
       clearInterval(pollId)
       map.off('unload', stopPoll)
-      mapRef.current = null
+      if (mapRef.current === map) {
+        mapRef.current = null
+      }
     }
   }, [currentMap])
   const router = useRouter()

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -117,6 +117,10 @@ const OverViewMap: React.FC<{
   const mapRef = useRef<L.Map | null>(null)
   const mapContainerRef = useRef<HTMLDivElement | null>(null)
 
+  // Track when the Leaflet map instance has been created so we can start the
+  // container-width poller below.
+  const [mapCreated, setMapCreated] = useState(false)
+
   // Call invalidateSize whenever the container resizes (fixes partial-map rendering
   // after refresh). useResizeObserver is polyfilled and throttled (100 ms by default).
   const { size } = useResizeObserver({ element: mapContainerRef })
@@ -126,14 +130,31 @@ const OverViewMap: React.FC<{
     }
   }, [size])
 
-  // Fallback: after mount, call invalidateSize at 1 s to catch any Allotment
-  // layout pass that settled after the map was created.
+  // Poll the container's offsetWidth every 100 ms for 2 s after the map is
+  // created. Whenever the width changes (Allotment settling its layout,
+  // especially during client-side navigation where the chunk is cached and the
+  // map mounts before Allotment has measured its container) call invalidateSize.
+  // This is the standard Leaflet pattern for dynamically-sized host containers.
   useEffect(() => {
-    const id = setTimeout(() => {
-      mapRef.current?.invalidateSize()
-    }, 1000)
-    return () => clearTimeout(id)
-  }, [])
+    if (!mapCreated) return
+    const map = mapRef.current
+    if (!map) return
+    let lastWidth = mapContainerRef.current?.offsetWidth ?? 0
+    let ticks = 0
+    const poll = setInterval(() => {
+      if (mapRef.current !== map) {
+        clearInterval(poll)
+        return
+      }
+      const w = mapContainerRef.current?.offsetWidth ?? 0
+      if (w > 0 && w !== lastWidth) {
+        lastWidth = w
+        map.invalidateSize()
+      }
+      if (++ticks >= 20) clearInterval(poll)
+    }, 100)
+    return () => clearInterval(poll)
+  }, [mapCreated])
   const router = useRouter()
   const { handleDepthRequest, elevationAvailable } = useGoogleElevator()
   const [center, setCenter] = useState<undefined | [number, number]>()
@@ -659,6 +680,7 @@ const OverViewMap: React.FC<{
           onMapReady={(map) => {
             logger.debug('🌍 Map ready callback triggered in OverViewMap')
             mapRef.current = map
+            setMapCreated(true)
 
             const invalidateIfCurrent = () => {
               if (mapRef.current === map) {

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -117,9 +117,10 @@ const OverViewMap: React.FC<{
   const mapRef = useRef<L.Map | null>(null)
   const mapContainerRef = useRef<HTMLDivElement | null>(null)
 
-  // Track when the Leaflet map instance has been created so we can start the
-  // container-width poller below.
-  const [mapCreated, setMapCreated] = useState(false)
+  // Track the current Leaflet map instance so the container-width poller below
+  // restarts whenever onMapReady fires with a new map (e.g. after the Map key
+  // changes on navigation while OverViewMap stays mounted).
+  const [currentMap, setCurrentMap] = useState<L.Map | null>(null)
 
   // Call invalidateSize whenever the container resizes (fixes partial-map rendering
   // after refresh). useResizeObserver is polyfilled and throttled (100 ms by default).
@@ -136,9 +137,8 @@ const OverViewMap: React.FC<{
   // map mounts before Allotment has measured its container) call invalidateSize.
   // This is the standard Leaflet pattern for dynamically-sized host containers.
   useEffect(() => {
-    if (!mapCreated) return
-    const map = mapRef.current
-    if (!map) return
+    if (!currentMap) return
+    const map = currentMap
     let lastWidth = mapContainerRef.current?.offsetWidth ?? 0
     let ticks = 0
     const poll = setInterval(() => {
@@ -156,7 +156,7 @@ const OverViewMap: React.FC<{
       }
     }, 100)
     return () => clearInterval(poll)
-  }, [mapCreated])
+  }, [currentMap])
   const router = useRouter()
   const { handleDepthRequest, elevationAvailable } = useGoogleElevator()
   const [center, setCenter] = useState<undefined | [number, number]>()
@@ -682,7 +682,7 @@ const OverViewMap: React.FC<{
           onMapReady={(map) => {
             logger.debug('🌍 Map ready callback triggered in OverViewMap')
             mapRef.current = map
-            setMapCreated(true)
+            setCurrentMap(map)
 
             const containerW = mapContainerRef.current?.offsetWidth ?? 0
             const containerH = mapContainerRef.current?.offsetHeight ?? 0
@@ -948,7 +948,7 @@ const OverviewPage: NextPage = () => {
                                   snap
                                   defaultSizes={[75, 25]}
                                   proportionalLayout
-                                  onChange={(sizes) => {
+                                  onChange={() => {
                                     mapInvalidateSizeRef.current?.()
                                   }}
                                 >

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -141,21 +141,32 @@ const OverViewMap: React.FC<{
     const map = currentMap
     let lastWidth = mapContainerRef.current?.offsetWidth ?? 0
     let ticks = 0
-    const poll = setInterval(() => {
-      if (mapRef.current !== map) {
-        clearInterval(poll)
+    let pollId: ReturnType<typeof setInterval>
+
+    const stopPoll = () => clearInterval(pollId)
+
+    pollId = setInterval(() => {
+      if (mapRef.current !== map || !mapContainerRef.current) {
+        clearInterval(pollId)
         return
       }
-      const w = mapContainerRef.current?.offsetWidth ?? 0
+      const w = mapContainerRef.current.offsetWidth
       if (w > 0 && w !== lastWidth) {
         lastWidth = w
         map.invalidateSize()
       }
       if (++ticks >= 20) {
-        clearInterval(poll)
+        clearInterval(pollId)
       }
     }, 100)
-    return () => clearInterval(poll)
+
+    map.once('unload', stopPoll)
+
+    return () => {
+      clearInterval(pollId)
+      map.off('unload', stopPoll)
+      mapRef.current = null
+    }
   }, [currentMap])
   const router = useRouter()
   const { handleDepthRequest, elevationAvailable } = useGoogleElevator()

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -121,26 +121,11 @@ const OverViewMap: React.FC<{
   // container-width poller below.
   const [mapCreated, setMapCreated] = useState(false)
 
-  useEffect(() => {
-    console.log(
-      '[MapDebug] OverViewMap mounted — container offsetWidth:',
-      mapContainerRef.current?.offsetWidth ?? 'ref not yet set'
-    )
-    return () => console.log('[MapDebug] OverViewMap unmounted')
-  }, [])
-
   // Call invalidateSize whenever the container resizes (fixes partial-map rendering
   // after refresh). useResizeObserver is polyfilled and throttled (100 ms by default).
   const { size } = useResizeObserver({ element: mapContainerRef })
   useEffect(() => {
-    console.log(
-      '[MapDebug] ResizeObserver fired — size:',
-      size,
-      '| mapRef set:',
-      !!mapRef.current
-    )
     if (typeof mapRef.current?.invalidateSize === 'function') {
-      console.log('[MapDebug] ResizeObserver → calling invalidateSize')
       mapRef.current.invalidateSize()
     }
   }, [size])
@@ -155,7 +140,6 @@ const OverViewMap: React.FC<{
     const map = mapRef.current
     if (!map) return
     let lastWidth = mapContainerRef.current?.offsetWidth ?? 0
-    console.log('[MapDebug] Poller started — initial offsetWidth:', lastWidth)
     let ticks = 0
     const poll = setInterval(() => {
       if (mapRef.current !== map) {
@@ -163,24 +147,11 @@ const OverViewMap: React.FC<{
         return
       }
       const w = mapContainerRef.current?.offsetWidth ?? 0
-      console.log(
-        `[MapDebug] Poller tick ${
-          ticks + 1
-        }/20 — offsetWidth: ${w}, lastWidth: ${lastWidth}`
-      )
       if (w > 0 && w !== lastWidth) {
         lastWidth = w
-        console.log(
-          '[MapDebug] Poller width changed → calling invalidateSize, new width:',
-          w
-        )
         map.invalidateSize()
       }
       if (++ticks >= 20) {
-        console.log(
-          '[MapDebug] Poller done after 20 ticks — final offsetWidth:',
-          w
-        )
         clearInterval(poll)
       }
     }, 100)
@@ -715,23 +686,11 @@ const OverViewMap: React.FC<{
 
             const containerW = mapContainerRef.current?.offsetWidth ?? 0
             const containerH = mapContainerRef.current?.offsetHeight ?? 0
-            console.log(
-              `[MapDebug] onMapReady — container: ${containerW}×${containerH} | Leaflet _size:`,
-              (map as any)._size
-            )
+            logger.debug(`onMapReady — container: ${containerW}×${containerH}`)
 
             const invalidateIfCurrent = () => {
               if (mapRef.current === map) {
-                const w = mapContainerRef.current?.offsetWidth ?? 0
-                const h = mapContainerRef.current?.offsetHeight ?? 0
-                console.log(
-                  `[MapDebug] invalidateIfCurrent called — container: ${w}×${h}`
-                )
                 map.invalidateSize()
-                console.log(
-                  '[MapDebug] invalidateIfCurrent done — Leaflet _size:',
-                  (map as any)._size
-                )
               }
             }
 
@@ -990,12 +949,6 @@ const OverviewPage: NextPage = () => {
                                   defaultSizes={[75, 25]}
                                   proportionalLayout
                                   onChange={(sizes) => {
-                                    console.log(
-                                      '[MapDebug] Allotment onChange — sizes:',
-                                      sizes,
-                                      '| invalidateSizeRef set:',
-                                      !!mapInvalidateSizeRef.current
-                                    )
                                     mapInvalidateSizeRef.current?.()
                                   }}
                                 >

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -121,11 +121,26 @@ const OverViewMap: React.FC<{
   // container-width poller below.
   const [mapCreated, setMapCreated] = useState(false)
 
+  useEffect(() => {
+    console.log(
+      '[MapDebug] OverViewMap mounted — container offsetWidth:',
+      mapContainerRef.current?.offsetWidth ?? 'ref not yet set'
+    )
+    return () => console.log('[MapDebug] OverViewMap unmounted')
+  }, [])
+
   // Call invalidateSize whenever the container resizes (fixes partial-map rendering
   // after refresh). useResizeObserver is polyfilled and throttled (100 ms by default).
   const { size } = useResizeObserver({ element: mapContainerRef })
   useEffect(() => {
+    console.log(
+      '[MapDebug] ResizeObserver fired — size:',
+      size,
+      '| mapRef set:',
+      !!mapRef.current
+    )
     if (typeof mapRef.current?.invalidateSize === 'function') {
+      console.log('[MapDebug] ResizeObserver → calling invalidateSize')
       mapRef.current.invalidateSize()
     }
   }, [size])
@@ -140,6 +155,7 @@ const OverViewMap: React.FC<{
     const map = mapRef.current
     if (!map) return
     let lastWidth = mapContainerRef.current?.offsetWidth ?? 0
+    console.log('[MapDebug] Poller started — initial offsetWidth:', lastWidth)
     let ticks = 0
     const poll = setInterval(() => {
       if (mapRef.current !== map) {
@@ -147,11 +163,26 @@ const OverViewMap: React.FC<{
         return
       }
       const w = mapContainerRef.current?.offsetWidth ?? 0
+      console.log(
+        `[MapDebug] Poller tick ${
+          ticks + 1
+        }/20 — offsetWidth: ${w}, lastWidth: ${lastWidth}`
+      )
       if (w > 0 && w !== lastWidth) {
         lastWidth = w
+        console.log(
+          '[MapDebug] Poller width changed → calling invalidateSize, new width:',
+          w
+        )
         map.invalidateSize()
       }
-      if (++ticks >= 20) clearInterval(poll)
+      if (++ticks >= 20) {
+        console.log(
+          '[MapDebug] Poller done after 20 ticks — final offsetWidth:',
+          w
+        )
+        clearInterval(poll)
+      }
     }, 100)
     return () => clearInterval(poll)
   }, [mapCreated])
@@ -682,9 +713,25 @@ const OverViewMap: React.FC<{
             mapRef.current = map
             setMapCreated(true)
 
+            const containerW = mapContainerRef.current?.offsetWidth ?? 0
+            const containerH = mapContainerRef.current?.offsetHeight ?? 0
+            console.log(
+              `[MapDebug] onMapReady — container: ${containerW}×${containerH} | Leaflet _size:`,
+              (map as any)._size
+            )
+
             const invalidateIfCurrent = () => {
               if (mapRef.current === map) {
+                const w = mapContainerRef.current?.offsetWidth ?? 0
+                const h = mapContainerRef.current?.offsetHeight ?? 0
+                console.log(
+                  `[MapDebug] invalidateIfCurrent called — container: ${w}×${h}`
+                )
                 map.invalidateSize()
+                console.log(
+                  '[MapDebug] invalidateIfCurrent done — Leaflet _size:',
+                  (map as any)._size
+                )
               }
             }
 
@@ -704,10 +751,6 @@ const OverViewMap: React.FC<{
             }
 
             invalidateIfCurrent()
-            // Allotment computes pane sizes asynchronously after mount. Call
-            // invalidateSize again on the next two animation frames and after a
-            // short timeout so Leaflet always measures the final container
-            // dimensions, regardless of when the split-pane layout settles.
             firstRafId = requestAnimationFrame(() => {
               invalidateIfCurrent()
               secondRafId = requestAnimationFrame(() => invalidateIfCurrent())
@@ -946,9 +989,15 @@ const OverviewPage: NextPage = () => {
                                   snap
                                   defaultSizes={[75, 25]}
                                   proportionalLayout
-                                  onChange={() =>
+                                  onChange={(sizes) => {
+                                    console.log(
+                                      '[MapDebug] Allotment onChange — sizes:',
+                                      sizes,
+                                      '| invalidateSizeRef set:',
+                                      !!mapInvalidateSizeRef.current
+                                    )
                                     mapInvalidateSizeRef.current?.()
-                                  }
+                                  }}
                                 >
                                   <Allotment.Pane>
                                     {primarySection}

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -39,27 +39,6 @@ import { createLogger } from '@mbari/utils'
 
 const logger = createLogger('Map')
 
-// safeLogger wrapper that suppresses debug logs during critical operations
-const createSafeLogger = (
-  originalLogger: any,
-  disabledLevels: string[] = ['debug']
-) => {
-  // Copy of the original logger
-  const safeLogger = { ...originalLogger }
-
-  // Disable specified log levels by replacing them with no-op functions
-  disabledLevels.forEach((level) => {
-    if (level in safeLogger) {
-      safeLogger[level] = () => {} // No-op function
-    }
-  })
-
-  return safeLogger
-}
-
-// safeLogger instance that will be used during initialization
-const safeLogger = createSafeLogger(logger, ['debug'])
-
 const DEFAULT_CENTER: [number, number] = [36.8022, -121.788]
 
 const regex = /\B(?=(\d{3})+(?!\d))/g
@@ -111,7 +90,7 @@ const MapReadyBridge: React.FC<{
       }
       if (onReady) onReady(map)
     }
-  })
+  }, [map, onReady, forwardedRef])
 
   return null
 }

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -6,6 +6,7 @@ import {
   LayersControl,
   ScaleControl,
   useMapEvents,
+  useMap,
 } from 'react-leaflet'
 import ReactLeafletGoogleLayer from 'react-leaflet-google-layer'
 const GoogleLayerAny =
@@ -86,6 +87,34 @@ interface StoredMarker {
 export type { MapProps } from './Map.types'
 
 export type MeasureMode = 'open' | 'measuring' | 'closed' | 'cancelled'
+
+/**
+ * MapReadyBridge — a react-leaflet v4 child component that uses useMap() to
+ * obtain the Leaflet map instance and fires `onReady` exactly once per map
+ * instance. This replaces the defunct `whenCreated` prop which was removed in
+ * react-leaflet v4 and is silently ignored (passed through to ...options on
+ * the Leaflet constructor which discards it).
+ */
+const MapReadyBridge: React.FC<{
+  onReady?: (map: L.Map) => void
+  forwardedRef?: React.Ref<L.Map>
+}> = ({ onReady, forwardedRef }) => {
+  const map = useMap()
+  const initializedMapRef = useRef<L.Map | null>(null)
+
+  useEffect(() => {
+    if (map && map !== initializedMapRef.current) {
+      initializedMapRef.current = map
+      if (forwardedRef) {
+        if (typeof forwardedRef === 'function') forwardedRef(map)
+        else (forwardedRef as React.MutableRefObject<L.Map>).current = map
+      }
+      if (onReady) onReady(map)
+    }
+  })
+
+  return null
+}
 
 const Map = React.forwardRef<L.Map, MapProps>(
   (
@@ -583,70 +612,11 @@ const Map = React.forwardRef<L.Map, MapProps>(
         // @ts-ignore
         maxNativeZoom={maxNativeZoom}
         ref={mapRef}
-        whenCreated={(map: L.Map) => {
-          try {
-            if (!map) {
-              logger.warn('Map instance is null in whenCreated')
-              return
-            }
-
-            safeLogger.debug('Map instance created, initializing...')
-
-            // Guard against GoogleMutant async callbacks firing after the map
-            // has been removed. When map.remove() runs, Leaflet nulls
-            // _controlCorners, but GoogleMutant still has pending Google API
-            // callbacks that call _setupAttribution → crash. Patching fire()
-            // on this specific instance to be a no-op once the map is gone is
-            // the least-invasive fix without modifying the library.
-            const origFire = (map as any).fire.bind(map)
-            ;(map as any).fire = (...args: Parameters<typeof map.fire>) => {
-              if (!(map as any)._controlCorners) return map
-              return origFire(...args)
-            }
-
-            // Store reference to actual Leaflet map
-            mapRef.current = map
-
-            // Forward the reference
-            if (ref) {
-              if (typeof ref === 'function') {
-                ref(map)
-              } else {
-                ref.current = map
-              }
-              safeLogger.debug('Map reference forwarded')
-            }
-
-            // Call onMapReady
-            if (onMapReady) {
-              safeLogger.debug('Calling onMapReady callback')
-              onMapReady(map)
-            }
-
-            // Dispatch with minimal delay
-            setTimeout(() => {
-              if (typeof window !== 'undefined') {
-                try {
-                  // Use safeLogger for this chatty operation
-                  safeLogger.debug('Creating mapready event')
-
-                  const mapReadyEvent = new CustomEvent('mapready', {
-                    detail: map,
-                  })
-                  window.dispatchEvent(mapReadyEvent)
-
-                  // This log is important enough to keep!
-                  logger.info('mapready event dispatched')
-                } catch (e) {
-                  logger.error('Error dispatching mapready event:', e)
-                }
-              }
-            }, 100)
-          } catch (err) {
-            logger.error('Error in map initialization:', err)
-          }
-        }}
       >
+        {/* Bridge to obtain the Leaflet map instance via useMap() — the
+            whenCreated prop was removed in react-leaflet v4 and is silently
+            ignored, so onMapReady and ref forwarding must go through here. */}
+        <MapReadyBridge onReady={onMapReady} forwardedRef={ref} />
         {!isMeasuring && (
           <CenterView
             coords={validatedCenter}

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -80,17 +80,34 @@ const MapReadyBridge: React.FC<{
 }> = ({ onReady, forwardedRef }) => {
   const map = useMap()
   const initializedMapRef = useRef<L.Map | null>(null)
+  const onReadyRef = useRef(onReady)
+  const forwardedRefHolder = useRef(forwardedRef)
+
+  // Keep latest callbacks in refs so the effect below doesn't need them as
+  // deps — onMapReady is typically an inline function and would otherwise
+  // cause the effect to re-fire (and re-call onReady) on every parent render.
+  onReadyRef.current = onReady
+  forwardedRefHolder.current = forwardedRef
 
   useEffect(() => {
     if (map && map !== initializedMapRef.current) {
       initializedMapRef.current = map
-      if (forwardedRef) {
-        if (typeof forwardedRef === 'function') forwardedRef(map)
-        else (forwardedRef as React.MutableRefObject<L.Map>).current = map
+      const fRef = forwardedRefHolder.current
+      if (fRef) {
+        if (typeof fRef === 'function') fRef(map)
+        else (fRef as React.MutableRefObject<L.Map>).current = map
       }
-      if (onReady) onReady(map)
+      onReadyRef.current?.(map)
     }
-  }, [map, onReady, forwardedRef])
+    return () => {
+      initializedMapRef.current = null
+      const fRef = forwardedRefHolder.current
+      if (fRef) {
+        if (typeof fRef === 'function') fRef(null)
+        else (fRef as React.MutableRefObject<L.Map | null>).current = null
+      }
+    }
+  }, [map])
 
   return null
 }


### PR DESCRIPTION
## Problem

The Overview map still renders at partial width when navigating to it from a deployment page (client-side navigation). During navigation, `mapsLoaded` is already `true` and the dynamic `<Map>` chunk is cached, so it mounts almost synchronously. Allotment fires its initial `onChange` layout callback **before** the map instance exists (`mapInvalidateSizeRef.current === null`), so the call is a no-op. Allotment never fires `onChange` again, leaving the map sized at its incorrect initialised dimensions.

## Fix

Replace the one-shot rAF/timeout approach with an `offsetWidth` poller:

- `onMapReady` sets a `mapCreated` React state flag in addition to populating `mapRef` and `invalidateSizeRef`.
- A `useEffect([mapCreated])` starts a 100 ms interval that reads `mapContainerRef.current.offsetWidth` on each tick and calls `map.invalidateSize()` whenever the width changes (max 20 ticks = 2 s).
- This reliably catches the Allotment layout pass regardless of whether it fires before or after the map is created — handles hard page loads, client-side navigations, and window resizes.

## Test plan
- [ ] Hard-refresh the Overview page — map fills its container every time
- [ ] Navigate from a deployment vehicle page to Overview — map fills its container every time  
- [ ] Navigate back and forth several times — consistent
- [ ] Drag the Allotment splitter — map repaints correctly