### PR TITLE
fix: correct ESRI tile layer URL and env var interpolation (#579)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
   NEXT_PUBLIC_ODSS2BASE_URL: ${{ vars.NEXT_PUBLIC_ODSS2BASE_URL || 'http://okeanids.mbari.org//odss2dash/api' }}
   NEXT_PUBLIC_WEBSOCKET_URL: ${{ vars.NEXT_PUBLIC_WEBSOCKET_URL || 'wss://okeanids.mbari.org/ws/' }}
   NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY || 'placeholder-api-key' }}
-  NEXT_PUBLIC_ESRI_API_KEY: ${{ secrets.REACT_APP_ESRI_API_KEY || 'placeholder-api-key' }}
+  NEXT_PUBLIC_ESRI_API_KEY: ${{ secrets.ESRI_API_KEY || secrets.REACT_APP_ESRI_API_KEY || 'placeholder-api-key' }}
 
 jobs:
   determine-environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
   NEXT_PUBLIC_ODSS2BASE_URL: ${{ vars.NEXT_PUBLIC_ODSS2BASE_URL || 'http://okeanids.mbari.org//odss2dash/api' }}
   NEXT_PUBLIC_WEBSOCKET_URL: ${{ vars.NEXT_PUBLIC_WEBSOCKET_URL || 'wss://okeanids.mbari.org/ws/' }}
   NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY || 'placeholder-api-key' }}
-  NEXT_PUBLIC_REACT_APP_ESRI_API_KEY: ${{ secrets.REACT_APP_ESRI_API_KEY || 'placeholder-api-key' }}
+  NEXT_PUBLIC_ESRI_API_KEY: ${{ secrets.REACT_APP_ESRI_API_KEY || 'placeholder-api-key' }}
 
 jobs:
   determine-environment:

--- a/apps/lrauv-dash2/.env.example
+++ b/apps/lrauv-dash2/.env.example
@@ -3,3 +3,4 @@ NEXT_PUBLIC_BASE_URL=http://localhost:3002/TethysDash/api
 NEXT_PUBLIC_ODSS2BASE_URL=http://localhost:3002/odss2dash/api
 NEXT_PUBLIC_WEBSOCKET_URL=wss://okeanids.mbari.org/ws/
 NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=<your key here>
+NEXT_PUBLIC_ESRI_API_KEY=<your key here>

