### PR TITLE
feat(#586): surface MTMSN/MOMSN in Schedule History popup for sat-ACKed commands

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -246,6 +246,7 @@ export const ScheduleEventDetailsModal: React.FC<
   const [showEndedTooltip, setShowEndedTooltip] = useState(false)
   const [showScheduledStartTooltip, setShowScheduledStartTooltip] =
     useState(false)
+  const [showIridiumTooltip, setShowIridiumTooltip] = useState(false)
   const event = globalModalId?.meta?.scheduleEvent
 
   // Reset tooltip state whenever the selected event changes
@@ -253,6 +254,7 @@ export const ScheduleEventDetailsModal: React.FC<
     setShowStatusTooltip(false)
     setShowEndedTooltip(false)
     setShowScheduledStartTooltip(false)
+    setShowIridiumTooltip(false)
   }, [event?.eventId])
 
   if (!event) return null
@@ -825,23 +827,53 @@ export const ScheduleEventDetailsModal: React.FC<
           </div>
           {(event.mtmsn != null || event.momsn != null) && (
             <div>
-              <p className="text-sm uppercase tracking-wide text-stone-500">
+              <p className="flex items-center gap-1 text-sm uppercase tracking-wide text-stone-500">
                 Iridium Msg IDs
+                <span className="relative inline-flex align-middle">
+                  <button
+                    type="button"
+                    className="cursor-pointer rounded-full border border-stone-300 px-1 text-[10px] font-semibold text-stone-500 hover:bg-stone-100 focus:bg-stone-100"
+                    onMouseEnter={() => setShowIridiumTooltip(true)}
+                    onMouseLeave={() => setShowIridiumTooltip(false)}
+                    onFocus={() => setShowIridiumTooltip(true)}
+                    onBlur={() => setShowIridiumTooltip(false)}
+                    onClick={() => setShowIridiumTooltip((prev) => !prev)}
+                    aria-label="Iridium message ID field help"
+                    aria-describedby={
+                      showIridiumTooltip ? 'iridium-msg-id-tooltip' : undefined
+                    }
+                  >
+                    ?
+                  </button>
+                  {showIridiumTooltip && (
+                    <div
+                      id="iridium-msg-id-tooltip"
+                      role="tooltip"
+                      className="pointer-events-none absolute left-0 top-full z-[9999] mt-1 w-72 -translate-x-1/2 rounded border px-3 py-2 text-xs normal-case leading-relaxed text-stone-700 shadow-lg"
+                      style={{
+                        borderColor: '#bae6fd',
+                        backgroundColor: '#fffbeb',
+                      }}
+                    >
+                      <p className="normal-case">
+                        <strong>MTMSN</strong> (Mobile Terminated): Iridium ID
+                        assigned to the command sent to the vehicle.
+                      </p>
+                      <p className="mt-1 normal-case">
+                        <strong>MOMSN</strong> (Mobile Originated): Iridium ID
+                        of the vehicle&apos;s acknowledgment reply. Present only
+                        after the vehicle confirms receipt.
+                      </p>
+                    </div>
+                  )}
+                </span>
               </p>
               <p className="font-medium font-mono text-sm">
-                {event.mtmsn != null && (
-                  <span title="Mobile Terminated Message Sequence Number — Iridium ID of command sent to vehicle">
-                    MTMSN: {event.mtmsn}
-                  </span>
-                )}
+                {event.mtmsn != null && <span>MTMSN: {event.mtmsn}</span>}
                 {event.mtmsn != null && event.momsn != null && (
                   <span className="mx-2 text-stone-400">·</span>
                 )}
-                {event.momsn != null && (
-                  <span title="Mobile Originated Message Sequence Number — Iridium ID of vehicle's ACK reply">
-                    MOMSN: {event.momsn}
-                  </span>
-                )}
+                {event.momsn != null && <span>MOMSN: {event.momsn}</span>}
               </p>
             </div>
           )}

--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -823,6 +823,28 @@ export const ScheduleEventDetailsModal: React.FC<
             </p>
             <p className="font-medium">{event.eventId}</p>
           </div>
