### PR TITLE
fix(#585): hide parameter summary for non-mission commands

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -825,30 +825,34 @@ export const ScheduleEventDetailsModal: React.FC<
           </div>
         </div>
 
-        <div>
-          <p className="text-sm uppercase tracking-wide text-stone-500">
-            Summary Parameters
-            {event.isParamUpdate && (
-              <span
-                className="ml-2 text-xs normal-case italic"
-                style={{ color: '#b45309' }}
-              >
-                (parameter update for associated mission)
-              </span>
-            )}
-            {event.isConfigSetUpdate && (
-              <span
-                className="ml-2 text-xs normal-case italic"
-                style={{ color: '#1e40af' }}
-              >
-                (vehicle config update)
-              </span>
-            )}
-          </p>
-          <p className="mt-1 rounded border border-stone-300 bg-stone-100 p-2 font-mono text-sm text-stone-900">
-            {event.secondary || 'No parsed parameters available'}
-          </p>
-        </div>
+        {(event.commandType === 'mission' ||
+          event.isParamUpdate ||
+          event.isConfigSetUpdate) && (
+          <div>
+            <p className="text-sm uppercase tracking-wide text-stone-500">
+              Summary Parameters
+              {event.isParamUpdate && (
+                <span
+                  className="ml-2 text-xs normal-case italic"
+                  style={{ color: '#b45309' }}
+                >
+                  (parameter update for associated mission)
+                </span>
+              )}
+              {event.isConfigSetUpdate && (
+                <span
+                  className="ml-2 text-xs normal-case italic"
+                  style={{ color: '#1e40af' }}
+                >
+                  (vehicle config update)
+                </span>
+              )}
+            </p>
+            <p className="mt-1 rounded border border-stone-300 bg-stone-100 p-2 font-mono text-sm text-stone-900">
+              {event.secondary || 'No parsed parameters available'}
+            </p>
+          </div>
+        )}
 
         {!!event.note && (
           <div>

--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -825,7 +825,7 @@ export const ScheduleEventDetailsModal: React.FC<
           </div>
         </div>
 
-        {(event.commandType === 'mission' ||
+        {(event.isLoadRunMission ||
           event.isParamUpdate ||
           event.isConfigSetUpdate) && (
           <div>

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -901,7 +901,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     return mission ? (
       <ScheduleCell
         label={missionName ?? 'Unknown'}
-        secondary={missionParams ?? 'No parameters'}
+        secondary={isMission ? missionParams ?? 'No parameters' : undefined}
         status={cellStatus}
         statusTooltip={
           cellStatus === 'ack' ? `Received by ${vehicleName}` : undefined
@@ -1023,7 +1023,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 commandType: cellCommandType,
                 status: cellStatus,
                 label: missionName ?? 'Unknown',
-                secondary: missionParams ?? undefined,
+                secondary: isMission ? missionParams ?? undefined : undefined,
                 user: mission.event.user ?? undefined,
                 note: mission.event.note ?? undefined,
                 eventData: mission.event.data ?? undefined,

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -106,7 +106,19 @@ const missionKeysMatch = (leftPath: string, rightPath: string) => {
 
 export const parseMissionCommand = (name: string) => {
   const keywords = new Set(['run', 'sched', 'asap'])
-  const info = name
+  // Strip sched <timestamp_or_asap> prefix so scheduled missions parse cleanly
+  // (e.g. "sched 20250616T0415 load ...;run" → "load ...;run").
+  // Also extract the payload from surrounding quotes when present — the
+  // chunked cell-comms form wraps each chunk in quotes:
+  //   sched 20250616T0415 "load ...;set ...;run" 41tnk 1 6
+  // The quoted content is extracted so the chunk ID suffix is discarded.
+  let cleaned = name
+    .replace(/^sched\s+(?:\d{8}}?T\d{2,4}|asap)?\s*/i, '')
+    .trim()
+  const quoted = cleaned.match(/^"([\s\S]*)"/)
+  if (quoted) cleaned = quoted[1].trim()
+
+  const info = cleaned
     .split(' ')
     .filter((s) => !keywords.has(s))
     .join(' ')

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -1035,8 +1035,14 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 commandType: cellCommandType,
                 status: cellStatus,
                 label: missionName ?? 'Unknown',
+                // For load+run missions: structured params summary from parsing.
+                // For param/configSet updates: the raw command text IS the
+                // parameter, so use it as the summary rather than showing
+                // 'No parsed parameters available' as a misleading fallback.
                 secondary: isLoadRunMission
                   ? missionParams ?? undefined
+                  : isParam || isConfigSet
+                  ? rawText || undefined
                   : undefined,
                 user: mission.event.user ?? undefined,
                 note: mission.event.note ?? undefined,

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -105,11 +105,14 @@ const missionKeysMatch = (leftPath: string, rightPath: string) => {
 }
 
 export const parseMissionCommand = (name: string) => {
+  const keywords = new Set(['run', 'sched', 'asap'])
   const info = name
     .split(' ')
-    .filter((s) => !['run', 'sched', 'asap'].includes(s))
+    .filter((s) => !keywords.has(s))
     .join(' ')
     .split(';')
+    .map((s) => s.trim())
+    .filter((s) => s && !keywords.has(s))
   return {
     name: info[0],
     parameters: info[1],
@@ -857,6 +860,13 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     const isMission =
       mission?.event?.eventType === 'run' ||
       isMissionCommand(mission?.event?.data, mission?.event?.text)
+    // Narrower check: only load+run missions (load <file>;[set ...;]run) can
+    // carry parameter overrides. Legacy bare-run events (run Science/mbts_sci2.tl)
+    // are still classified as missions but never have parameters.
+    const isLoadRunMission = isMissionCommand(
+      mission?.event?.data,
+      mission?.event?.text
+    )
     const isParam =
       !isMission && isParamCommand(mission?.event?.data, mission?.event?.text)
     const isConfigSet =
@@ -901,7 +911,9 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     return mission ? (
       <ScheduleCell
         label={missionName ?? 'Unknown'}
-        secondary={isMission ? missionParams ?? 'No parameters' : undefined}
+        secondary={
+          isLoadRunMission ? missionParams ?? 'No parameters' : undefined
+        }
         status={cellStatus}
         statusTooltip={
           cellStatus === 'ack' ? `Received by ${vehicleName}` : undefined
@@ -1023,7 +1035,9 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 commandType: cellCommandType,
                 status: cellStatus,
                 label: missionName ?? 'Unknown',
-                secondary: isMission ? missionParams ?? undefined : undefined,
+                secondary: isLoadRunMission
+                  ? missionParams ?? undefined
+                  : undefined,
                 user: mission.event.user ?? undefined,
                 note: mission.event.note ?? undefined,
                 eventData: mission.event.data ?? undefined,
@@ -1038,6 +1052,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 via: getVia(mission.event.note) ?? undefined,
                 isParamUpdate: isParam,
                 isConfigSetUpdate: isConfigSet,
+                isLoadRunMission,
                 commsStatus: commsLookup.get(mission.event.eventId),
               },
             },

--- a/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
@@ -1,0 +1,152 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { ScheduleEventDetailsModal } from '../components/ScheduleEventDetailsModal'
+
+// Mock hooks the modal depends on
+jest.mock('../lib/useGlobalModalId', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}))
+jest.mock('../lib/useCurrentDeployment', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ deployment: null })),
+}))
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(() => ({ query: {} })),
+}))
+
+import useGlobalModalId from '../lib/useGlobalModalId'
+
+const baseEvent = {
+  eventId: 1001,
+  commandType: 'mission' as const,
+  status: 'sent' as const,
+  label: 'load Transport/transit.tl',
+  user: 'test-operator',
+  note: '[[via:cell, timeout:5min]]',
+  eventData: 'load Transport/transit.tl;set transit.Depth 50 m;run',
+  eventText: null,
+  startedAt: Date.now() - 60 * 1000,
+  vehicleName: 'triton',
+  via: 'cell' as const,
+}
+
+const makeModalId = (event: object) => ({
+  globalModalId: {
+    id: 'scheduleEventDetails' as const,
+    meta: { scheduleEvent: event },
+  },
+  setGlobalModalId: jest.fn(),
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+// ── Summary Parameters visibility ─────────────────────────────────────────────
+
+test('shows Summary Parameters for load+run mission with params', () => {
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      isLoadRunMission: true,
+      secondary: 'set transit.Depth 50 m',
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.getByText(/Summary Parameters/i)).toBeInTheDocument()
+  // The text appears in both Summary Parameters and Raw Payload sections.
+  expect(screen.getAllByText('set transit.Depth 50 m').length).toBeGreaterThan(
+    0
+  )
+  expect(
+    screen.queryByText('No parsed parameters available')
+  ).not.toBeInTheDocument()
+})
+
+test('shows "No parsed parameters available" for load+run mission with no params', () => {
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      isLoadRunMission: true,
+      secondary: undefined,
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.getByText(/Summary Parameters/i)).toBeInTheDocument()
+  expect(screen.getByText('No parsed parameters available')).toBeInTheDocument()
+})
+
+test('hides Summary Parameters for non-mission bare commands', () => {
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      commandType: 'command' as const,
+      isLoadRunMission: false,
+      isParamUpdate: false,
+      isConfigSetUpdate: false,
+      secondary: undefined,
+      eventData: 'restart logs',
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.queryByText(/Summary Parameters/i)).not.toBeInTheDocument()
+  expect(
+    screen.queryByText('No parsed parameters available')
+  ).not.toBeInTheDocument()
+})
+
+test('shows Summary Parameters with raw payload for isParamUpdate commands', () => {
+  const rawCmd = 'set transit.Depth 50 m'
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      commandType: 'command' as const,
+      isLoadRunMission: false,
+      isParamUpdate: true,
+      isConfigSetUpdate: false,
+      secondary: rawCmd,
+      eventData: rawCmd,
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.getByText(/Summary Parameters/i)).toBeInTheDocument()
+  // secondary is now the raw command text — not the generic placeholder
+  expect(
+    screen.queryByText('No parsed parameters available')
+  ).not.toBeInTheDocument()
+  // The text appears in both Summary Parameters and Raw Payload sections.
+  expect(screen.getAllByText(rawCmd).length).toBeGreaterThan(0)
+})
+
+test('shows Summary Parameters with raw payload for isConfigSetUpdate commands', () => {
+  const rawCmd = 'configSet CTD_Seabird.loadAtStartup 1 bool persist'
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      commandType: 'command' as const,
+      isLoadRunMission: false,
+      isParamUpdate: false,
+      isConfigSetUpdate: true,
+      secondary: rawCmd,
+      eventData: rawCmd,
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.getByText(/Summary Parameters/i)).toBeInTheDocument()
+  expect(
+    screen.queryByText('No parsed parameters available')
+  ).not.toBeInTheDocument()
+  expect(screen.getAllByText(rawCmd).length).toBeGreaterThan(0)
+})