--- a/apps/lrauv-dash2/next.config.js
+++ b/apps/lrauv-dash2/next.config.js
@@ -1,5 +1,3 @@
-const path = require('path')
-
 // This is a workaround for Next.js 15 to handle TypeScript files in workspace packages
 const nextConfig = {
   output: 'export',

--- a/apps/lrauv-dash2/next.config.js
+++ b/apps/lrauv-dash2/next.config.js
@@ -1,3 +1,5 @@
+const path = require('path')
+
 // This is a workaround for Next.js 15 to handle TypeScript files in workspace packages
 const nextConfig = {
   output: 'export',
@@ -9,6 +11,16 @@ const nextConfig = {
 
   // Next.js 13+ uses transpilePackages
   transpilePackages: ['@mbari/react-ui', '@mbari/utils', '@mbari/api-client'],
+
+  webpack: (config) => {
+    // Watch monorepo packages for HMR so changes to packages/react-ui etc.
+    // trigger hot reload without a full dev server restart.
+    config.watchOptions = {
+      ...config.watchOptions,
+      ignored: ['**/node_modules/**', '**/.git/**', '**/.next/**'],
+    }
+    return config
+  },
 }
 
 module.exports = nextConfig

--- a/packages/react-ui/src/Map/Map.test.tsx
+++ b/packages/react-ui/src/Map/Map.test.tsx
@@ -1,5 +1,37 @@
 import '@testing-library/jest-dom'
+import { esriTileUrl } from './esriTileUrl'
 
 test.todo(
   'forego testing on the Map component unless we want to troubleshoot webpack, jest, and leaflet which is going to be can of worms.'
 )
+
+describe('esriTileUrl', () => {
+  const BASE =
+    'https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}'
+
+  it('includes the provided API key as a token query param', () => {
+    const url = esriTileUrl('my-test-key')
+    expect(url).toBe(`${BASE}?token=my-test-key`)
+  })
+
+  it('uses NEXT_PUBLIC_ESRI_API_KEY from the environment when no key is passed', () => {
+    const original = process.env.NEXT_PUBLIC_ESRI_API_KEY
+    process.env.NEXT_PUBLIC_ESRI_API_KEY = 'env-key'
+    expect(esriTileUrl()).toBe(`${BASE}?token=env-key`)
+    process.env.NEXT_PUBLIC_ESRI_API_KEY = original
+  })
+
+  it('produces an empty token when no key is available', () => {
+    const original = process.env.NEXT_PUBLIC_ESRI_API_KEY
+    delete process.env.NEXT_PUBLIC_ESRI_API_KEY
+    expect(esriTileUrl()).toBe(`${BASE}?token=`)
+    process.env.NEXT_PUBLIC_ESRI_API_KEY = original
+  })
+
+  it('does not contain a literal placeholder or XML tags', () => {
+    const url = esriTileUrl('my-test-key')
+    expect(url).not.toContain('REACT_APP')
+    expect(url).not.toContain('ACCESS_TOKEN')
+    expect(url).not.toContain('process.env')
+  })
+})

--- a/packages/react-ui/src/Map/Map.test.tsx
+++ b/packages/react-ui/src/Map/Map.test.tsx
@@ -14,18 +14,10 @@ describe('esriTileUrl', () => {
     expect(url).toBe(`${BASE}?token=my-test-key`)
   })
 
-  it('uses NEXT_PUBLIC_ESRI_API_KEY from the environment when no key is passed', () => {
-    const original = process.env.NEXT_PUBLIC_ESRI_API_KEY
-    process.env.NEXT_PUBLIC_ESRI_API_KEY = 'env-key'
-    expect(esriTileUrl()).toBe(`${BASE}?token=env-key`)
-    process.env.NEXT_PUBLIC_ESRI_API_KEY = original
-  })
-
-  it('produces an empty token when no key is available', () => {
-    const original = process.env.NEXT_PUBLIC_ESRI_API_KEY
-    delete process.env.NEXT_PUBLIC_ESRI_API_KEY
-    expect(esriTileUrl()).toBe(`${BASE}?token=`)
-    process.env.NEXT_PUBLIC_ESRI_API_KEY = original
+  it('embeds the key directly — no token=undefined possible', () => {
+    const url = esriTileUrl('explicit-key')
+    expect(url).toContain('token=explicit-key')
+    expect(url).not.toContain('undefined')
   })
 
   it('does not contain a literal placeholder or XML tags', () => {

--- a/packages/react-ui/src/Map/Map.test.tsx
+++ b/packages/react-ui/src/Map/Map.test.tsx
@@ -1,29 +1,5 @@
 import '@testing-library/jest-dom'
-import { esriTileUrl } from './esriTileUrl'
 
 test.todo(
   'forego testing on the Map component unless we want to troubleshoot webpack, jest, and leaflet which is going to be can of worms.'
 )
-
-describe('esriTileUrl', () => {
-  const BASE =
-    'https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}'
-
-  it('includes the provided API key as a token query param', () => {
-    const url = esriTileUrl('my-test-key')
-    expect(url).toBe(`${BASE}?token=my-test-key`)
-  })
-
-  it('embeds the key directly — no token=undefined possible', () => {
-    const url = esriTileUrl('explicit-key')
-    expect(url).toContain('token=explicit-key')
-    expect(url).not.toContain('undefined')
-  })
-
-  it('does not contain a literal placeholder or XML tags', () => {
-    const url = esriTileUrl('my-test-key')
-    expect(url).not.toContain('REACT_APP')
-    expect(url).not.toContain('ACCESS_TOKEN')
-    expect(url).not.toContain('process.env')
-  })
-})

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -161,14 +161,41 @@ const Map = React.forwardRef<L.Map, MapProps>(
     const internalMapRef = useRef<L.Map | null>(null)
     const addBaseLayerHandler = useCallback(
       (layer: BaseLayerOption) => () => {
+        console.log('[Map] Base layer add event fired:', layer)
         setBaseLayer(layer)
         if (layer === 'ESRI Oceans/Labels') {
+          console.log(
+            '[Map] ESRI layer selected — internalMapRef:',
+            internalMapRef.current
+          )
           requestAnimationFrame(() => {
+            const currentZoom = internalMapRef.current?.getZoom()
+            console.log(
+              '[Map] rAF fired — currentZoom:',
+              currentZoom,
+              'ESRI_MAX_NATIVE_ZOOM:',
+              ESRI_MAX_NATIVE_ZOOM
+            )
             if (
               internalMapRef.current &&
-              internalMapRef.current.getZoom() > ESRI_MAX_NATIVE_ZOOM
+              currentZoom !== undefined &&
+              currentZoom > ESRI_MAX_NATIVE_ZOOM
             ) {
+              console.log(
+                '[Map] Zooming out from',
+                currentZoom,
+                'to',
+                ESRI_MAX_NATIVE_ZOOM
+              )
               internalMapRef.current.setZoom(ESRI_MAX_NATIVE_ZOOM)
+            } else {
+              console.log(
+                '[Map] No zoom adjustment needed — zoom is',
+                currentZoom,
+                '(max native:',
+                ESRI_MAX_NATIVE_ZOOM,
+                ')'
+              )
             }
           })
         }
@@ -627,6 +654,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
             ignored, so onMapReady and ref forwarding must go through here. */}
         <MapReadyBridge
           onReady={(map) => {
+            console.log('[Map] Map ready — storing in internalMapRef:', map)
             internalMapRef.current = map
             onMapReady?.(map)
           }}

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -600,6 +600,8 @@ const Map = React.forwardRef<L.Map, MapProps>(
       }
     }, [isAddingMarkers])
 
+    const esriApiKey = process.env.NEXT_PUBLIC_ESRI_API_KEY
+
     return (
       <MapContainer
         center={validatedCenter}
@@ -616,24 +618,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
         {/* Bridge to obtain the Leaflet map instance via useMap() — the
             whenCreated prop was removed in react-leaflet v4 and is silently
             ignored, so onMapReady and ref forwarding must go through here. */}
-        <MapReadyBridge
-          onReady={(map) => {
-            const onBaseLayerChange = (e: any) => {
-              if (
-                e.name === 'ESRI Oceans/Labels' &&
-                map.getZoom() > ESRI_MAX_NATIVE_ZOOM
-              ) {
-                map.setZoom(ESRI_MAX_NATIVE_ZOOM)
-              }
-            }
-            map.on('baselayerchange', onBaseLayerChange)
-            map.once('unload', () =>
-              map.off('baselayerchange', onBaseLayerChange)
-            )
-            onMapReady?.(map)
-          }}
-          forwardedRef={ref}
-        />
+        <MapReadyBridge onReady={onMapReady} forwardedRef={ref} />
         {!isMeasuring && (
           <CenterView
             coords={validatedCenter}
@@ -674,28 +659,22 @@ const Map = React.forwardRef<L.Map, MapProps>(
               />
             </LayersControl.BaseLayer>
           )}
-          {mapReady &&
-            (() => {
-              const esriApiKey = process.env.NEXT_PUBLIC_ESRI_API_KEY
-              return (
-                esriApiKey && (
-                  <LayersControl.BaseLayer
-                    name="ESRI Oceans/Labels"
-                    checked={baseLayer === 'ESRI Oceans/Labels'}
-                  >
-                    <TileLayer
-                      url={esriTileUrl(esriApiKey)}
-                      attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
-                      maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
-                      maxZoom={maxZoom}
-                      eventHandlers={{
-                        add: addBaseLayerHandler('ESRI Oceans/Labels'),
-                      }}
-                    />
-                  </LayersControl.BaseLayer>
-                )
-              )
-            })()}
+          {mapReady && esriApiKey && (
+            <LayersControl.BaseLayer
+              name="ESRI Oceans/Labels"
+              checked={baseLayer === 'ESRI Oceans/Labels'}
+            >
+              <TileLayer
+                url={esriTileUrl(esriApiKey)}
+                attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
+                maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
+                maxZoom={maxZoom}
+                eventHandlers={{
+                  add: addBaseLayerHandler('ESRI Oceans/Labels'),
+                }}
+              />
+            </LayersControl.BaseLayer>
+          )}
           {gmrtLayer}
           {mapReady && (
             <LayersControl.BaseLayer

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -158,24 +158,24 @@ const Map = React.forwardRef<L.Map, MapProps>(
     const [isAddingMarkersLocal, setIsAddingMarkersLocal] =
       useState(isAddingMarkers)
     const { baseLayer, setBaseLayer } = useMapBaseLayer()
+    const internalMapRef = useRef<L.Map | null>(null)
     const addBaseLayerHandler = useCallback(
       (layer: BaseLayerOption) => () => {
         setBaseLayer(layer)
+        if (layer === 'ESRI Oceans/Labels') {
+          requestAnimationFrame(() => {
+            if (
+              internalMapRef.current &&
+              internalMapRef.current.getZoom() > ESRI_MAX_NATIVE_ZOOM
+            ) {
+              internalMapRef.current.setZoom(ESRI_MAX_NATIVE_ZOOM)
+            }
+          })
+        }
       },
       [setBaseLayer]
     )
     const vehicleColorsButtonRef = useRef<HTMLButtonElement>(null)
-    const internalMapRef = useRef<L.Map | null>(null)
-
-    useEffect(() => {
-      if (
-        baseLayer === 'ESRI Oceans/Labels' &&
-        internalMapRef.current &&
-        internalMapRef.current.getZoom() > ESRI_MAX_NATIVE_ZOOM
-      ) {
-        internalMapRef.current.setZoom(ESRI_MAX_NATIVE_ZOOM)
-      }
-    }, [baseLayer])
 
     const validatedCenter: [number, number] =
       Array.isArray(center) &&

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -114,6 +114,8 @@ const MapReadyBridge: React.FC<{
   return null
 }
 
+const ESRI_MAX_NATIVE_ZOOM = 16
+
 const Map = React.forwardRef<L.Map, MapProps>(
   (
     {

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -117,23 +117,33 @@ const MapReadyBridge: React.FC<{
 const ESRI_MAX_NATIVE_ZOOM = 16
 
 /**
- * EsriZoomGuard — zooms the map out to ESRI_MAX_NATIVE_ZOOM when the user
- * switches to the ESRI Oceans/Labels layer while zoomed in beyond what the
- * tile service provides, preventing a blank map.
+ * EsriTileLayer — wraps TileLayer for the ESRI Oceans/Labels base layer.
+ * Uses useMap() so that on the layer's own `add` event we can immediately
+ * zoom the map out to ESRI_MAX_NATIVE_ZOOM if the user was zoomed in
+ * beyond what the tile service provides, preventing a blank map.
  */
-const EsriZoomGuard: React.FC = () => {
+const EsriTileLayer: React.FC<{
+  url: string
+  maxZoom: number
+  onAdd: () => void
+}> = ({ url, maxZoom, onAdd }) => {
   const map = useMap()
-  useMapEvents({
-    baselayerchange(e) {
-      if (
-        e.name === 'ESRI Oceans/Labels' &&
-        map.getZoom() > ESRI_MAX_NATIVE_ZOOM
-      ) {
-        map.setZoom(ESRI_MAX_NATIVE_ZOOM)
-      }
-    },
-  })
-  return null
+  return (
+    <TileLayer
+      url={url}
+      attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
+      maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
+      maxZoom={maxZoom}
+      eventHandlers={{
+        add: () => {
+          onAdd()
+          if (map.getZoom() > ESRI_MAX_NATIVE_ZOOM) {
+            map.setZoom(ESRI_MAX_NATIVE_ZOOM)
+          }
+        },
+      }}
+    />
+  )
 }
 
 const Map = React.forwardRef<L.Map, MapProps>(
@@ -637,7 +647,6 @@ const Map = React.forwardRef<L.Map, MapProps>(
             whenCreated prop was removed in react-leaflet v4 and is silently
             ignored, so onMapReady and ref forwarding must go through here. */}
         <MapReadyBridge onReady={onMapReady} forwardedRef={ref} />
-        <EsriZoomGuard />
         {!isMeasuring && (
           <CenterView
             coords={validatedCenter}
@@ -683,14 +692,10 @@ const Map = React.forwardRef<L.Map, MapProps>(
               name="ESRI Oceans/Labels"
               checked={baseLayer === 'ESRI Oceans/Labels'}
             >
-              <TileLayer
+              <EsriTileLayer
                 url={esriTileUrl()}
-                attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
-                maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
                 maxZoom={maxZoom}
-                eventHandlers={{
-                  add: addBaseLayerHandler('ESRI Oceans/Labels'),
-                }}
+                onAdd={addBaseLayerHandler('ESRI Oceans/Labels')}
               />
             </LayersControl.BaseLayer>
           )}

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -663,7 +663,8 @@ const Map = React.forwardRef<L.Map, MapProps>(
               <TileLayer
                 url={esriTileUrl()}
                 attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
-                maxNativeZoom={maxNativeZoom}
+                maxNativeZoom={16}
+                maxZoom={maxZoom}
                 eventHandlers={{
                   add: addBaseLayerHandler('ESRI Oceans/Labels'),
                 }}

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -165,6 +165,17 @@ const Map = React.forwardRef<L.Map, MapProps>(
       [setBaseLayer]
     )
     const vehicleColorsButtonRef = useRef<HTMLButtonElement>(null)
+    const internalMapRef = useRef<L.Map | null>(null)
+
+    useEffect(() => {
+      if (
+        baseLayer === 'ESRI Oceans/Labels' &&
+        internalMapRef.current &&
+        internalMapRef.current.getZoom() > ESRI_MAX_NATIVE_ZOOM
+      ) {
+        internalMapRef.current.setZoom(ESRI_MAX_NATIVE_ZOOM)
+      }
+    }, [baseLayer])
 
     const validatedCenter: [number, number] =
       Array.isArray(center) &&
@@ -614,7 +625,13 @@ const Map = React.forwardRef<L.Map, MapProps>(
         {/* Bridge to obtain the Leaflet map instance via useMap() — the
             whenCreated prop was removed in react-leaflet v4 and is silently
             ignored, so onMapReady and ref forwarding must go through here. */}
-        <MapReadyBridge onReady={onMapReady} forwardedRef={ref} />
+        <MapReadyBridge
+          onReady={(map) => {
+            internalMapRef.current = map
+            onMapReady?.(map)
+          }}
+          forwardedRef={ref}
+        />
         {!isMeasuring && (
           <CenterView
             coords={validatedCenter}

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -117,33 +117,23 @@ const MapReadyBridge: React.FC<{
 const ESRI_MAX_NATIVE_ZOOM = 16
 
 /**
- * EsriTileLayer — wraps TileLayer for the ESRI Oceans/Labels base layer.
- * Uses useMap() so that on the layer's own `add` event we can immediately
- * zoom the map out to ESRI_MAX_NATIVE_ZOOM if the user was zoomed in
- * beyond what the tile service provides, preventing a blank map.
+ * EsriZoomGuard — zooms the map out to ESRI_MAX_NATIVE_ZOOM when the user
+ * switches to the ESRI Oceans/Labels layer while zoomed in beyond what the
+ * tile service provides, preventing a blank map.
  */
-const EsriTileLayer: React.FC<{
-  url: string
-  maxZoom: number
-  onAdd: () => void
-}> = ({ url, maxZoom, onAdd }) => {
+const EsriZoomGuard: React.FC = () => {
   const map = useMap()
-  return (
-    <TileLayer
-      url={url}
-      attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
-      maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
-      maxZoom={maxZoom}
-      eventHandlers={{
-        add: () => {
-          onAdd()
-          if (map.getZoom() > ESRI_MAX_NATIVE_ZOOM) {
-            map.setZoom(ESRI_MAX_NATIVE_ZOOM)
-          }
-        },
-      }}
-    />
-  )
+  useMapEvents({
+    baselayerchange(e) {
+      if (
+        e.name === 'ESRI Oceans/Labels' &&
+        map.getZoom() > ESRI_MAX_NATIVE_ZOOM
+      ) {
+        map.setZoom(ESRI_MAX_NATIVE_ZOOM)
+      }
+    },
+  })
+  return null
 }
 
 const Map = React.forwardRef<L.Map, MapProps>(
@@ -647,6 +637,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
             whenCreated prop was removed in react-leaflet v4 and is silently
             ignored, so onMapReady and ref forwarding must go through here. */}
         <MapReadyBridge onReady={onMapReady} forwardedRef={ref} />
+        <EsriZoomGuard />
         {!isMeasuring && (
           <CenterView
             coords={validatedCenter}
@@ -692,10 +683,14 @@ const Map = React.forwardRef<L.Map, MapProps>(
               name="ESRI Oceans/Labels"
               checked={baseLayer === 'ESRI Oceans/Labels'}
             >
-              <EsriTileLayer
+              <TileLayer
                 url={esriTileUrl()}
+                attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
+                maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
                 maxZoom={maxZoom}
-                onAdd={addBaseLayerHandler('ESRI Oceans/Labels')}
+                eventHandlers={{
+                  add: addBaseLayerHandler('ESRI Oceans/Labels'),
+                }}
               />
             </LayersControl.BaseLayer>
           )}

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -160,7 +160,6 @@ const Map = React.forwardRef<L.Map, MapProps>(
     const [isAddingMarkersLocal, setIsAddingMarkersLocal] =
       useState(isAddingMarkers)
     const { baseLayer, setBaseLayer } = useMapBaseLayer()
-    const internalMapRef = useRef<L.Map | null>(null)
     const addBaseLayerHandler = useCallback(
       (layer: BaseLayerOption) => () => {
         setBaseLayer(layer)
@@ -619,7 +618,6 @@ const Map = React.forwardRef<L.Map, MapProps>(
             ignored, so onMapReady and ref forwarding must go through here. */}
         <MapReadyBridge
           onReady={(map) => {
-            internalMapRef.current = map
             const onBaseLayerChange = (e: any) => {
               if (
                 e.name === 'ESRI Oceans/Labels' &&
@@ -676,22 +674,28 @@ const Map = React.forwardRef<L.Map, MapProps>(
               />
             </LayersControl.BaseLayer>
           )}
-          {mapReady && !!process.env.NEXT_PUBLIC_ESRI_API_KEY && (
-            <LayersControl.BaseLayer
-              name="ESRI Oceans/Labels"
-              checked={baseLayer === 'ESRI Oceans/Labels'}
-            >
-              <TileLayer
-                url={esriTileUrl(process.env.NEXT_PUBLIC_ESRI_API_KEY)}
-                attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
-                maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
-                maxZoom={maxZoom}
-                eventHandlers={{
-                  add: addBaseLayerHandler('ESRI Oceans/Labels'),
-                }}
-              />
-            </LayersControl.BaseLayer>
-          )}
+          {mapReady &&
+            (() => {
+              const esriApiKey = process.env.NEXT_PUBLIC_ESRI_API_KEY
+              return (
+                esriApiKey && (
+                  <LayersControl.BaseLayer
+                    name="ESRI Oceans/Labels"
+                    checked={baseLayer === 'ESRI Oceans/Labels'}
+                  >
+                    <TileLayer
+                      url={esriTileUrl(esriApiKey)}
+                      attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
+                      maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
+                      maxZoom={maxZoom}
+                      eventHandlers={{
+                        add: addBaseLayerHandler('ESRI Oceans/Labels'),
+                      }}
+                    />
+                  </LayersControl.BaseLayer>
+                )
+              )
+            })()}
           {gmrtLayer}
           {mapReady && (
             <LayersControl.BaseLayer

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -114,28 +114,6 @@ const MapReadyBridge: React.FC<{
   return null
 }
 
-const ESRI_MAX_NATIVE_ZOOM = 16
-
-/**
- * EsriZoomGuard — zooms the map out to ESRI_MAX_NATIVE_ZOOM when the user
- * switches to the ESRI Oceans/Labels layer while zoomed in beyond what the
- * tile service provides, preventing a blank map.
- */
-const EsriZoomGuard: React.FC = () => {
-  const map = useMap()
-  useMapEvents({
-    baselayerchange(e) {
-      if (
-        e.name === 'ESRI Oceans/Labels' &&
-        map.getZoom() > ESRI_MAX_NATIVE_ZOOM
-      ) {
-        map.setZoom(ESRI_MAX_NATIVE_ZOOM)
-      }
-    },
-  })
-  return null
-}
-
 const Map = React.forwardRef<L.Map, MapProps>(
   (
     {
@@ -637,7 +615,6 @@ const Map = React.forwardRef<L.Map, MapProps>(
             whenCreated prop was removed in react-leaflet v4 and is silently
             ignored, so onMapReady and ref forwarding must go through here. */}
         <MapReadyBridge onReady={onMapReady} forwardedRef={ref} />
-        <EsriZoomGuard />
         {!isMeasuring && (
           <CenterView
             coords={validatedCenter}
@@ -686,7 +663,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
               <TileLayer
                 url={esriTileUrl()}
                 attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
-                maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
+                maxNativeZoom={16}
                 maxZoom={maxZoom}
                 eventHandlers={{
                   add: addBaseLayerHandler('ESRI Oceans/Labels'),

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -114,6 +114,28 @@ const MapReadyBridge: React.FC<{
   return null
 }
 
+const ESRI_MAX_NATIVE_ZOOM = 16
+
+/**
+ * EsriZoomGuard — zooms the map out to ESRI_MAX_NATIVE_ZOOM when the user
+ * switches to the ESRI Oceans/Labels layer while zoomed in beyond what the
+ * tile service provides, preventing a blank map.
+ */
+const EsriZoomGuard: React.FC = () => {
+  const map = useMap()
+  useMapEvents({
+    baselayerchange(e) {
+      if (
+        e.name === 'ESRI Oceans/Labels' &&
+        map.getZoom() > ESRI_MAX_NATIVE_ZOOM
+      ) {
+        map.setZoom(ESRI_MAX_NATIVE_ZOOM)
+      }
+    },
+  })
+  return null
+}
+
 const Map = React.forwardRef<L.Map, MapProps>(
   (
     {
@@ -615,6 +637,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
             whenCreated prop was removed in react-leaflet v4 and is silently
             ignored, so onMapReady and ref forwarding must go through here. */}
         <MapReadyBridge onReady={onMapReady} forwardedRef={ref} />
+        <EsriZoomGuard />
         {!isMeasuring && (
           <CenterView
             coords={validatedCenter}
@@ -663,7 +686,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
               <TileLayer
                 url={esriTileUrl()}
                 attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
-                maxNativeZoom={16}
+                maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
                 maxZoom={maxZoom}
                 eventHandlers={{
                   add: addBaseLayerHandler('ESRI Oceans/Labels'),

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -163,44 +163,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
     const internalMapRef = useRef<L.Map | null>(null)
     const addBaseLayerHandler = useCallback(
       (layer: BaseLayerOption) => () => {
-        console.log('[Map] Base layer add event fired:', layer)
         setBaseLayer(layer)
-        if (layer === 'ESRI Oceans/Labels') {
-          console.log(
-            '[Map] ESRI layer selected — internalMapRef:',
-            internalMapRef.current
-          )
-          requestAnimationFrame(() => {
-            const currentZoom = internalMapRef.current?.getZoom()
-            console.log(
-              '[Map] rAF fired — currentZoom:',
-              currentZoom,
-              'ESRI_MAX_NATIVE_ZOOM:',
-              ESRI_MAX_NATIVE_ZOOM
-            )
-            if (
-              internalMapRef.current &&
-              currentZoom !== undefined &&
-              currentZoom > ESRI_MAX_NATIVE_ZOOM
-            ) {
-              console.log(
-                '[Map] Zooming out from',
-                currentZoom,
-                'to',
-                ESRI_MAX_NATIVE_ZOOM
-              )
-              internalMapRef.current.setZoom(ESRI_MAX_NATIVE_ZOOM)
-            } else {
-              console.log(
-                '[Map] No zoom adjustment needed — zoom is',
-                currentZoom,
-                '(max native:',
-                ESRI_MAX_NATIVE_ZOOM,
-                ')'
-              )
-            }
-          })
-        }
       },
       [setBaseLayer]
     )
@@ -656,28 +619,19 @@ const Map = React.forwardRef<L.Map, MapProps>(
             ignored, so onMapReady and ref forwarding must go through here. */}
         <MapReadyBridge
           onReady={(map) => {
-            console.log('[Map] Map ready — attaching baselayerchange listener')
             internalMapRef.current = map
-            map.on('baselayerchange', (e: any) => {
-              console.log(
-                '[Map] baselayerchange fired:',
-                e.name,
-                'current zoom:',
-                map.getZoom()
-              )
+            const onBaseLayerChange = (e: any) => {
               if (
                 e.name === 'ESRI Oceans/Labels' &&
                 map.getZoom() > ESRI_MAX_NATIVE_ZOOM
               ) {
-                console.log(
-                  '[Map] Zooming out from',
-                  map.getZoom(),
-                  'to',
-                  ESRI_MAX_NATIVE_ZOOM
-                )
                 map.setZoom(ESRI_MAX_NATIVE_ZOOM)
               }
-            })
+            }
+            map.on('baselayerchange', onBaseLayerChange)
+            map.once('unload', () =>
+              map.off('baselayerchange', onBaseLayerChange)
+            )
             onMapReady?.(map)
           }}
           forwardedRef={ref}
@@ -722,13 +676,13 @@ const Map = React.forwardRef<L.Map, MapProps>(
               />
             </LayersControl.BaseLayer>
           )}
-          {mapReady && (
+          {mapReady && !!process.env.NEXT_PUBLIC_ESRI_API_KEY && (
             <LayersControl.BaseLayer
               name="ESRI Oceans/Labels"
               checked={baseLayer === 'ESRI Oceans/Labels'}
             >
               <TileLayer
-                url={esriTileUrl()}
+                url={esriTileUrl(process.env.NEXT_PUBLIC_ESRI_API_KEY)}
                 attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
                 maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
                 maxZoom={maxZoom}

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -37,6 +37,8 @@ import { CenterView } from './MapViews'
 import type { MapProps } from './Map.types'
 import { createLogger } from '@mbari/utils'
 
+import { esriTileUrl } from './esriTileUrl'
+
 const logger = createLogger('Map')
 
 const DEFAULT_CENTER: [number, number] = [36.8022, -121.788]
@@ -659,7 +661,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
               checked={baseLayer === 'ESRI Oceans/Labels'}
             >
               <TileLayer
-                url={`https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}?token=${process.env.NEXT_PUBLIC_ESRI_API_KEY}`}
+                url={esriTileUrl()}
                 attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
                 maxNativeZoom={maxNativeZoom}
                 eventHandlers={{

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -659,7 +659,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
               checked={baseLayer === 'ESRI Oceans/Labels'}
             >
               <TileLayer
-                url="https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}?//token=<ACCESS_TOKEN>process.env.REACT_APP_ESRI_API_KEY</ACCESS_TOKEN>"
+                url={`https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}?token=${process.env.NEXT_PUBLIC_ESRI_API_KEY}`}
                 attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
                 maxNativeZoom={maxNativeZoom}
                 eventHandlers={{

--- a/packages/react-ui/src/Map/Map.tsx
+++ b/packages/react-ui/src/Map/Map.tsx
@@ -114,7 +114,7 @@ const MapReadyBridge: React.FC<{
   return null
 }
 
-const ESRI_MAX_NATIVE_ZOOM = 16
+const ESRI_MAX_NATIVE_ZOOM = 13
 
 const Map = React.forwardRef<L.Map, MapProps>(
   (
@@ -656,8 +656,28 @@ const Map = React.forwardRef<L.Map, MapProps>(
             ignored, so onMapReady and ref forwarding must go through here. */}
         <MapReadyBridge
           onReady={(map) => {
-            console.log('[Map] Map ready — storing in internalMapRef:', map)
+            console.log('[Map] Map ready — attaching baselayerchange listener')
             internalMapRef.current = map
+            map.on('baselayerchange', (e: any) => {
+              console.log(
+                '[Map] baselayerchange fired:',
+                e.name,
+                'current zoom:',
+                map.getZoom()
+              )
+              if (
+                e.name === 'ESRI Oceans/Labels' &&
+                map.getZoom() > ESRI_MAX_NATIVE_ZOOM
+              ) {
+                console.log(
+                  '[Map] Zooming out from',
+                  map.getZoom(),
+                  'to',
+                  ESRI_MAX_NATIVE_ZOOM
+                )
+                map.setZoom(ESRI_MAX_NATIVE_ZOOM)
+              }
+            })
             onMapReady?.(map)
           }}
           forwardedRef={ref}
@@ -710,7 +730,7 @@ const Map = React.forwardRef<L.Map, MapProps>(
               <TileLayer
                 url={esriTileUrl()}
                 attribution='&copy; <a href="https://developers.arcgis.com/">ArcGIS</a>'
-                maxNativeZoom={16}
+                maxNativeZoom={ESRI_MAX_NATIVE_ZOOM}
                 maxZoom={maxZoom}
                 eventHandlers={{
                   add: addBaseLayerHandler('ESRI Oceans/Labels'),

--- a/packages/react-ui/src/Map/esriTileUrl.test.ts
+++ b/packages/react-ui/src/Map/esriTileUrl.test.ts
@@ -1,0 +1,24 @@
+import { esriTileUrl } from './esriTileUrl'
+
+const BASE =
+  'https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}'
+
+describe('esriTileUrl', () => {
+  it('includes the provided API key as a token query param', () => {
+    expect(esriTileUrl('my-test-key')).toBe(`${BASE}?token=my-test-key`)
+  })
+
+  it('URL-encodes the API key to handle special characters', () => {
+    expect(esriTileUrl('key+with/special=chars')).toBe(
+      `${BASE}?token=key%2Bwith%2Fspecial%3Dchars`
+    )
+  })
+
+  it('does not contain a literal placeholder or XML tags', () => {
+    const url = esriTileUrl('my-test-key')
+    expect(url).not.toContain('REACT_APP')
+    expect(url).not.toContain('ACCESS_TOKEN')
+    expect(url).not.toContain('process.env')
+    expect(url).not.toContain('undefined')
+  })
+})

--- a/packages/react-ui/src/Map/esriTileUrl.ts
+++ b/packages/react-ui/src/Map/esriTileUrl.ts
@@ -1,0 +1,6 @@
+export const esriTileUrl = (
+  apiKey: string | undefined = process.env.NEXT_PUBLIC_ESRI_API_KEY
+): string =>
+  `https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}?token=${
+    apiKey ?? ''
+  }`

--- a/packages/react-ui/src/Map/esriTileUrl.ts
+++ b/packages/react-ui/src/Map/esriTileUrl.ts
@@ -1,2 +1,4 @@
 export const esriTileUrl = (apiKey: string): string =>
-  `https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}?token=${apiKey}`
+  `https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}?token=${encodeURIComponent(
+    apiKey
+  )}`

--- a/packages/react-ui/src/Map/esriTileUrl.ts
+++ b/packages/react-ui/src/Map/esriTileUrl.ts
@@ -1,6 +1,2 @@
-export const esriTileUrl = (
-  apiKey: string | undefined = process.env.NEXT_PUBLIC_ESRI_API_KEY
-): string =>
-  `https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}?token=${
-    apiKey ?? ''
-  }`
+export const esriTileUrl = (apiKey: string): string =>
+  `https://ibasemaps-api.arcgis.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/tile/{z}/{y}/{x}?token=${apiKey}`


### PR DESCRIPTION
## Summary

- The ESRI Oceans/Labels base layer was not displaying because the tile URL was malformed in two ways:
  - The ArcGIS API key was embedded as a **literal string** with XML-like `<ACCESS_TOKEN>` tags instead of being interpolated via a JS template literal
  - The env var referenced `REACT_APP_ESRI_API_KEY` (a Create React App convention), which Next.js does not expose — it must be `NEXT_PUBLIC_ESRI_API_KEY`
- Fixes the URL to use a proper template literal: `` `...?token=${process.env.NEXT_PUBLIC_ESRI_API_KEY}` ``
- Adds `NEXT_PUBLIC_ESRI_API_KEY` to `.env.example` so it is documented alongside the other required API keys

## Test plan

- [ ] Add a valid `NEXT_PUBLIC_ESRI_API_KEY` to your local `.env.local`
- [ ] Run the dev server and open the map
- [ ] Select "ESRI Oceans/Labels" from the layer picker and confirm tiles render correctly

Closes #579