+          {(event.mtmsn != null || event.momsn != null) && (
+            <div>
+              <p className="text-sm uppercase tracking-wide text-stone-500">
+                Iridium Msg IDs
+              </p>
+              <p className="font-medium font-mono text-sm">
+                {event.mtmsn != null && (
+                  <span title="Mobile Terminated Message Sequence Number — Iridium ID of command sent to vehicle">
+                    MTMSN: {event.mtmsn}
+                  </span>
+                )}
+                {event.mtmsn != null && event.momsn != null && (
+                  <span className="mx-2 text-stone-400">·</span>
+                )}
+                {event.momsn != null && (
+                  <span title="Mobile Originated Message Sequence Number — Iridium ID of vehicle's ACK reply">
+                    MOMSN: {event.momsn}
+                  </span>
+                )}
+              </p>
+            </div>
+          )}
         </div>
 
         <div>

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -218,14 +218,17 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     return map
   }, [commsEventsResponse.data])
 
-  // eventId → { mtmsn, momsn } for sat-ACKed commands
+  // eventId → { mtmsn, momsn } for sat commands with Iridium sequence number
+  // data. Includes pre-ACK sat sends (MTMSN only) as well as fully ACKed
+  // commands (both MTMSN and MOMSN). 0 is a sentinel for "not present" in
+  // TethysDash so both values are normalized to undefined when falsy.
   const commsMsgIdLookup = useMemo(() => {
     const map = new Map<number, { mtmsn?: number; momsn?: number }>()
     commsEventsResponse.data.forEach((e) => {
-      if (e.eventId != null && (e.mtmsn != null || e.momsn != null)) {
+      if (e.eventId != null && (e.mtmsn || e.momsn)) {
         map.set(e.eventId, {
-          mtmsn: e.mtmsn ?? undefined,
-          momsn: e.momsn ?? undefined,
+          mtmsn: e.mtmsn || undefined,
+          momsn: e.momsn || undefined,
         })
       }
     })

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -218,6 +218,20 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     return map
   }, [commsEventsResponse.data])
 
+  // eventId → { mtmsn, momsn } for sat-ACKed commands
+  const commsMsgIdLookup = useMemo(() => {
+    const map = new Map<number, { mtmsn?: number; momsn?: number }>()
+    commsEventsResponse.data.forEach((e) => {
+      if (e.eventId != null && (e.mtmsn != null || e.momsn != null)) {
+        map.set(e.eventId, {
+          mtmsn: e.mtmsn ?? undefined,
+          momsn: e.momsn ?? undefined,
+        })
+      }
+    })
+    return map
+  }, [commsEventsResponse.data])
+
   const { isLoading, isFetching, refetch } = deploymentLogsOnly
     ? deploymentResponse
     : allLogsResponse
@@ -1039,6 +1053,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 isParamUpdate: isParam,
                 isConfigSetUpdate: isConfigSet,
                 commsStatus: commsLookup.get(mission.event.eventId),
+                ...commsMsgIdLookup.get(mission.event.eventId),
               },
             },
           })

--- a/apps/lrauv-dash2/lib/useGlobalModalId.ts
+++ b/apps/lrauv-dash2/lib/useGlobalModalId.ts
@@ -65,6 +65,10 @@ export interface GlobalModalMetaData {
     isConfigSetUpdate?: boolean
     /** Raw comms status from the Comms Queue — 'queued'|'sent'|'ack'|'timeout' */
     commsStatus?: string
+    /** Iridium Mobile Terminated Message Sequence Number (sat comms) */
+    mtmsn?: number
+    /** Iridium Mobile Originated Message Sequence Number — vehicle's ack reply (sat comms) */
+    momsn?: number
     /** True for automatic Default mission rows (not operator-commanded) */
     isDefaultMission?: boolean
     /** Vehicle GPS position at Default mission start (from missionStarted telemetry) */

--- a/packages/api-client/src/axios/Util/determineCommandStatus.ts
+++ b/packages/api-client/src/axios/Util/determineCommandStatus.ts
@@ -92,8 +92,9 @@ export const determineCommandStatus = (
         timeout,
         status: 'ack',
         commsIsoTime: matchingSbdReceive.isoTime,
-        mtmsn: matchingSbdReceipt.mtmsn ?? undefined,
-        momsn: matchingSbdReceive.momsn ?? undefined,
+        // 0 is a sentinel for "no MTMSN/MOMSN" in TethysDash — normalize to undefined
+        mtmsn: matchingSbdReceipt.mtmsn || undefined,
+        momsn: matchingSbdReceive.momsn || undefined,
       }
     }
   }