--- a/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
@@ -128,6 +128,32 @@ test('shows Summary Parameters with raw payload for isParamUpdate commands', () 
   expect(screen.getAllByText(rawCmd).length).toBeGreaterThan(0)
 })
 
+test('hides Summary Parameters for legacy bare-run mission (commandType mission, isLoadRunMission false)', () => {
+  // Command-status payloads can carry bare "run Science/mbts_sci2.tl" events
+  // (no load prefix) — these are classified as commandType:'mission' but
+  // isLoadRunMission is false because there is no load+run pair. The modal
+  // must NOT show the Summary Parameters block for these legacy rows.
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      commandType: 'mission' as const,
+      isLoadRunMission: false,
+      isParamUpdate: false,
+      isConfigSetUpdate: false,
+      secondary: undefined,
+      label: 'Science/mbts_sci2.tl',
+      eventData: 'run Science/mbts_sci2.tl',
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.queryByText(/Summary Parameters/i)).not.toBeInTheDocument()
+  expect(
+    screen.queryByText('No parsed parameters available')
+  ).not.toBeInTheDocument()
+})
+
 test('shows Summary Parameters with raw payload for isConfigSetUpdate commands', () => {
   const rawCmd = 'configSet CTD_Seabird.loadAtStartup 1 bool persist'
   ;(useGlobalModalId as jest.Mock).mockReturnValue(

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -783,6 +783,31 @@ test('parseMissionCommand strips bare sched/asap tokens', () => {
   })
 })
 
+test('parseMissionCommand strips sched timestamp prefix', () => {
+  expect(
+    parseMissionCommand(
+      'sched 20250616T0415 load Science/profile_station.tl;run'
+    )
+  ).toEqual({
+    name: 'load Science/profile_station.tl',
+    parameters: undefined,
+  })
+})
+
+test('parseMissionCommand extracts payload from quoted chunked cell-comms form', () => {
+  // Chunked cell delivery wraps the payload in quotes and appends a chunk ID
+  // suffix (e.g. "41tnk 1 6"). The parser should extract the quoted content
+  // and discard the suffix, yielding clean name/parameters.
+  expect(
+    parseMissionCommand(
+      'sched 20250616T0415 "load Science/sci2_circle_hotspot.tl;set sci2_circle_hotspot.MissionTimeout 24 h;run" 41tnk 1 6'
+    )
+  ).toEqual({
+    name: 'load Science/sci2_circle_hotspot.tl',
+    parameters: 'set sci2_circle_hotspot.MissionTimeout 24 h',
+  })
+})
+
 // ── Legacy run <file> — no parameter summary row (#585) ───────────────────────
 
 test('legacy run <file> mission row does not show "No parameters" subtitle', async () => {

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -8,6 +8,7 @@ import {
   isMissionCommand,
   isParamCommand,
   isConfigSetCommand,
+  parseMissionCommand,
 } from '../components/ScheduleSection'
 import { QueryClient } from 'react-query'
 import { rest } from 'msw'
@@ -751,4 +752,75 @@ test('mission command row shows "No parameters" secondary text when no params se
     expect(screen.getByText('load Transport/transit.tl')).toBeInTheDocument()
   })
   expect(screen.getByText('No parameters')).toBeInTheDocument()
+})
+
+// ── parseMissionCommand unit tests (#585) ─────────────────────────────────────
+
+test('parseMissionCommand strips trailing run from semicolon-delimited commands', () => {
+  // load;run with no set params should return parameters: undefined so the
+  // row falls back to "No parameters" rather than showing "run" as a param.
+  expect(parseMissionCommand('load Transport/transit.tl;run')).toEqual({
+    name: 'load Transport/transit.tl',
+    parameters: undefined,
+  })
+})
+
+test('parseMissionCommand preserves set params between load and run', () => {
+  expect(
+    parseMissionCommand('load Transport/transit.tl;set transit.Depth 50 m;run')
+  ).toEqual({
+    name: 'load Transport/transit.tl',
+    parameters: 'set transit.Depth 50 m',
+  })
+})
+
+test('parseMissionCommand strips bare sched/asap tokens', () => {
+  expect(
+    parseMissionCommand('sched asap load Science/profile_station.tl;run')
+  ).toEqual({
+    name: 'load Science/profile_station.tl',
+    parameters: undefined,
+  })
+})
+
+// ── Legacy run <file> — no parameter summary row (#585) ───────────────────────
+
+test('legacy run <file> mission row does not show "No parameters" subtitle', async () => {
+  // Legacy format: eventType 'run' but command data is bare 'run <file>'.
+  // isMission is true (eventType=run), but isLoadRunMission is false (no load),
+  // so the secondary text should be suppressed entirely.
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            {
+              data: 'run Science/mbts_sci2.tl',
+              unixTime: Date.now() - 60 * 1000,
+              eventId: 410,
+              eventType: 'run',
+              text: null,
+              note: null,
+              user: 'test-operator',
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection {...props} currentDeploymentId={1} />
+    </MockProviders>
+  )
+
+  await waitFor(() => {
+    expect(screen.getByText(/mbts_sci2/)).toBeInTheDocument()
+  })
+  expect(screen.queryByText('No parameters')).not.toBeInTheDocument()
 })

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -5,6 +5,7 @@ import '@testing-library/jest-dom'
 import {
   ScheduleSection,
   ScheduleSectionProps,
+  isMissionCommand,
   isParamCommand,
   isConfigSetCommand,
 } from '../components/ScheduleSection'
