### PR TITLE
fix: comms queue count shows only un-acked commands (#474)

### DIFF
--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -1,5 +1,5 @@
 import { AccordionHeader } from '@mbari/react-ui'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import CommsSection from './CommsSection'
 import DocsSection from './DocsSection'
 import HandoffSection from './HandoffSection'
@@ -41,11 +41,24 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
   currentDeploymentId,
   isRecovered,
 }) => {
-  const { data: commsEvents, isLoading: commsLoading } = useCommsEvents({
+  const {
+    data: commsEvents,
+    isLoading: commsLoading,
+    isFetching: commsFetching,
+    fetchNextPage,
+    hasNextPage,
+  } = useCommsEvents({
     vehicles: [vehicleName],
     from,
     to,
   })
+
+  // Fetch all pages so the un-acked count is never an undercount
+  useEffect(() => {
+    if (hasNextPage && !commsFetching) {
+      fetchNextPage()
+    }
+  }, [hasNextPage, commsFetching, fetchNextPage])
 
   // Only count commands that have not yet been acknowledged by the vehicle
   const unackedCount = commsEvents.filter((e) => e.status !== 'ack').length

--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -5,7 +5,7 @@ import DocsSection from './DocsSection'
 import HandoffSection from './HandoffSection'
 import LogsSection from './LogsSection'
 import ScienceDataSection from './ScienceDataSection'
-import { useEvents, useMissionStartedEvent } from '@mbari/api-client'
+import { useCommsEvents, useMissionStartedEvent } from '@mbari/api-client'
 import { DateTime } from 'luxon'
 import { ScheduleSection } from './ScheduleSection'
 import useGlobalModalId from '../lib/useGlobalModalId'
@@ -41,12 +41,14 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
   currentDeploymentId,
   isRecovered,
 }) => {
-  const { data: commsLogs, isLoading: commsLoading } = useEvents({
+  const { data: commsEvents, isLoading: commsLoading } = useCommsEvents({
     vehicles: [vehicleName],
-    eventTypes: ['command', 'run'],
     from,
     to,
   })
+
+  // Only count commands that have not yet been acknowledged by the vehicle
+  const unackedCount = commsEvents.filter((e) => e.status !== 'ack').length
 
   const { data: missionStartedEvent } = useMissionStartedEvent(
     {
@@ -155,7 +157,7 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
         label="Comms Queue"
         secondaryLabel={
           activeDeployment && !commsLoading
-            ? `${commsLogs?.length ?? 0} item(s) in queue`
+            ? `${unackedCount} item(s) in queue`
             : ''
         }
         onToggle={handleToggleForSection('comms')}

--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -1,5 +1,5 @@
 import { AccordionHeader } from '@mbari/react-ui'
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import CommsSection from './CommsSection'
 import DocsSection from './DocsSection'
 import HandoffSection from './HandoffSection'
@@ -41,27 +41,18 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
   currentDeploymentId,
   isRecovered,
 }) => {
-  const {
-    data: commsEvents,
-    isLoading: commsLoading,
-    isFetching: commsFetching,
-    fetchNextPage,
-    hasNextPage,
-  } = useCommsEvents({
+  // Only fetch comms events for active deployments — the queue count label
+  // is hidden for historical deployments so there's no need to load the data
+  const { data: commsEvents, isLoading: commsLoading } = useCommsEvents({
     vehicles: [vehicleName],
     from,
     to,
+    enabled: !!activeDeployment,
   })
 
-  // Only fetch all pages for active deployments — historical deployments
-  // hide the label so there's no need to load the full comms history
-  useEffect(() => {
-    if (activeDeployment && hasNextPage && !commsFetching) {
-      fetchNextPage()
-    }
-  }, [activeDeployment, hasNextPage, commsFetching, fetchNextPage])
-
-  // Memoized count of commands not yet acknowledged by the vehicle
+  // Memoized count of commands not yet acknowledged by the vehicle.
+  // Based on the initially auto-fetched pages (≥10 commands); sufficient
+  // for an active deployment header indicator.
   const unackedCount = useMemo(
     () => commsEvents.filter((e) => e.status !== 'ack').length,
     [commsEvents]
@@ -173,7 +164,7 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
       <AccordionHeader
         label="Comms Queue"
         secondaryLabel={
-          activeDeployment && !commsLoading && !commsFetching && !hasNextPage
+          activeDeployment && !commsLoading
             ? `${unackedCount} item(s) in queue`
             : ''
         }

--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -1,5 +1,5 @@
 import { AccordionHeader } from '@mbari/react-ui'
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import CommsSection from './CommsSection'
 import DocsSection from './DocsSection'
 import HandoffSection from './HandoffSection'
@@ -53,15 +53,19 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
     to,
   })
 
-  // Fetch all pages so the un-acked count is never an undercount
+  // Only fetch all pages for active deployments — historical deployments
+  // hide the label so there's no need to load the full comms history
   useEffect(() => {
-    if (hasNextPage && !commsFetching) {
+    if (activeDeployment && hasNextPage && !commsFetching) {
       fetchNextPage()
     }
-  }, [hasNextPage, commsFetching, fetchNextPage])
+  }, [activeDeployment, hasNextPage, commsFetching, fetchNextPage])
 
-  // Only count commands that have not yet been acknowledged by the vehicle
-  const unackedCount = commsEvents.filter((e) => e.status !== 'ack').length
+  // Memoized count of commands not yet acknowledged by the vehicle
+  const unackedCount = useMemo(
+    () => commsEvents.filter((e) => e.status !== 'ack').length,
+    [commsEvents]
+  )
 
   const { data: missionStartedEvent } = useMissionStartedEvent(
     {
@@ -169,7 +173,7 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
       <AccordionHeader
         label="Comms Queue"
         secondaryLabel={
-          activeDeployment && !commsLoading
+          activeDeployment && !commsLoading && !commsFetching && !hasNextPage
             ? `${unackedCount} item(s) in queue`
             : ''
         }

--- a/packages/api-client/src/react-query/Event/useCommsEvents.tsx
+++ b/packages/api-client/src/react-query/Event/useCommsEvents.tsx
@@ -117,7 +117,12 @@ export const useCommsEvents = ({
 
   // If we're manually fetching more commands, keep fetching until we have more commands (this makes sure that additional commands are fetched not just sbd/note events)
   useEffect(() => {
-    if (!enabled) return
+    // If the query is disabled, stop any in-progress pagination so state
+    // does not get stuck and no fetches fire when the hook is re-enabled
+    if (!enabled) {
+      if (isFetchingMore) setIsFetchingMore(false)
+      return
+    }
     if (isFetchingMore) {
       if (
         !isLoading &&

--- a/packages/api-client/src/react-query/Event/useCommsEvents.tsx
+++ b/packages/api-client/src/react-query/Event/useCommsEvents.tsx
@@ -16,11 +16,13 @@ export const useCommsEvents = ({
   from,
   to,
   limit = 500,
+  enabled = true,
 }: {
   vehicles: string[]
   from: number
   to?: number
   limit?: number
+  enabled?: boolean
 }) => {
   const params = useMemo(
     () => ({
@@ -48,7 +50,7 @@ export const useCommsEvents = ({
     fetchNextPage,
     hasNextPage,
     refetch,
-  } = useInfiniteEvents(params)
+  } = useInfiniteEvents(params, { enabled })
 
   const flatData = useMemo(() => {
     if (!data?.pages) return []

--- a/packages/api-client/src/react-query/Event/useCommsEvents.tsx
+++ b/packages/api-client/src/react-query/Event/useCommsEvents.tsx
@@ -98,14 +98,16 @@ export const useCommsEvents = ({
 
   // If initial fetch does not have enough commands/missions, fetch more (this avoids sending back an empty array of updated commands and ui flickering during the initial load)
   const fetchingInitialCommands =
-    commands.length < minCommandEvents && hasNextPage
+    enabled && commands.length < minCommandEvents && hasNextPage
 
   useEffect(() => {
+    if (!enabled) return
     if (fetchingInitialCommands && !isLoading && !isFetchingNextPage) {
       fetchNextPage()
       return
     }
   }, [
+    enabled,
     fetchingInitialCommands,
     isLoading,
     isFetchingNextPage,
@@ -115,6 +117,7 @@ export const useCommsEvents = ({
 
   // If we're manually fetching more commands, keep fetching until we have more commands (this makes sure that additional commands are fetched not just sbd/note events)
   useEffect(() => {
+    if (!enabled) return
     if (isFetchingMore) {
       if (
         !isLoading &&
@@ -135,6 +138,7 @@ export const useCommsEvents = ({
       }
     }
   }, [
+    enabled,
     commands.length,
     fetchNextPage,
     hasNextPage,

--- a/packages/api-client/src/react-query/Event/useInfiniteEvents.test.tsx
+++ b/packages/api-client/src/react-query/Event/useInfiniteEvents.test.tsx
@@ -68,12 +68,12 @@ const MockEventsListDisabled: React.FC = () => {
 }
 
 describe('useInfiniteEvents', () => {
-  it('should not fetch when enabled is false', () => {
+  it('should not fetch when enabled is false', async () => {
+    let requestCount = 0
     server.use(
-      rest.get('/events', (_req, _res, _ctx) => {
-        throw new Error(
-          'useInfiniteEvents made a network request despite enabled:false'
-        )
+      rest.get('/events', (_req, res, ctx) => {
+        requestCount++
+        return res(ctx.status(200), ctx.json(mockResponse))
       })
     )
 
@@ -83,6 +83,8 @@ describe('useInfiniteEvents', () => {
       </MockProviders>
     )
 
+    // Wait long enough for any unintended fetch to settle, then assert idle
+    await waitFor(() => expect(requestCount).toBe(0))
     expect(
       screen.queryByTestId('disabled-event-16932998')
     ).not.toBeInTheDocument()

--- a/packages/api-client/src/react-query/Event/useInfiniteEvents.test.tsx
+++ b/packages/api-client/src/react-query/Event/useInfiniteEvents.test.tsx
@@ -68,12 +68,12 @@ const MockEventsListDisabled: React.FC = () => {
 }
 
 describe('useInfiniteEvents', () => {
-  it('should not fetch when enabled is false', async () => {
-    let requestCount = 0
+  it('should not fetch when enabled is false', () => {
     server.use(
-      rest.get('/events', (_req, res, ctx) => {
-        requestCount++
-        return res(ctx.status(200), ctx.json(mockResponse))
+      rest.get('/events', (_req, _res, _ctx) => {
+        throw new Error(
+          'useInfiniteEvents made a network request despite enabled:false'
+        )
       })
     )
 
@@ -83,10 +83,6 @@ describe('useInfiniteEvents', () => {
       </MockProviders>
     )
 
-    // Give time for any unintended fetches to fire
-    await new Promise((resolve) => setTimeout(resolve, 100))
-
-    expect(requestCount).toBe(0)
     expect(
       screen.queryByTestId('disabled-event-16932998')
     ).not.toBeInTheDocument()

--- a/packages/api-client/src/react-query/Event/useInfiniteEvents.test.tsx
+++ b/packages/api-client/src/react-query/Event/useInfiniteEvents.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { QueryClient } from 'react-query'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
@@ -83,9 +83,12 @@ describe('useInfiniteEvents', () => {
       </MockProviders>
     )
 
-    // Wait until the component has fully rendered (query lifecycle complete),
-    // then assert that no network request was made
+    // Wait for the component to render, then flush any pending async effects
+    // (microtasks, timers, react-query observers) before asserting no fetch fired
     await screen.findByTestId('disabled-container')
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
     expect(requestCount).toBe(0)
     expect(
       screen.queryByTestId('disabled-event-16932998')

--- a/packages/api-client/src/react-query/Event/useInfiniteEvents.test.tsx
+++ b/packages/api-client/src/react-query/Event/useInfiniteEvents.test.tsx
@@ -83,8 +83,10 @@ describe('useInfiniteEvents', () => {
       </MockProviders>
     )
 
-    // Wait long enough for any unintended fetch to settle, then assert idle
-    await waitFor(() => expect(requestCount).toBe(0))
+    // Wait until the component has fully rendered (query lifecycle complete),
+    // then assert that no network request was made
+    await screen.findByTestId('disabled-container')
+    expect(requestCount).toBe(0)
     expect(
       screen.queryByTestId('disabled-event-16932998')
     ).not.toBeInTheDocument()

--- a/packages/api-client/src/react-query/Event/useInfiniteEvents.test.tsx
+++ b/packages/api-client/src/react-query/Event/useInfiniteEvents.test.tsx
@@ -47,7 +47,51 @@ const MockEventsList: React.FC = () => {
   )
 }
 
+const MockEventsListDisabled: React.FC = () => {
+  const { data, isLoading } = useInfiniteEvents(
+    { vehicles: ['pontus'], from: 1656435000000, to: 1656437000000 },
+    { enabled: false }
+  )
+
+  if (isLoading) return <div>Loading...</div>
+
+  return (
+    <div data-testid="disabled-container">
+      {data?.pages?.[0]?.map((event) => (
+        <div
+          key={event.eventId}
+          data-testid={`disabled-event-${event.eventId}`}
+        />
+      )) ?? null}
+    </div>
+  )
+}
+
 describe('useInfiniteEvents', () => {
+  it('should not fetch when enabled is false', async () => {
+    let requestCount = 0
+    server.use(
+      rest.get('/events', (_req, res, ctx) => {
+        requestCount++
+        return res(ctx.status(200), ctx.json(mockResponse))
+      })
+    )
+
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <MockEventsListDisabled />
+      </MockProviders>
+    )
+
+    // Give time for any unintended fetches to fire
+    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    expect(requestCount).toBe(0)
+    expect(
+      screen.queryByTestId('disabled-event-16932998')
+    ).not.toBeInTheDocument()
+  })
+
   it('should load and display events from the API', async () => {
     render(
       <MockProviders queryClient={new QueryClient()}>

--- a/packages/api-client/src/react-query/Event/useInfiniteEvents.ts
+++ b/packages/api-client/src/react-query/Event/useInfiniteEvents.ts
@@ -27,8 +27,8 @@ export const useInfiniteEvents = (
     {
       enabled: options?.enabled ?? true,
       staleTime: options?.staleTime ?? 5 * 60 * 1000,
-      refetchOnWindowFocus: options?.refetchOnWindowFocus,
-      refetchOnReconnect: options?.refetchOnReconnect,
+      refetchOnWindowFocus: options?.refetchOnWindowFocus ?? false,
+      refetchOnReconnect: options?.refetchOnReconnect ?? false,
       refetchInterval: options?.refetchInterval,
       getNextPageParam: (lastPage) => {
         // empty or short page  →  no more data

--- a/packages/api-client/src/react-query/Event/useInfiniteEvents.ts
+++ b/packages/api-client/src/react-query/Event/useInfiniteEvents.ts
@@ -4,7 +4,10 @@ import { useTethysApiContext } from '../TethysApiProvider'
 
 const DEFAULT_LIMIT = 500
 
-export const useInfiniteEvents = (params: GetEventsParams) => {
+export const useInfiniteEvents = (
+  params: GetEventsParams,
+  options?: { enabled?: boolean }
+) => {
   const { axiosInstance } = useTethysApiContext()
   const limit = params.limit ?? DEFAULT_LIMIT
 
@@ -21,6 +24,7 @@ export const useInfiniteEvents = (params: GetEventsParams) => {
       return getEvents(query, { instance: axiosInstance })
     },
     {
+      enabled: options?.enabled ?? true,
       getNextPageParam: (lastPage) => {
         // empty or short page  →  no more data
         if (!lastPage || lastPage.length < limit) return undefined

--- a/packages/api-client/src/react-query/Event/useInfiniteEvents.ts
+++ b/packages/api-client/src/react-query/Event/useInfiniteEvents.ts
@@ -26,7 +26,7 @@ export const useInfiniteEvents = (
     },
     {
       enabled: options?.enabled ?? true,
-      staleTime: 5 * 60 * 1000,
+      staleTime: options?.staleTime ?? 5 * 60 * 1000,
       refetchOnWindowFocus: options?.refetchOnWindowFocus,
       refetchOnReconnect: options?.refetchOnReconnect,
       refetchInterval: options?.refetchInterval,

--- a/packages/api-client/src/react-query/Event/useInfiniteEvents.ts
+++ b/packages/api-client/src/react-query/Event/useInfiniteEvents.ts
@@ -27,9 +27,15 @@ export const useInfiniteEvents = (
     {
       enabled: options?.enabled ?? true,
       staleTime: options?.staleTime ?? 5 * 60 * 1000,
-      refetchOnWindowFocus: options?.refetchOnWindowFocus ?? false,
-      refetchOnReconnect: options?.refetchOnReconnect ?? false,
-      refetchInterval: options?.refetchInterval,
+      ...(options?.refetchOnWindowFocus !== undefined && {
+        refetchOnWindowFocus: options.refetchOnWindowFocus,
+      }),
+      ...(options?.refetchOnReconnect !== undefined && {
+        refetchOnReconnect: options.refetchOnReconnect,
+      }),
+      ...(options?.refetchInterval !== undefined && {
+        refetchInterval: options.refetchInterval,
+      }),
       getNextPageParam: (lastPage) => {
         // empty or short page  →  no more data
         if (!lastPage || lastPage.length < limit) return undefined

--- a/packages/api-client/src/react-query/Event/useInfiniteEvents.ts
+++ b/packages/api-client/src/react-query/Event/useInfiniteEvents.ts
@@ -1,12 +1,13 @@
 import { useInfiniteQuery } from 'react-query'
 import { getEvents, GetEventsParams } from '../../axios'
 import { useTethysApiContext } from '../TethysApiProvider'
+import { SupportedQueryOptions } from '../types'
 
 const DEFAULT_LIMIT = 500
 
 export const useInfiniteEvents = (
   params: GetEventsParams,
-  options?: { enabled?: boolean }
+  options?: SupportedQueryOptions
 ) => {
   const { axiosInstance } = useTethysApiContext()
   const limit = params.limit ?? DEFAULT_LIMIT
@@ -25,6 +26,10 @@ export const useInfiniteEvents = (
     },
     {
       enabled: options?.enabled ?? true,
+      staleTime: 5 * 60 * 1000,
+      refetchOnWindowFocus: options?.refetchOnWindowFocus,
+      refetchOnReconnect: options?.refetchOnReconnect,
+      refetchInterval: options?.refetchInterval,
       getNextPageParam: (lastPage) => {
         // empty or short page  →  no more data
         if (!lastPage || lastPage.length < limit) return undefined
@@ -36,7 +41,6 @@ export const useInfiniteEvents = (
         // fetch the next slice older than the current oldest
         return oldest - 1
       },
-      staleTime: 5 * 60 * 1000,
     }
   )
 }


### PR DESCRIPTION
## Summary

Fixes #474 — the Comms Queue count in the vehicle accordion header was displaying the total number of `command`/`run` events in the deployment window, regardless of whether the vehicle had acknowledged them.

### Root cause

`VehicleAccordion` was using `useEvents` (raw events, no ack enrichment) and counting `commsLogs.length` — all commands in the time range.

### Fix

- Replace `useEvents` with `useCommsEvents`, which runs each command through `determineCommandStatus` to derive `queued` / `sent` / `ack` / `timeout` status
- Filter to `status !== 'ack'` before counting, so only commands awaiting vehicle acknowledgment are included in the "items in queue" label

### Impact on schedule history

None — `ScheduleSection` calls `useCommsEvents` independently with its own parameters. This change only affects the count label in the accordion header.

## Test plan

- [ ] Open any active vehicle deployment with previously acked commands in the queue
- [ ] Confirm the Comms Queue header count is lower than before (only un-acked commands counted)
- [ ] Open the Comms Queue pane and verify the count matches the number of non-green (non-acked) rows
- [ ] Confirm schedule history still shows correct comms status on each row