@@ -104,6 +105,6 @@ export const determineCommandStatus = (
     timeout,
     status: 'sent',
     commsIsoTime: matchingSbdSend.isoTime,
-    mtmsn: matchingSbdReceipt?.mtmsn ?? undefined,
+    mtmsn: matchingSbdReceipt?.mtmsn || undefined,
   }
 }

--- a/packages/api-client/src/axios/Util/determineCommandStatus.ts
+++ b/packages/api-client/src/axios/Util/determineCommandStatus.ts
@@ -5,6 +5,10 @@ export interface CommsEvent extends GetEventsResponse {
   via?: 'cellsat' | 'cell' | 'sat'
   commsIsoTime?: string
   timeout?: string
+  /** Mobile Terminated Message Sequence Number — Iridium ID of the command sent to the vehicle (sat comms) */
+  mtmsn?: number
+  /** Mobile Originated Message Sequence Number — Iridium ID of the vehicle's acknowledgment reply (sat comms) */
+  momsn?: number
 }
 
 export const digitsForIdRegEx = /\d+/
@@ -88,6 +92,8 @@ export const determineCommandStatus = (
         timeout,
         status: 'ack',
         commsIsoTime: matchingSbdReceive.isoTime,
+        mtmsn: matchingSbdReceipt.mtmsn ?? undefined,
+        momsn: matchingSbdReceive.momsn ?? undefined,
       }
     }
   }
@@ -98,5 +104,6 @@ export const determineCommandStatus = (
     timeout,
     status: 'sent',
     commsIsoTime: matchingSbdSend.isoTime,
+    mtmsn: matchingSbdReceipt?.mtmsn ?? undefined,
   }
 }


### PR DESCRIPTION
## Summary

Adds Iridium message sequence numbers to the Schedule History event details popup so operators can confirm vehicle receipt and correlate sat comms IDs across Logs, Comms Queue, and Schedule History — all in one place.

MOMSN/MTMSN were already visible in the Logs section. This change surfaces them in the Schedule History popup once a directive has been satellite-acknowledged.

## Changes

- **`determineCommandStatus.ts`** — adds `mtmsn` and `momsn` fields to `CommsEvent`; populates `mtmsn` from the `sbdReceipt` event and `momsn` from the `sbdReceive` event on sat-ack returns
- **`ScheduleSection.tsx`** — builds a `commsMsgIdLookup` (eventId → `{mtmsn, momsn}`) from comms events and spreads it into the `scheduleEvent` modal meta
- **`useGlobalModalId.ts`** — adds optional `mtmsn` / `momsn` fields to the `ScheduleEvent` type
- **`ScheduleEventDetailsModal.tsx`** — renders an **"Iridium Msg IDs"** row showing `MTMSN: N · MOMSN: N` (with descriptive tooltips) when either value is present; the row is hidden for cell commands and unacknowledged sat commands

## Behavior

- **Cell ACK:** no MTMSN/MOMSN row shown (cell comms don't use Iridium SBD sequence numbers)
- **Sat sent (not yet ACKed):** MTMSN shown if available (command was transmitted to Iridium gateway)
- **Sat ACKed:** both MTMSN and MOMSN shown (vehicle confirmed receipt)
- **Unresolved / queued:** row hidden

## Test plan

- [ ] Send a mission/command via **cell** — verify no "Iridium Msg IDs" row appears in the popup
- [ ] Send a mission/command via **sat** — verify the popup shows `MTMSN: <number>` once the SBD receipt is recorded
- [ ] After the vehicle sends its acknowledgment, verify `MOMSN: <number>` also appears
- [ ] Hover over each label to confirm the descriptive tooltip is shown
- [ ] Verify the row is absent for queued/unresolved commands

Closes #586