@@ -646,4 +647,108 @@ test('configSet command row shows Sent status and config badge tooltip', async (
     const wrenchIcon = document.querySelector('svg[data-icon="wrench"]')
     expect(wrenchIcon).toBeInTheDocument()
   })
+})
+
+// ── isMissionCommand unit tests ───────────────────────────────────────────────
+
+test('isMissionCommand returns true for load+run commands', () => {
+  expect(
+    isMissionCommand(
+      'load Science/profile_station.tl;set profile_station.NeedCommsTime 30 min;run'
+    )
+  ).toBe(true)
+  expect(isMissionCommand('load Transport/transit.tl;run')).toBe(true)
+  expect(isMissionCommand(undefined, 'load Science/sci2.xml;run')).toBe(true)
+})
+
+test('isMissionCommand returns false for commands without load+run', () => {
+  expect(isMissionCommand('restart logs')).toBe(false)
+  expect(isMissionCommand('schedule clear;schedule resume')).toBe(false)
+  expect(isMissionCommand('set profile_station.YoYoMaxDepth 40 meter')).toBe(
+    false
+  )
+  expect(
+    isMissionCommand('configSet CTD_Seabird.loadAtStartup 1 bool persist')
+  ).toBe(false)
+  expect(isMissionCommand('schedule clear')).toBe(false)
+  expect(isMissionCommand(undefined, undefined)).toBe(false)
+})
+
+// ── secondary label gating integration tests ──────────────────────────────────
+
+test('bare command row does not show "No parameters" secondary text', async () => {
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            {
+              data: 'restart logs',
+              unixTime: Date.now() - 60 * 1000,
+              eventId: 400,
+              eventType: 'command',
+              text: null,
+              note: null,
+              user: 'test-operator',
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection {...props} currentDeploymentId={1} />
+    </MockProviders>
+  )
+
+  await waitFor(() => {
+    expect(screen.getByText('restart logs')).toBeInTheDocument()
+  })
+  expect(screen.queryByText('No parameters')).not.toBeInTheDocument()
+  expect(
+    screen.queryByText('No parsed parameters available')
+  ).not.toBeInTheDocument()
+})
+
+test('mission command row shows "No parameters" secondary text when no params set', async () => {
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            {
+              data: 'load Transport/transit.tl;run',
+              unixTime: Date.now() - 60 * 1000,
+              eventId: 401,
+              eventType: 'run',
+              text: null,
+              note: null,
+              user: 'test-operator',
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection {...props} currentDeploymentId={1} />
+    </MockProviders>
+  )
+
+  await waitFor(() => {
+    expect(screen.getByText('load Transport/transit.tl')).toBeInTheDocument()
+  })
+  expect(screen.getByText('No parameters')).toBeInTheDocument()
 })

