### PR TITLE
fix(#597): timeout takes priority over cell state:2 ACK in determineCommandStatus

### DIFF
--- a/packages/api-client/src/axios/Util/determineCommandStatus.test.ts
+++ b/packages/api-client/src/axios/Util/determineCommandStatus.test.ts
@@ -330,6 +330,69 @@ describe('determineCommandStatus', () => {
     expect(result.commsIsoTime).toBe(baseSbdSend.isoTime)
   })
 
+  it('should return timeout (not ack) for cell command with state:2 sbdSend when timeout note exists', () => {
+    // Regression for #597: a cell command dispatched via state:2 sbdSend was
+    // incorrectly shown as 'received by vehicle' even when the vehicle never
+    // fetched it and a timeout note existed for the same eventId.
+    // Timeout is ground-truth for queue-and-fetch cell delivery.
+    const sbdSendMap = new Map<string, GetEventsResponse>([
+      [String(baseCellCommand.eventId), cellSbdSend],
+    ])
+    const timeoutMap = new Map<string, GetEventsResponse>([
+      [String(baseCellCommand.eventId), baseTimeoutEvent],
+    ])
+
+    const result = determineCommandStatus(
+      baseCellCommand,
+      sbdSendMap,
+      new Map(),
+      new Map(),
+      timeoutMap
+    )
+
+    expect(result.status).toBe('timeout')
+    expect(result.via).toBe('cell')
+    expect(result.commsIsoTime).toBe(baseTimeoutEvent.isoTime)
+    expect(result.mtmsn).toBeUndefined()
+    expect(result.momsn).toBeUndefined()
+  })
+
+  it('should return timeout (not ack) for cellsat command with state:2 sbdSend when timeout note exists', () => {
+    // Same scenario via 'cellsat': the earlier timeout guard required via==='cell',
+    // so cellsat commands would bypass it and incorrectly fall through to 'ack'.
+    const cellsatSbdSend: GetEventsResponse = {
+      ...cellSbdSend,
+      eventId: 50,
+      refId: baseCellsatCommand.eventId, // references eventId 3
+      state: 2,
+    }
+    const cellsatTimeoutEvent: GetEventsResponse = {
+      ...baseTimeoutEvent,
+      eventId: 51,
+      note: `id=${baseCellsatCommand.eventId}: Timeout while waiting`,
+    }
+    const sbdSendMap = new Map<string, GetEventsResponse>([
+      [String(baseCellsatCommand.eventId), cellsatSbdSend],
+    ])
+    const timeoutMap = new Map<string, GetEventsResponse>([
+      [String(baseCellsatCommand.eventId), cellsatTimeoutEvent],
+    ])
+
+    const result = determineCommandStatus(
+      baseCellsatCommand,
+      sbdSendMap,
+      new Map(),
+      new Map(),
+      timeoutMap
+    )
+
+    expect(result.status).toBe('timeout')
+    expect(result.via).toBe('cellsat')
+    expect(result.commsIsoTime).toBe(cellsatTimeoutEvent.isoTime)
+    expect(result.mtmsn).toBeUndefined()
+    expect(result.momsn).toBeUndefined()
+  })
+
   it('should handle missing receipt mtmsn', () => {
     const sbdSendMap = new Map<string, GetEventsResponse>([
       [String(baseSatCommand.eventId), baseSbdSend],

--- a/packages/api-client/src/axios/Util/determineCommandStatus.ts
+++ b/packages/api-client/src/axios/Util/determineCommandStatus.ts
@@ -65,10 +65,28 @@ export const determineCommandStatus = (
     }
   }
 
-  // A state of 2 indicates cell comms, aka direct comms in dash4
+  // A state of 2 indicates cell comms, aka direct comms in dash4.
   // Cell comms are considered ACKed if they are sent since that indicates the socket is open.
-  // Explicitly clear mtmsn/momsn — cell comms do not carry Iridium SBD IDs.
+  // However, for queue-and-fetch cell delivery the vehicle must still poll and retrieve the
+  // command — a timeout note means it never did. Timeout always takes priority over the
+  // cell send so we re-check timeoutMap here even though we checked it above, because the
+  // earlier check requires (via === 'cell' && timeout), which may not match all cell paths.
   if (matchingSbdSend && (matchingSbdSend?.state === 2 || via === undefined)) {
+    if (command.eventId) {
+      const timeoutEvent = timeoutMap.get(String(command.eventId))
+      if (timeoutEvent) {
+        return {
+          ...command,
+          via,
+          timeout,
+          status: 'timeout',
+          commsIsoTime: timeoutEvent.isoTime,
+          mtmsn: undefined,
+          momsn: undefined,
+        }
+      }
+    }
+    // Explicitly clear mtmsn/momsn — cell comms do not carry Iridium SBD IDs.
     return {
       ...command,
       via,


### PR DESCRIPTION
## Problem

A cell command dispatched via `sbdSend state:2` was shown as **received by vehicle** (ack) in the Logs/Comms sections even when the vehicle never fetched it and a timeout note existed for the same event ID.

For queue-and-fetch cell delivery, `state:2` only means the command was dispatched to the queue — the vehicle must still poll and retrieve it. A timeout note is the ground-truth signal that it never did.

## Root Cause

`determineCommandStatus` checked for timeout early (lines 36–49), but that guard required `via === 'cell'`. If `via` was `'cellsat'` or `undefined`, the timeout check was bypassed and the function fell through to the `state === 2` branch, returning `'ack'` regardless of whether a timeout existed.

## Fix

Added a `timeoutMap` lookup **inside** the `state:2/no-via` branch as a definitive override — if a timeout note exists for the command, it always returns `'timeout'` regardless of which path reached that branch.

```typescript
if (matchingSbdSend && (matchingSbdSend?.state === 2 || via === undefined)) {
  if (command.eventId) {
    const timeoutEvent = timeoutMap.get(String(command.eventId))
    if (timeoutEvent) {
      return { ...command, status: 'timeout', ... }
    }
  }
  return { ...command, status: 'ack', ... }
}
```

## Test Plan

- [ ] Run `npx jest --config packages/api-client/jest.config.js packages/api-client/src/axios/Util/determineCommandStatus.test.ts` — all 17 tests pass.
- [ ] On `localhost:3000`: a command that timed out should now show the timeout/warning icon in the Comms/Logs section rather than the "received by vehicle" checkmark.

Closes #597