### PR TITLE
fix(#584): apply comms lookup to mission commands stuck on pending

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -882,18 +882,15 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         return 'sent'
       }
       const raw = toScheduleCellStatus(mission?.status ?? '')
-      // Non-mission, non-param commands with no future scheduled start
-      // are already dispatched — API 'pending'/'TBD' just means the vehicle
-      // hasn't confirmed yet. Use comms lookup for the most accurate status.
-      if (
-        raw === 'pending' &&
-        !isMission &&
-        !(scheduleDate && scheduleDate !== 'asap')
-      ) {
+      // For any pending command with no specific future scheduled start,
+      // use the comms lookup to upgrade status based on actual vehicle
+      // receipt. The API always returns TBD/'pending' for mission commands
+      // so comms data is the only reliable signal for missions too.
+      if (raw === 'pending' && !(scheduleDate && scheduleDate !== 'asap')) {
         const commsStatus = commsLookup.get(mission.event.eventId)
         if (commsStatus === 'ack') return 'ack'
         if (commsStatus === 'timeout') return 'timeout'
-        return 'sent'
+        if (commsStatus === 'sent') return 'sent'
       }
       return raw
     })()

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -978,8 +978,8 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
               : cellStatus === 'running'
               ? 'Started'
               : cellStatus === 'ack'
-              ? // Comms ACK means the vehicle received the command via SBD —
-                // not that the mission started executing.
+              ? // Comms ACK means the vehicle received the command via comms
+                // (cell or sat) — not that the mission started executing.
                 'Received'
               : cellStatus === 'timeout'
               ? 'Timed out'

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -891,6 +891,11 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         if (commsStatus === 'ack') return 'ack'
         if (commsStatus === 'timeout') return 'timeout'
         if (commsStatus === 'sent') return 'sent'
+        // Non-mission ASAP/immediate commands are always dispatched to the
+        // comms layer — fall back to 'sent' even when the comms event falls
+        // outside the fetch window. Mission commands stay 'pending' until
+        // a comms entry confirms transmission to avoid misleading operators.
+        if (!isMission) return 'sent'
       }
       return raw
     })()

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -977,6 +977,14 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 : 'Sent'
               : cellStatus === 'running'
               ? 'Started'
+              : cellStatus === 'ack'
+              ? // Comms ACK means the vehicle received the command via SBD —
+                // not that the mission started executing.
+                'Received'
+              : cellStatus === 'timeout'
+              ? 'Timed out'
+              : cellStatus === 'sent'
+              ? 'Sent'
               : isMission
               ? 'Started'
               : 'Ran'

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -756,3 +756,66 @@ test('mission command stays pending when no comms entry exists (outside fetch wi
   })
   expect(screen.queryByTitle(/Received by/i)).not.toBeInTheDocument()
 })
+
+test('future-scheduled mission stays pending even when comms indicates sent', async () => {
+  // A mission scheduled for a far-future time should not be upgraded via the
+  // comms lookup because the scheduleDate gate prevents it: only ASAP/unscheduled
+  // missions should be upgraded based on comms data.
+  const futureStamp = '20991231T2359'
+  const scheduledMission = {
+    data: `sched ${futureStamp} "load Transport/transit.tl;run"`,
+    unixTime: Date.now() - 60 * 1000,
+    eventId: 470,
+    eventType: 'run',
+    text: null,
+    note: '[[via:cell, timeout:5min]]',
+    user: 'test-operator',
+  }
+  const sbdSendEvent = {
+    eventId: 471,
+    eventType: 'sbdSend',
+    refId: 470,
+    state: 2,
+    unixTime: Date.now() - 58 * 1000,
+    isoTime: new Date(Date.now() - 58 * 1000).toISOString(),
+    data: null,
+    text: null,
+    note: null,
+    user: null,
+  }
+
+  server.use(
+    rest.get('/events', (req, res, ctx) => {
+      const eventTypes = req.url.searchParams.get('eventTypes') ?? ''
+      const isCommsQuery = eventTypes.includes('sbdSend')
+      return res(
+        ctx.status(200),
+        ctx.json({
+          result: isCommsQuery
+            ? [scheduledMission, sbdSendEvent]
+            : [scheduledMission],
+        })
+      )
+    }),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection
+        {...props}
+        currentDeploymentId={1}
+        deploymentStartTime={Date.now() - 3600 * 1000}
+      />
+    </MockProviders>
+  )
+
+  // Despite the sbdSend comms event, the mission must stay 'pending' because
+  // it has a future scheduled start time (scheduleDate !== 'asap').
+  await waitFor(() => {
+    expect(screen.getByTitle(/pending/i)).toBeInTheDocument()
+  })
+  expect(screen.queryByTitle(/Received by/i)).not.toBeInTheDocument()
+})

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -762,7 +762,7 @@ test('mission command stays pending when no comms entry exists (outside fetch wi
   expect(screen.queryByTitle(/Received by/i)).not.toBeInTheDocument()
 })
 