--- a/apps/lrauv-dash2/lib/useGlobalModalId.ts
+++ b/apps/lrauv-dash2/lib/useGlobalModalId.ts
@@ -63,6 +63,8 @@ export interface GlobalModalMetaData {
     via?: 'cell' | 'sat' | 'cellsat'
     isParamUpdate?: boolean
     isConfigSetUpdate?: boolean
+    /** True for load+run missions (load <file>;[set ...;]run) — the only format that can carry parameter overrides */
+    isLoadRunMission?: boolean
     /** Raw comms status from the Comms Queue — 'queued'|'sent'|'ack'|'timeout' */
     commsStatus?: string
     /** True for automatic Default mission rows (not operator-commanded) */

--- a/packages/react-ui/src/Cells/ScheduleCell.test.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.test.tsx
@@ -87,3 +87,25 @@ test('should have teal label when pending and the schedule is paused', async () 
     'text-teal-600'
   )
 })
+
+test('should render secondary text when secondary prop is provided', () => {
+  render(<ScheduleCell {...props} secondary="breakfast of champions" />)
+
+  expect(screen.getByText('breakfast of champions')).toBeInTheDocument()
+})
+
+test('should not render an empty secondary row when secondary is undefined', () => {
+  // Previously ScheduleCell always rendered the secondary <li> even when
+  // secondary was undefined, leaving an empty subtitle row for non-mission
+  // commands. This guards against regressions.
+  // Base props include secondary='breakfast of champions'; override to undefined.
+  render(<ScheduleCell {...props} secondary={undefined} />)
+
+  // The label still renders...
+  expect(screen.getByText(props.label)).toBeInTheDocument()
+  // ...but the secondary text from the base props must not appear.
+  expect(screen.queryByText('breakfast of champions')).not.toBeInTheDocument()
+  // ...and there must be no italic subtitle <li> in the DOM at all.
+  const italicLis = document.querySelectorAll('li.italic')
+  expect(italicLis).toHaveLength(0)
+})

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -34,7 +34,7 @@ export interface ScheduleCellProps {
   scheduleStatus?: 'paused' | 'running'
   label: string
   ariaLabel?: string
-  secondary: string
+  secondary?: string
   name: string
   eventId: number
   commandType: CommandType
@@ -207,14 +207,16 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
               </Tippy>
             )}
           </li>
