### PR TITLE
fix(#587): remove spurious } from sched timestamp in makeCommand

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -112,10 +112,12 @@ const formatScheduleDate = (scheduleDate?: string): string => {
   if (!scheduleDate) return 'N/A'
   if (scheduleDate.toLowerCase() === 'asap') return 'ASAP'
 
+  // Strip legacy } (from older makeCommand builds) before parsing so events
+  // stored as YYYYMMDD}THHMM continue to display a formatted timestamp.
+  const normalized = scheduleDate.replace('}', '')
+
   // Format: 20260401T0600 or 20260331T18 (UTC)
-  const shortMatch = scheduleDate.match(
-    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})?$/
-  )
+  const shortMatch = normalized.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})?$/)
   if (shortMatch) {
     const utc = DateTime.fromObject(
       {

--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -112,25 +112,7 @@ const formatScheduleDate = (scheduleDate?: string): string => {
   if (!scheduleDate) return 'N/A'
   if (scheduleDate.toLowerCase() === 'asap') return 'ASAP'
 
-  // Format: 20260401}T0600 (makeCommand format, UTC)
-  const fullMatch = scheduleDate.match(
-    /^(\d{4})(\d{2})(\d{2})}T(\d{2})(\d{2})$/
-  )
-  if (fullMatch) {
-    const utc = DateTime.fromObject(
-      {
-        year: parseInt(fullMatch[1]),
-        month: parseInt(fullMatch[2]),
-        day: parseInt(fullMatch[3]),
-        hour: parseInt(fullMatch[4]),
-        minute: parseInt(fullMatch[5]),
-      },
-      { zone: 'utc' }
-    ).toLocal()
-    return `${utc.toFormat('MMM d, yyyy HH:mm')} (local)`
-  }
-
-  // Format: 20260331T18 or 20260331T1800 (alternate, no }, UTC)
+  // Format: 20260401T0600 or 20260331T18 (UTC)
   const shortMatch = scheduleDate.match(
     /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})?$/
   )

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -314,8 +314,9 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       text?: string
     ): number | undefined => {
       const raw = data ?? text ?? ''
-      // Format: 20260331T18 or 20260331T1800 (UTC)
-      const m = raw.match(/sched\s+(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})?/)
+      // Format: 20260331T18 or 20260331T1800 (UTC). Also accept the legacy
+      // }T format emitted by older makeCommand builds until old events age out.
+      const m = raw.match(/sched\s+(\d{4})(\d{2})(\d{2})}?T(\d{2})(\d{2})?/)
       if (!m) return undefined
       const dt = DateTime.fromObject(
         {
@@ -865,7 +866,8 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       ? 'mission'
       : 'command'
     const rawText = mission?.event.data ?? mission?.event.text ?? ''
-    const schedDateMatch = rawText.match(/sched\s+(\d{8}T\d{2,4})/)
+    // Also accept the legacy }T format for historical events in the database.
+    const schedDateMatch = rawText.match(/sched\s+(\d{8}}?T\d{2,4})/)
     const scheduleDate = rawText.match(/sched\s+asap/i)
       ? 'asap'
       : schedDateMatch
@@ -928,9 +930,11 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
           // WHEN it will run, not when the command was sent.
           const scheduledDt = (() => {
             if (!isQueued || !scheduleDate) return null
+            // Strip legacy } (from older makeCommand builds) before parsing.
+            const clean = scheduleDate.replace('}', '')
             const m =
-              scheduleDate.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})$/) ||
-              scheduleDate.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})$/)
+              clean.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})$/) ||
+              clean.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})$/)
             if (!m) return null
             return DateTime.fromObject(
               {

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -314,10 +314,8 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       text?: string
     ): number | undefined => {
       const raw = data ?? text ?? ''
-      // Format: 20260401}T0600 or 20260331T18 or 20260331T1800 (UTC)
-      const m =
-        raw.match(/sched\s+(\d{4})(\d{2})(\d{2})}T(\d{2})(\d{2})/) ||
-        raw.match(/sched\s+(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})?/)
+      // Format: 20260331T18 or 20260331T1800 (UTC)
+      const m = raw.match(/sched\s+(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})?/)
       if (!m) return undefined
       const dt = DateTime.fromObject(
         {
@@ -867,7 +865,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       ? 'mission'
       : 'command'
     const rawText = mission?.event.data ?? mission?.event.text ?? ''
-    const schedDateMatch = rawText.match(/sched\s+(\d{8}}?T\d{2,4})/)
+    const schedDateMatch = rawText.match(/sched\s+(\d{8}T\d{2,4})/)
     const scheduleDate = rawText.match(/sched\s+asap/i)
       ? 'asap'
       : schedDateMatch
@@ -930,10 +928,9 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
           // WHEN it will run, not when the command was sent.
           const scheduledDt = (() => {
             if (!isQueued || !scheduleDate) return null
-            const clean = scheduleDate.replace('}', '')
             const m =
-              clean.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})$/) ||
-              clean.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})$/)
+              scheduleDate.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})$/) ||
+              scheduleDate.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})$/)
             if (!m) return null
             return DateTime.fromObject(
               {

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -647,3 +647,82 @@ test('configSet command row shows Sent status and config badge tooltip', async (
     expect(wrenchIcon).toBeInTheDocument()
   })
 })