-test('future-scheduled mission stays pending even when comms indicates sent', async () => {
+test('future-scheduled mission stays pending even when comms indicates ack', async () => {
   // A mission scheduled for a far-future time should not be upgraded via the
   // comms lookup because the scheduleDate gate prevents it: only ASAP/unscheduled
   // missions should be upgraded based on comms data.

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -680,12 +680,17 @@ test('mission command upgrades from pending to ack when cell comms ACK is receiv
       // The history query requests only command,run; the comms query also
       // includes sbdSend,sbdReceipt,sbdReceive,note. Branch accordingly so
       // sbdSend is only visible to the comms lookup, matching production.
+      // The cancellation-notes query uses eventTypes=note exclusively — return
+      // [] so that query doesn't accidentally receive run/sbdSend events.
       const eventTypes = req.url.searchParams.get('eventTypes') ?? ''
+      const isNoteQuery = eventTypes === 'note'
       const isCommsQuery = eventTypes.includes('sbdSend')
       return res(
         ctx.status(200),
         ctx.json({
-          result: isCommsQuery
+          result: isNoteQuery
+            ? []
+            : isCommsQuery
             ? [missionRunEvent, sbdSendEvent]
             : [missionRunEvent],
         })
@@ -786,12 +791,17 @@ test('future-scheduled mission stays pending even when comms indicates sent', as
 
   server.use(
     rest.get('/events', (req, res, ctx) => {
+      // Return [] for note-only queries (cancellation-notes lookup) so test
+      // data is isolated and doesn't bleed into unrelated component branches.
       const eventTypes = req.url.searchParams.get('eventTypes') ?? ''
+      const isNoteQuery = eventTypes === 'note'
       const isCommsQuery = eventTypes.includes('sbdSend')
       return res(
         ctx.status(200),
         ctx.json({
-          result: isCommsQuery
+          result: isNoteQuery
+            ? []
+            : isCommsQuery
             ? [scheduledMission, sbdSendEvent]
             : [scheduledMission],
         })

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -647,3 +647,105 @@ test('configSet command row shows Sent status and config badge tooltip', async (
     expect(wrenchIcon).toBeInTheDocument()
   })
 })
+
+// ── Mission comms-lookup upgrade regression tests (#584) ─────────────────────
+
+test('mission command upgrades from pending to ack when cell comms ACK is received', async () => {
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            // Mission run event — API always returns TBD/pending
+            {
+              data: 'load Transport/transit.tl;set transit.Depth 50 m;run',
+              unixTime: Date.now() - 90 * 1000,
+              eventId: 450,
+              eventType: 'run',
+              text: null,
+              note: '[[via:cell, timeout:5min]]',
+              user: 'test-operator',
+            },
+            // sbdSend with refId matching mission eventId and state:2 (cell = instant ACK)
+            {
+              eventId: 451,
+              eventType: 'sbdSend',
+              refId: 450,
+              state: 2,
+              unixTime: Date.now() - 88 * 1000,
+              isoTime: new Date(Date.now() - 88 * 1000).toISOString(),
+              data: null,
+              text: null,
+              note: null,
+              user: null,
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection
+        {...props}
+        currentDeploymentId={1}
+        deploymentStartTime={Date.now() - 3600 * 1000}
+      />
+    </MockProviders>
+  )
+
+  // Row should show ACK icon (AcknowledgeIcon) with "Received by" tooltip,
+  // not the clock/pending icon.
+  await waitFor(() => {
+    expect(screen.getByTitle(/Received by example/i)).toBeInTheDocument()
+  })
+})
+
+test('mission command stays pending when no comms entry exists (outside fetch window)', async () => {
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            // Mission run event with no matching sbdSend in the response
+            {
+              data: 'load Transport/transit.tl;run',
+              unixTime: Date.now() - 90 * 1000,
+              eventId: 460,
+              eventType: 'run',
+              text: null,
+              note: '[[via:sat, timeout:60min]]',
+              user: 'test-operator',
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection
+        {...props}
+        currentDeploymentId={1}
+        deploymentStartTime={Date.now() - 3600 * 1000}
+      />
+    </MockProviders>
+  )
+
+  // Without a comms entry, mission should remain 'pending' (clock icon),
+  // not fall through to 'sent'.
+  await waitFor(() => {
+    expect(screen.getByTitle(/pending/i)).toBeInTheDocument()
+  })
+  expect(screen.queryByTitle(/Received by/i)).not.toBeInTheDocument()
+})

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -651,39 +651,46 @@ test('configSet command row shows Sent status and config badge tooltip', async (
 // ── Mission comms-lookup upgrade regression tests (#584) ─────────────────────
 
 test('mission command upgrades from pending to ack when cell comms ACK is received', async () => {
+  // The mission run event returned by the schedule history query.
+  const missionRunEvent = {
+    data: 'load Transport/transit.tl;set transit.Depth 50 m;run',
+    unixTime: Date.now() - 90 * 1000,
+    eventId: 450,
+    eventType: 'run',
+    text: null,
+    note: '[[via:cell, timeout:5min]]',
+    user: 'test-operator',
+  }
+  // The sbdSend comms event returned only by the useCommsEvents query.
+  const sbdSendEvent = {
+    eventId: 451,
+    eventType: 'sbdSend',
+    refId: 450,
+    state: 2,
+    unixTime: Date.now() - 88 * 1000,
+    isoTime: new Date(Date.now() - 88 * 1000).toISOString(),
+    data: null,
+    text: null,
+    note: null,
+    user: null,
+  }
+
   server.use(
-    rest.get('/events', (_req, res, ctx) =>
-      res(
+    rest.get('/events', (req, res, ctx) => {
+      // The history query requests only command,run; the comms query also
+      // includes sbdSend,sbdReceipt,sbdReceive,note. Branch accordingly so
+      // sbdSend is only visible to the comms lookup, matching production.
+      const eventTypes = req.url.searchParams.get('eventTypes') ?? ''
+      const isCommsQuery = eventTypes.includes('sbdSend')
+      return res(
         ctx.status(200),
         ctx.json({
-          result: [
-            // Mission run event — API always returns TBD/pending
-            {
-              data: 'load Transport/transit.tl;set transit.Depth 50 m;run',
-              unixTime: Date.now() - 90 * 1000,
-              eventId: 450,
-              eventType: 'run',
-              text: null,
-              note: '[[via:cell, timeout:5min]]',
-              user: 'test-operator',
-            },
-            // sbdSend with refId matching mission eventId and state:2 (cell = instant ACK)
-            {
-              eventId: 451,
-              eventType: 'sbdSend',
-              refId: 450,
-              state: 2,
-              unixTime: Date.now() - 88 * 1000,
-              isoTime: new Date(Date.now() - 88 * 1000).toISOString(),
-              data: null,
-              text: null,
-              note: null,
-              user: null,
-            },
-          ],
+          result: isCommsQuery
+            ? [missionRunEvent, sbdSendEvent]
+            : [missionRunEvent],
         })
       )
-    ),
+    }),
     rest.get('/events/mission-started', (_req, res, ctx) =>
       res(ctx.status(200), ctx.json({ result: [] }))
     )


### PR DESCRIPTION
## Summary

Mission commands in Schedule History were permanently stuck at **pending** even after the vehicle sent an ACK. The `cellStatus` derivation was guarded by `!isMission`, which completely bypassed the comms lookup for mission commands.

## Root Cause

The TethysDash API **always** returns `status: TBD` (mapped to `pending`) for mission commands — it never updates. The comms event pipeline (`sbdSend` → `sbdReceipt` → `sbdReceive`) is the only reliable signal for actual vehicle receipt. Non-mission commands already used this pipeline; missions did not.

## Fix

Removes the `!isMission` guard from the comms-lookup upgrade block. Now **any** pending command with no specific future scheduled start — mission or otherwise — consults the comms lookup:

- `ack` → vehicle received the directive via cell or sat ACK
- `sent` → SBD transmitted but vehicle hasn't ACKed yet
- `timeout` → cell timeout expired with no ACK
- Future-scheduled items (timestamp `scheduleDate !== 'asap'`) are unchanged — `pending` is correct until the scheduled time arrives

## Example

Mission 27107227 (triton, cell comms):
- **Before:** row showed `pending` indefinitely
- **After:** row shows `ack` once the `ACK command Id: 27107227` entry appears in Direct Comms

## Test plan

- [ ] Send an ASAP mission to a vehicle via cell — verify the Schedule History row advances from `pending` → `sent` → `ack` within the 30s polling interval
- [ ] Send a future-scheduled mission (specific timestamp) — verify it stays `pending` until the scheduled time (comms lookup is not applied for timestamp-scheduled items)
- [ ] Verify existing non-mission command behaviour is unchanged (param updates, config-set commands still advance to ack/sent/timeout correctly)

Closes #584