-          <li
-            className={clsx(
-              'flex truncate italic',
-              isOpen ? styles.text : styles.textLight
-            )}
-          >
-            {secondary}
-          </li>
+          {secondary && (
+            <li
+              className={clsx(
+                'flex truncate italic',
+                isOpen ? styles.text : styles.textLight
+              )}
+            >
+              {secondary}
+            </li>
+          )}
           <li
             className={clsx(
               'flex truncate',


### PR DESCRIPTION
## Summary

- Bare cell commands, `set` parameter updates, config-set commands, and other non-mission directives cannot have mission parameters, but the Schedule History row and popup always showed a `"No parameters"` / `"No parsed parameters available"` fallback
- Operators were confused into thinking parameters were an option when they were not

## Changes

- **`ScheduleSection.tsx`** — gate the `secondary` prop on `isMissionCommand()`: non-mission rows now render no secondary label at all
- **`ScheduleSection.tsx`** — pass `secondary: undefined` to the details modal for non-mission commands
- **`ScheduleEventDetailsModal.tsx`** — wrap the "Summary Parameters" block in a guard so it only renders for `commandType === 'mission'`, param-update, or config-set commands

## Test plan

- [ ] Send a bare cell command (no `load`) — verify the Schedule History row shows no parameter subtitle and the popup has no "Summary Parameters" section
- [ ] Send a mission command with parameters — verify the row shows the parameter summary and the popup "Summary Parameters" section appears as before
- [ ] Send a mission command with no parameters — verify row shows `"No parameters"` and popup shows `"No parsed parameters available"` (acceptable for missions where the operator actively chose not to set params)
- [ ] Send a `set` param update — verify "Summary Parameters" section still shows in the popup (with the amber "parameter update for associated mission" tag)
- [ ] Send a config-set command — verify "Summary Parameters" section still shows in the popup (with the blue "vehicle config update" tag)

Closes #585