+
+test('parses corrected sched YYYYMMDDT timestamp without }', async () => {
+  // Use a far-future date so isQueued stays true regardless of test runtime.
+  const futureStamp = '20991231T2359'
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            {
+              data: `sched ${futureStamp} "load Science/profile_station.tl;run"`,
+              unixTime: Date.now() - 5 * 1000,
+              eventId: 701,
+              eventType: 'run',
+              text: null,
+              note: null,
+              user: 'test-engineer',
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection {...props} currentDeploymentId={1} />
+    </MockProviders>
+  )
+
+  // The row should display a scheduled start time derived from the timestamp,
+  // not fall back to 'N/A' (which would mean parsing failed).
+  await waitFor(() => {
+    expect(screen.getByText(/Dec 31/)).toBeInTheDocument()
+  })
+})
+
+test('parses legacy sched YYYYMMDD}T timestamp for backwards compatibility', async () => {
+  // Simulate an event stored before the makeCommand } fix was deployed.
+  const legacyStamp = '20991231}T2359'
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            {
+              data: `sched ${legacyStamp} "load Science/profile_station.tl;run"`,
+              unixTime: Date.now() - 5 * 1000,
+              eventId: 702,
+              eventType: 'run',
+              text: null,
+              note: null,
+              user: 'test-engineer',
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection {...props} currentDeploymentId={1} />
+    </MockProviders>
+  )
+
+  // The row should still display a scheduled start time despite the legacy }T.
+  await waitFor(() => {
+    expect(screen.getByText(/Dec 31/)).toBeInTheDocument()
+  })
+})

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -681,10 +681,11 @@ test('parses corrected sched YYYYMMDDT timestamp without }', async () => {
     </MockProviders>
   )
 
-  // The row should display a scheduled start time derived from the timestamp,
-  // not fall back to 'N/A' (which would mean parsing failed).
+  // The row should display "Sent and Queued for … UTC" — the fixed prefix and
+  // UTC suffix are locale-independent and confirm that timestamp parsing
+  // succeeded (a parse failure falls back to 'N/A' with no "Queued" prefix).
   await waitFor(() => {
-    expect(screen.getByText(/Dec 31/)).toBeInTheDocument()
+    expect(screen.getByText(/Sent and Queued for .+ UTC/)).toBeInTheDocument()
   })
 })
 
@@ -721,8 +722,9 @@ test('parses legacy sched YYYYMMDD}T timestamp for backwards compatibility', asy
     </MockProviders>
   )
 
-  // The row should still display a scheduled start time despite the legacy }T.
+  // The row should still display "Sent and Queued for … UTC" despite the
+  // legacy }T — same locale-independent assertion used for the clean timestamp.
   await waitFor(() => {
-    expect(screen.getByText(/Dec 31/)).toBeInTheDocument()
+    expect(screen.getByText(/Sent and Queued for .+ UTC/)).toBeInTheDocument()
   })
 })

--- a/apps/lrauv-dash2/lib/makeCommand.ts
+++ b/apps/lrauv-dash2/lib/makeCommand.ts
@@ -45,7 +45,7 @@ export const makeCommand = ({
         }
       }
       const t = DateTime.fromISO(specifiedLocalTime).toUTC()
-      const schedDate = `${t.toFormat('yyyyMMdd')}}T${t.toFormat('HHmm')}`
+      const schedDate = `${t.toFormat('yyyyMMdd')}T${t.toFormat('HHmm')}`
       return {
         commandText: resolvedCommandText,
         schedDate,


### PR DESCRIPTION
## Summary

- Fixes a one-character typo in \`makeCommand.ts\` where the template literal \`\${t.toFormat('yyyyMMdd')}}T\` was emitting a literal \`}\` between the date and time portion of the \`sched\` timestamp, causing all scheduled future-time directives to be sent as \`sched 20260505}T1844 \"...\"\` which the vehicle rejects as invalid syntax.
- Retains backwards-compatible \`}?\` regex patterns in \`ScheduleSection.tsx\` and \`ScheduleEventDetailsModal.tsx\` and normalises \`}\` via \`.replace('}','')\` before parsing, so existing events stored with the legacy format continue to display correctly until they age out.
- Adds regression tests for both the corrected (\`YYYYMMDDT\`) and legacy (\`YYYYMMDD}T\`) timestamp formats.

## Files Changed

- \`apps/lrauv-dash2/lib/makeCommand.ts\` — remove extra \`}\` from template literal (1-char fix)
- \`apps/lrauv-dash2/components/ScheduleSection.tsx\` — accept optional \`}?\` in \`parseScheduledUnixTime\` and \`schedDateMatch\` regexes; restore \`.replace('}','')\` in \`scheduledDt\` block
- \`apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx\` — normalise \`}\` before \`formatScheduleDate\` regex match so legacy events render a formatted timestamp instead of the raw string
- \`apps/lrauv-dash2/jest/ScheduleSection.test.tsx\` — regression tests for both timestamp formats

## Test plan

- [ ] Schedule a mission with a specific future time via the Mission Modal
- [ ] Verify the preview SBD shows \`sched 20260505T1844 \"...\"\` (no \`}\`)
- [ ] Confirm queued rows with the legacy \`YYYYMMDD}T\` format still display \"Sent and Queued for …\" with the correct scheduled time
- [ ] Regression tests pass for both corrected and legacy timestamp formats

Closes #587