### PR TITLE
fix(#596): group same-event-ID timeout notes into one collapsible Logs row

### DIFF
--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -192,9 +192,11 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   //       5 s is generous for a sub-second burst while preventing accidental
   //       merging of close-but-distinct retry incidents.
   //
-  // Groups are keyed by a stable composite `${eventId}-${unixTime}` string so
-  // that pagination, filter changes, and list refreshes never shift a key onto
-  // a different row. The same key is used for expand/collapse state.
+  // Groups are keyed by a stable composite `${event.eventId}-${unixTime}` string
+  // (event.eventId is the database row ID, distinct from the parsed id=XXXXX in
+  // the note text which is stored in the local `eventId` variable below) so that
+  // pagination, filter changes, and list refreshes never shift a key onto a
+  // different row. The same key is used for expand/collapse state.
   const GROUP_WINDOW_MS = 5 * 1000 // 5 seconds — chunk bursts are sub-second
   type TimeoutGroup = { all: GetEventsResponse[] }
   const { processedData, timeoutGroups } = useMemo(() => {

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -180,49 +180,61 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     hasSelection,
     includeDataEvents,
   ])
-  // Group timeout notes that share the same event ID into a single row.
+  // Group consecutive timeout notes that share the same event ID into one row.
   // When a mission command is split into N SBD chunks and all N chunks time out,
   // the API emits N separate note events with the same id=XXXXX prefix — all
   // within the same second. This collapses them so the log stays readable.
   //
-  // Grouping is intentionally conservative: a note only joins an existing group
-  // when (a) it shares the same event ID AND (b) its timestamp is within
-  // GROUP_WINDOW_MS of the representative note. This prevents non-consecutive
-  // notes (e.g. a retry incident much later) from being silently swallowed into
-  // an older group, and preserves correct event ordering in the timeline.
+  // Grouping rules (both must hold):
+  //   (a) The note immediately follows the previous note in the list (consecutive).
+  //       A non-timeout event or a timeout for a different ID breaks the group.
+  //   (b) The note's timestamp is within GROUP_WINDOW_MS of the representative.
+  //       This prevents a later retry incident (same command ID, far in time) from
+  //       being silently folded into an earlier group.
+  //
+  // Groups are keyed by the representative's index in processedData so that
+  // two separate incidents with the same event ID never share the same bucket.
   const GROUP_WINDOW_MS = 2 * 60 * 1000 // 2 minutes — well above any chunk burst
-  type TimeoutGroup = {
-    representative: GetEventsResponse
-    all: GetEventsResponse[]
-  }
+  type TimeoutGroup = { all: GetEventsResponse[] }
   const { processedData, timeoutGroups } = useMemo(() => {
-    const groups = new Map<number, TimeoutGroup>()
+    const groups = new Map<number, TimeoutGroup>() // key = index in processedData
     const processed: GetEventsResponse[] = []
+    let lastGroupIdx: number | undefined = undefined
 
     flatData.forEach((event) => {
       if (event.eventType !== 'note') {
         processed.push(event)
+        lastGroupIdx = undefined
         return
       }
       const match = event.note?.match(timeoutExpiredRegEx)
       if (!match) {
         processed.push(event)
+        lastGroupIdx = undefined
         return
       }
       const eventId = Number(match[1])
-      const existing = groups.get(eventId)
       const eventMs = event.unixTime ?? 0
-      const representativeMs = existing?.representative.unixTime ?? 0
-      // Only join the group when the note is temporally close to the
-      // representative (same incident burst). If it falls outside the window,
-      // treat it as a new standalone note — don't group across incidents.
-      if (existing && Math.abs(eventMs - representativeMs) <= GROUP_WINDOW_MS) {
-        existing.all.push(event)
-      } else {
-        const group: TimeoutGroup = { representative: event, all: [event] }
-        groups.set(eventId, group)
-        processed.push(event) // only the representative goes into the list
+
+      if (lastGroupIdx !== undefined) {
+        const openGroup = groups.get(lastGroupIdx)
+        const repNote = openGroup?.all[0]
+        const repId = repNote?.note
+          ? Number(repNote.note.match(timeoutExpiredRegEx)?.[1])
+          : NaN
+        const repMs = repNote?.unixTime ?? 0
+        // Join when consecutive, same command, and within the time window.
+        if (repId === eventId && Math.abs(eventMs - repMs) <= GROUP_WINDOW_MS) {
+          openGroup!.all.push(event)
+          return
+        }
       }
+
+      // Start a new group at the current position in processedData.
+      const newIdx = processed.length
+      groups.set(newIdx, { all: [event] })
+      processed.push(event)
+      lastGroupIdx = newIdx
     })
 
     return { processedData: processed, timeoutGroups: groups }
@@ -286,10 +298,10 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     const time = DateTime.fromISO(isoTime).toFormat('H:mm:ss')
 
     // Check if this item is the representative of a multi-note timeout group.
-    const timeoutMatch = item.note?.match(timeoutExpiredRegEx)
-    const groupEventId = timeoutMatch ? Number(timeoutMatch[1]) : undefined
-    const group =
-      groupEventId != null ? timeoutGroups.get(groupEventId) : undefined
+    // Groups are keyed by the representative's index in processedData, so
+    // the lookup is simply timeoutGroups.get(index) — no event-ID lookup needed.
+    const isTimeoutNote = item.note?.match(timeoutExpiredRegEx) != null
+    const group = isTimeoutNote ? timeoutGroups.get(index) : undefined
     const isGrouped = group != null && group.all.length > 1
 
     const baseLog = formatEvent(
@@ -306,16 +318,16 @@ const LogsSection: React.FC<LogsSectionProps> = ({
           <button
             type="button"
             className="text-xs text-primary-600 underline hover:no-underline"
-            onClick={() => toggleGroup(groupEventId!)}
-            aria-expanded={expandedGroupIds.has(groupEventId!)}
+            onClick={() => toggleGroup(index)}
+            aria-expanded={expandedGroupIds.has(index)}
           >
-            {expandedGroupIds.has(groupEventId!) ? 'Collapse' : 'Expand all'}
+            {expandedGroupIds.has(index) ? 'Collapse' : 'Expand all'}
           </button>
         </div>
         {/* Always show the first (representative) note */}
         <div className="opacity-80">{baseLog}</div>
         {/* Show remaining notes only when expanded */}
-        {expandedGroupIds.has(groupEventId!) &&
+        {expandedGroupIds.has(index) &&
           group.all.slice(1).map((note) => (
             <div
               key={note.eventId}

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -182,8 +182,15 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   ])
   // Group timeout notes that share the same event ID into a single row.
   // When a mission command is split into N SBD chunks and all N chunks time out,
-  // the API emits N separate note events with the same id=XXXXX prefix. This
-  // collapses them into one representative row so the log stays readable.
+  // the API emits N separate note events with the same id=XXXXX prefix — all
+  // within the same second. This collapses them so the log stays readable.
+  //
+  // Grouping is intentionally conservative: a note only joins an existing group
+  // when (a) it shares the same event ID AND (b) its timestamp is within
+  // GROUP_WINDOW_MS of the representative note. This prevents non-consecutive
+  // notes (e.g. a retry incident much later) from being silently swallowed into
+  // an older group, and preserves correct event ordering in the timeline.
+  const GROUP_WINDOW_MS = 2 * 60 * 1000 // 2 minutes — well above any chunk burst
   type TimeoutGroup = {
     representative: GetEventsResponse
     all: GetEventsResponse[]
@@ -204,7 +211,12 @@ const LogsSection: React.FC<LogsSectionProps> = ({
       }
       const eventId = Number(match[1])
       const existing = groups.get(eventId)
-      if (existing) {
+      const eventMs = event.unixTime ?? 0
+      const representativeMs = existing?.representative.unixTime ?? 0
+      // Only join the group when the note is temporally close to the
+      // representative (same incident burst). If it falls outside the window,
+      // treat it as a new standalone note — don't group across incidents.
+      if (existing && Math.abs(eventMs - representativeMs) <= GROUP_WINDOW_MS) {
         existing.all.push(event)
       } else {
         const group: TimeoutGroup = { representative: event, all: [event] }

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -189,35 +189,36 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   //   (a) The note immediately follows the previous note in the list (consecutive).
   //       A non-timeout event or a timeout for a different ID breaks the group.
   //   (b) The note's timestamp is within GROUP_WINDOW_MS of the representative.
-  //       This prevents a later retry incident (same command ID, far in time) from
-  //       being silently folded into an earlier group.
+  //       5 s is generous for a sub-second burst while preventing accidental
+  //       merging of close-but-distinct retry incidents.
   //
-  // Groups are keyed by the representative's index in processedData so that
-  // two separate incidents with the same event ID never share the same bucket.
-  const GROUP_WINDOW_MS = 2 * 60 * 1000 // 2 minutes — well above any chunk burst
+  // Groups are keyed by a stable composite `${eventId}-${unixTime}` string so
+  // that pagination, filter changes, and list refreshes never shift a key onto
+  // a different row. The same key is used for expand/collapse state.
+  const GROUP_WINDOW_MS = 5 * 1000 // 5 seconds — chunk bursts are sub-second
   type TimeoutGroup = { all: GetEventsResponse[] }
   const { processedData, timeoutGroups } = useMemo(() => {
-    const groups = new Map<number, TimeoutGroup>() // key = index in processedData
+    const groups = new Map<string, TimeoutGroup>() // key = `${repEventId}-${repUnixTime}`
     const processed: GetEventsResponse[] = []
-    let lastGroupIdx: number | undefined = undefined
+    let lastGroupKey: string | undefined = undefined
 
     flatData.forEach((event) => {
       if (event.eventType !== 'note') {
         processed.push(event)
-        lastGroupIdx = undefined
+        lastGroupKey = undefined
         return
       }
       const match = event.note?.match(timeoutExpiredRegEx)
       if (!match) {
         processed.push(event)
-        lastGroupIdx = undefined
+        lastGroupKey = undefined
         return
       }
       const eventId = Number(match[1])
       const eventMs = event.unixTime ?? 0
 
-      if (lastGroupIdx !== undefined) {
-        const openGroup = groups.get(lastGroupIdx)
+      if (lastGroupKey !== undefined) {
+        const openGroup = groups.get(lastGroupKey)
         const repNote = openGroup?.all[0]
         const repId = repNote?.note
           ? Number(repNote.note.match(timeoutExpiredRegEx)?.[1])
@@ -230,26 +231,26 @@ const LogsSection: React.FC<LogsSectionProps> = ({
         }
       }
 
-      // Start a new group at the current position in processedData.
-      const newIdx = processed.length
-      groups.set(newIdx, { all: [event] })
+      // Start a new group keyed by the representative's stable identity.
+      const newKey = `${event.eventId ?? 'x'}-${eventMs}`
+      groups.set(newKey, { all: [event] })
       processed.push(event)
-      lastGroupIdx = newIdx
+      lastGroupKey = newKey
     })
 
     return { processedData: processed, timeoutGroups: groups }
   }, [flatData])
 
-  const [expandedGroupIds, setExpandedGroupIds] = useState<Set<number>>(
+  const [expandedGroupKeys, setExpandedGroupKeys] = useState<Set<string>>(
     new Set()
   )
-  const toggleGroup = useCallback((eventId: number) => {
-    setExpandedGroupIds((prev) => {
+  const toggleGroup = useCallback((groupKey: string) => {
+    setExpandedGroupKeys((prev) => {
       const next = new Set(prev)
-      if (next.has(eventId)) {
-        next.delete(eventId)
+      if (next.has(groupKey)) {
+        next.delete(groupKey)
       } else {
-        next.add(eventId)
+        next.add(groupKey)
       }
       return next
     })
@@ -298,10 +299,14 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     const time = DateTime.fromISO(isoTime).toFormat('H:mm:ss')
 
     // Check if this item is the representative of a multi-note timeout group.
-    // Groups are keyed by the representative's index in processedData, so
-    // the lookup is simply timeoutGroups.get(index) — no event-ID lookup needed.
+    // The stable group key mirrors what was set during processedData construction:
+    // `${eventId}-${unixTime}`. Using a stable key means the expand/collapse state
+    // survives pagination loads, filter changes, and list refreshes.
     const isTimeoutNote = item.note?.match(timeoutExpiredRegEx) != null
-    const group = isTimeoutNote ? timeoutGroups.get(index) : undefined
+    const groupKey = isTimeoutNote
+      ? `${item.eventId ?? 'x'}-${item.unixTime ?? 0}`
+      : undefined
+    const group = groupKey != null ? timeoutGroups.get(groupKey) : undefined
     const isGrouped = group != null && group.all.length > 1
 
     const baseLog = formatEvent(
@@ -318,16 +323,19 @@ const LogsSection: React.FC<LogsSectionProps> = ({
           <button
             type="button"
             className="text-xs text-primary-600 underline hover:no-underline"
-            onClick={() => toggleGroup(index)}
-            aria-expanded={expandedGroupIds.has(index)}
+            onClick={() => groupKey != null && toggleGroup(groupKey)}
+            aria-expanded={groupKey != null && expandedGroupKeys.has(groupKey)}
           >
-            {expandedGroupIds.has(index) ? 'Collapse' : 'Expand all'}
+            {groupKey != null && expandedGroupKeys.has(groupKey)
+              ? 'Collapse'
+              : 'Expand all'}
           </button>
         </div>
         {/* Always show the first (representative) note */}
         <div className="opacity-80">{baseLog}</div>
         {/* Show remaining notes only when expanded */}
-        {expandedGroupIds.has(index) &&
+        {groupKey != null &&
+          expandedGroupKeys.has(groupKey) &&
           group.all.slice(1).map((note) => (
             <div
               key={note.eventId}

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -1,5 +1,10 @@
-import React, { useMemo, useState } from 'react'
-import { useInfiniteEvents, useTethysApiContext } from '@mbari/api-client'
+import React, { useMemo, useState, useCallback } from 'react'
+import {
+  useInfiniteEvents,
+  useTethysApiContext,
+  timeoutExpiredRegEx,
+  GetEventsResponse,
+} from '@mbari/api-client'
 import {
   Virtualizer,
   LogCell,
@@ -175,7 +180,58 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     hasSelection,
     includeDataEvents,
   ])
-  const dataCount = flatData?.length ?? 0
+  // Group timeout notes that share the same event ID into a single row.
+  // When a mission command is split into N SBD chunks and all N chunks time out,
+  // the API emits N separate note events with the same id=XXXXX prefix. This
+  // collapses them into one representative row so the log stays readable.
+  type TimeoutGroup = {
+    representative: GetEventsResponse
+    all: GetEventsResponse[]
+  }
+  const { processedData, timeoutGroups } = useMemo(() => {
+    const groups = new Map<number, TimeoutGroup>()
+    const processed: GetEventsResponse[] = []
+
+    flatData.forEach((event) => {
+      if (event.eventType !== 'note') {
+        processed.push(event)
+        return
+      }
+      const match = event.note?.match(timeoutExpiredRegEx)
+      if (!match) {
+        processed.push(event)
+        return
+      }
+      const eventId = Number(match[1])
+      const existing = groups.get(eventId)
+      if (existing) {
+        existing.all.push(event)
+      } else {
+        const group: TimeoutGroup = { representative: event, all: [event] }
+        groups.set(eventId, group)
+        processed.push(event) // only the representative goes into the list
+      }
+    })
+
+    return { processedData: processed, timeoutGroups: groups }
+  }, [flatData])
+
+  const [expandedGroupIds, setExpandedGroupIds] = useState<Set<number>>(
+    new Set()
+  )
+  const toggleGroup = useCallback((eventId: number) => {
+    setExpandedGroupIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(eventId)) {
+        next.delete(eventId)
+      } else {
+        next.add(eventId)
+      }
+      return next
+    })
+  }, [])
+
+  const dataCount = processedData?.length ?? 0
   const totalCount = hasNextPage ? dataCount + 1 : dataCount
   const listLoading = hasSelection && (isLoading || isFetching)
   const showNoFiltersMessage = !hasSelection && !listLoading
@@ -206,26 +262,74 @@ const LogsSection: React.FC<LogsSectionProps> = ({
       )
     }
 
-    const item = flatData[index]
-    const isoTime = item?.isoTime ?? ''
+    const item = processedData[index]
+    if (!item) return <span />
+
+    const isoTime = item.isoTime ?? ''
     const diff = DateTime.fromISO(isoTime).diffNow('days').days
     const date =
       Math.abs(diff) < 1
         ? 'Today'
         : DateTime.fromISO(isoTime).toFormat('yyyy-MM-dd')
     const time = DateTime.fromISO(isoTime).toFormat('H:mm:ss')
-    return item ? (
+
+    // Check if this item is the representative of a multi-note timeout group.
+    const timeoutMatch = item.note?.match(timeoutExpiredRegEx)
+    const groupEventId = timeoutMatch ? Number(timeoutMatch[1]) : undefined
+    const group =
+      groupEventId != null ? timeoutGroups.get(groupEventId) : undefined
+    const isGrouped = group != null && group.all.length > 1
+
+    const baseLog = formatEvent(
+      item,
+      siteConfig?.appConfig.external.tethysdash ?? ''
+    )
+
+    const log = isGrouped ? (
+      <div className="flex flex-col gap-1 text-sm">
+        <div className="flex items-center gap-2">
+          <span className="rounded bg-amber-100 px-1.5 py-0.5 text-xs font-semibold text-amber-800">
+            {group.all.length} timeout notes
+          </span>
+          <button
+            type="button"
+            className="text-xs text-primary-600 underline hover:no-underline"
+            onClick={() => toggleGroup(groupEventId!)}
+            aria-expanded={expandedGroupIds.has(groupEventId!)}
+          >
+            {expandedGroupIds.has(groupEventId!) ? 'Collapse' : 'Expand all'}
+          </button>
+        </div>
+        {/* Always show the first (representative) note */}
+        <div className="opacity-80">{baseLog}</div>
+        {/* Show remaining notes only when expanded */}
+        {expandedGroupIds.has(groupEventId!) &&
+          group.all.slice(1).map((note) => (
+            <div
+              key={note.eventId}
+              className="border-t border-amber-100 pt-1 opacity-70"
+            >
+              {formatEvent(
+                note,
+                siteConfig?.appConfig.external.tethysdash ?? ''
+              )}
+            </div>
+          ))}
+      </div>
+    ) : (
+      baseLog
+    )
+
+    return (
       <LogCell
         className="border-b border-slate-200"
         date={date}
         time={time}
         label={displayNameForEventType(item)}
-        log={formatEvent(item, siteConfig?.appConfig.external.tethysdash ?? '')}
+        log={log}
         isUpload={isUploadEvent(item)}
         onCopy={handleCopyEventLogs}
       />
-    ) : (
-      <span />
     )
   }
 

--- a/apps/lrauv-dash2/jest/LogsSection.test.tsx
+++ b/apps/lrauv-dash2/jest/LogsSection.test.tsx
@@ -140,7 +140,7 @@ test('timeout notes for same event ID outside the time window are NOT grouped', 
     user: null,
     state: 0,
   }
-  // More than 2 minutes later — should NOT be folded into the same group
+  // 10 minutes later (well outside the 5-second window) — should NOT be folded into the same group
   const oldNote = {
     eventId: 9002,
     vehicleName: 'triton',
@@ -155,7 +155,7 @@ test('timeout notes for same event ID outside the time window are NOT grouped', 
   renderLogs([recentNote, oldNote])
 
   await waitFor(() => {
-    // Two Note rows should be visible — not grouped, since they're 10 min apart
+    // Two Note rows should be visible — not grouped, since they're 10 min apart (> 5s window)
     const noteLabels = screen.getAllByText(/^Note$/)
     expect(noteLabels).toHaveLength(2)
     // No group badge should appear

--- a/apps/lrauv-dash2/jest/LogsSection.test.tsx
+++ b/apps/lrauv-dash2/jest/LogsSection.test.tsx
@@ -124,3 +124,41 @@ test('notes with different event IDs are kept as separate rows', async () => {
     expect(badges).toHaveLength(2)
   })
 })
+
+test('timeout notes for same event ID outside the time window are NOT grouped', async () => {
+  // Regression for Copilot review: grouping must be time-bounded so a timeout
+  // note from a later incident (same event ID, far apart in time) doesn't get
+  // silently swallowed into an earlier group and disappear from the timeline.
+  const now = Date.now()
+  const recentNote = {
+    eventId: 9001,
+    vehicleName: 'triton',
+    eventType: 'note',
+    unixTime: now - 30 * 1000,
+    isoTime: new Date(now - 30 * 1000).toISOString(),
+    note: 'id=400: Timeout while waiting for triton to fetch command via cell',
+    user: null,
+    state: 0,
+  }
+  // More than 2 minutes later — should NOT be folded into the same group
+  const oldNote = {
+    eventId: 9002,
+    vehicleName: 'triton',
+    eventType: 'note',
+    unixTime: now - 10 * 60 * 1000,
+    isoTime: new Date(now - 10 * 60 * 1000).toISOString(),
+    note: 'id=400: Timeout while waiting for triton to fetch command via cell',
+    user: null,
+    state: 0,
+  }
+
+  renderLogs([recentNote, oldNote])
+
+  await waitFor(() => {
+    // Two Note rows should be visible — not grouped, since they're 10 min apart
+    const noteLabels = screen.getAllByText(/^Note$/)
+    expect(noteLabels).toHaveLength(2)
+    // No group badge should appear
+    expect(screen.queryByText(/timeout notes/i)).not.toBeInTheDocument()
+  })
+})

--- a/apps/lrauv-dash2/jest/LogsSection.test.tsx
+++ b/apps/lrauv-dash2/jest/LogsSection.test.tsx
@@ -34,16 +34,19 @@ const renderLogs = (events: object[]) => {
 }
 
 // Helpers to build note events for tests
-const makeTimeoutNote = (eventId: number, chunkNum: number): object => ({
-  eventId: eventId * 100 + chunkNum,
-  vehicleName: 'triton',
-  eventType: 'note',
-  unixTime: Date.now() - 60 * 1000,
-  isoTime: new Date(Date.now() - 60 * 1000).toISOString(),
-  note: `id=${eventId}: Timeout while waiting for 'triton' to fetch command via cell: 'sched "chunk ${chunkNum}"'`,
-  user: null,
-  state: 0,
-})
+const makeTimeoutNote = (eventId: number, chunkNum: number): object => {
+  const ts = Date.now() - 60 * 1000
+  return {
+    eventId: eventId * 100 + chunkNum,
+    vehicleName: 'triton',
+    eventType: 'note',
+    unixTime: ts,
+    isoTime: new Date(ts).toISOString(),
+    note: `id=${eventId}: Timeout while waiting for 'triton' to fetch command via cell: 'sched "chunk ${chunkNum}"'`,
+    user: null,
+    state: 0,
+  }
+}
 
 // ── Grouping regression tests (#596) ──────────────────────────────────────────
 

--- a/apps/lrauv-dash2/jest/LogsSection.test.tsx
+++ b/apps/lrauv-dash2/jest/LogsSection.test.tsx
@@ -1,0 +1,126 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import LogsSection from '../components/LogsSection'
+import { QueryClient } from 'react-query'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { MockProviders } from '../components/testHelpers'
+
+const server = setupServer(
+  rest.get('/info', (_req, res, ctx) => res(ctx.status(200), ctx.json({})))
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+const renderLogs = (events: object[]) => {
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: events }))
+    )
+  )
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <LogsSection
+        vehicleName="triton"
+        from={0}
+        deploymentLogsOnly={false}
+        setDeploymentLogsOnly={() => {}}
+      />
+    </MockProviders>
+  )
+}
+
+// Helpers to build note events for tests
+const makeTimeoutNote = (eventId: number, chunkNum: number): object => ({
+  eventId: eventId * 100 + chunkNum,
+  vehicleName: 'triton',
+  eventType: 'note',
+  unixTime: Date.now() - 60 * 1000,
+  isoTime: new Date(Date.now() - 60 * 1000).toISOString(),
+  note: `id=${eventId}: Timeout while waiting for 'triton' to fetch command via cell: 'sched "chunk ${chunkNum}"'`,
+  user: null,
+  state: 0,
+})
+
+// ── Grouping regression tests (#596) ──────────────────────────────────────────
+
+test('single timeout note renders normally (no grouping needed)', async () => {
+  renderLogs([makeTimeoutNote(500, 1)])
+
+  await waitFor(() => {
+    expect(screen.getByText(/Note/i)).toBeInTheDocument()
+  })
+  // No "N timeout notes" badge should appear for a single note
+  expect(screen.queryByText(/timeout notes/i)).not.toBeInTheDocument()
+})
+
+test('multiple timeout notes with the same event ID are collapsed into one row', async () => {
+  // 6 chunks timed out → 6 note events with id=27107237 in the API response
+  const events = [1, 2, 3, 4, 5, 6].map((n) => makeTimeoutNote(27107237, n))
+  renderLogs(events)
+
+  await waitFor(() => {
+    // A badge showing the group size should appear
+    expect(screen.getByText(/6 timeout notes/i)).toBeInTheDocument()
+  })
+
+  // Only ONE "Note" label row should be in the log (not 6)
+  const noteLabels = screen.getAllByText(/^Note$/)
+  expect(noteLabels).toHaveLength(1)
+})
+
+test('expanded group shows all chunk notes', async () => {
+  const events = [1, 2, 3].map((n) => makeTimeoutNote(100, n))
+  renderLogs(events)
+
+  await waitFor(() => {
+    expect(screen.getByText(/3 timeout notes/i)).toBeInTheDocument()
+  })
+
+  // Initially only the first chunk text is visible
+  expect(screen.queryByText(/chunk 2/i)).not.toBeInTheDocument()
+
+  // Click "Expand all"
+  fireEvent.click(screen.getByRole('button', { name: /expand all/i }))
+
+  await waitFor(() => {
+    expect(screen.getByText(/chunk 2/i)).toBeInTheDocument()
+    expect(screen.getByText(/chunk 3/i)).toBeInTheDocument()
+  })
+})
+
+test('collapse hides chunk notes again after expanding', async () => {
+  const events = [1, 2].map((n) => makeTimeoutNote(200, n))
+  renderLogs(events)
+
+  await waitFor(() => {
+    expect(screen.getByText(/2 timeout notes/i)).toBeInTheDocument()
+  })
+
+  fireEvent.click(screen.getByRole('button', { name: /expand all/i }))
+  await waitFor(() => {
+    expect(screen.getByText(/chunk 2/i)).toBeInTheDocument()
+  })
+
+  fireEvent.click(screen.getByRole('button', { name: /collapse/i }))
+  await waitFor(() => {
+    expect(screen.queryByText(/chunk 2/i)).not.toBeInTheDocument()
+  })
+})
+
+test('notes with different event IDs are kept as separate rows', async () => {
+  // Two separate command IDs each with 2 timeout notes → 2 grouped rows
+  const events = [
+    ...[1, 2].map((n) => makeTimeoutNote(300, n)),
+    ...[1, 2].map((n) => makeTimeoutNote(301, n)),
+  ]
+  renderLogs(events)
+
+  await waitFor(() => {
+    const badges = screen.getAllByText(/2 timeout notes/i)
+    expect(badges).toHaveLength(2)
+  })
+})


### PR DESCRIPTION
## Problem

When a mission command is split across multiple SBD chunks and all of them time out, the API emits one `note` event per chunk — all sharing the same `id=XXXXX` prefix in their text. In the Logs section these appeared as 6 (or more) separate identical-looking rows, making the failure look more disruptive than it is and obscuring other nearby log events.

## Solution

Post-process the logs list in `LogsSection` to collapse all timeout notes sharing an event ID into a single row that shows:

- An amber badge: **"N timeout notes"**
- The first note's text, always visible
- An **"Expand all / Collapse"** toggle button to reveal the individual chunk-level notes inline

All other note types and timeout notes with unique event IDs render unchanged.

## Test Plan

- [ ] Run `npx jest --config apps/lrauv-dash2/jest.config.js apps/lrauv-dash2/jest/LogsSection.test.tsx` — all 5 tests pass.
- [ ] On `localhost:3000`: trigger or replay a chunked timeout scenario in the Logs section and confirm the 6 notes are collapsed into one row. Clicking **Expand all** reveals each chunk's note. Clicking **Collapse** hides them again.
- [ ] Confirm that a single (non-chunked) timeout note still renders as a normal row with no badge.

Closes #596