### PR TITLE
fix(#604): timeout note is ground truth for all via types in determineCommandStatus

### DIFF
--- a/packages/api-client/src/axios/Util/determineCommandStatus.test.ts
+++ b/packages/api-client/src/axios/Util/determineCommandStatus.test.ts
@@ -393,6 +393,47 @@ describe('determineCommandStatus', () => {
     expect(result.momsn).toBeUndefined()
   })
 
+  it('should return timeout (not sent) for sat command with sbdSend state:1 when timeout note exists', () => {
+    // Regression for #604: sat comms bypass the original cell-only timeout guard and
+    // fall through to 'sent' (sbdSend exists, no sbdReceive). A timeout note is ground
+    // truth regardless of via type — the command must return 'timeout'.
+    const satCommandWithTimeout: GetEventsResponse = {
+      ...baseSatCommand,
+      note: 'command[via: sat, timeout:30min]',
+    }
+    const satSbdSend: GetEventsResponse = {
+      ...baseSbdSend,
+      eventId: 60,
+      refId: satCommandWithTimeout.eventId,
+      state: 1, // sent to Iridium, but vehicle never responded
+    }
+    const satTimeoutEvent: GetEventsResponse = {
+      ...baseTimeoutEvent,
+      eventId: 61,
+      note: `id=${satCommandWithTimeout.eventId}: Timeout while waiting`,
+    }
+    const sbdSendMap = new Map<string, GetEventsResponse>([
+      [String(satCommandWithTimeout.eventId), satSbdSend],
+    ])
+    const timeoutMap = new Map<string, GetEventsResponse>([
+      [String(satCommandWithTimeout.eventId), satTimeoutEvent],
+    ])
+
+    const result = determineCommandStatus(
+      satCommandWithTimeout,
+      sbdSendMap,
+      new Map(),
+      new Map(),
+      timeoutMap
+    )
+
+    expect(result.status).toBe('timeout')
+    expect(result.via).toBe('sat')
+    expect(result.commsIsoTime).toBe(satTimeoutEvent.isoTime)
+    expect(result.mtmsn).toBeUndefined()
+    expect(result.momsn).toBeUndefined()
+  })
+
   it('should handle missing receipt mtmsn', () => {
     const sbdSendMap = new Map<string, GetEventsResponse>([
       [String(baseSatCommand.eventId), baseSbdSend],

--- a/packages/api-client/src/axios/Util/determineCommandStatus.ts
+++ b/packages/api-client/src/axios/Util/determineCommandStatus.ts
@@ -32,8 +32,10 @@ export const determineCommandStatus = (
     ? (command.note.match(timeoutRegEx) || [])[1]
     : undefined
 
-  // Check if the cell comm has timed out by looking for a timeout note event with command eventId
-  if (command.eventId && timeout && via === 'cell') {
+  // A timeout note is ground truth for any comms type (cell, sat, cellsat, unknown).
+  // Check it first — before sbdSend state — so a timed-out command is never
+  // misreported as 'sent' or 'ack' regardless of what Iridium bookkeeping exists.
+  if (command.eventId) {
     const timeoutEvent = timeoutMap.get(String(command.eventId))
     if (timeoutEvent) {
       return {
@@ -65,27 +67,9 @@ export const determineCommandStatus = (
     }
   }
 
-  // A state of 2 indicates cell comms, aka direct comms in dash4.
-  // Cell comms are considered ACKed if they are sent since that indicates the socket is open.
-  // However, for queue-and-fetch cell delivery the vehicle must still poll and retrieve the
-  // command — a timeout note means it never did. Timeout always takes priority over the
-  // cell send so we re-check timeoutMap here even though we checked it above, because the
-  // earlier check requires (via === 'cell' && timeout), which may not match all cell paths.
-  if (matchingSbdSend && (matchingSbdSend?.state === 2 || via === undefined)) {
-    if (command.eventId) {
-      const timeoutEvent = timeoutMap.get(String(command.eventId))
-      if (timeoutEvent) {
-        return {
-          ...command,
-          via,
-          timeout,
-          status: 'timeout',
-          commsIsoTime: timeoutEvent.isoTime,
-          mtmsn: undefined,
-          momsn: undefined,
-        }
-      }
-    }
+  // A state of 2 indicates cell comms (direct socket delivery).
+  // Cell comms are considered ACKed when sent since an open socket means delivery.
+  if (matchingSbdSend?.state === 2 || via === undefined) {
     // Explicitly clear mtmsn/momsn — cell comms do not carry Iridium SBD IDs.
     return {
       ...command,


### PR DESCRIPTION
## Problem

After PR #600, the timeout pill **still did not display** for `via:sat` directives that timed out.

`determineCommandStatus` had two separate timeout checks — neither covered sat comms:

| Guard | Covers |
|---|---|
| `via === 'cell'` (original) | Cell-only |
| `state === 2 \|\| via === undefined` (PR #600) | Cell/cellsat direct socket |

Sat comms use `sbdSend state:1` and `via === 'sat'`, so they bypassed **both** and fell through to `status: 'sent'` at the bottom even when a timeout note existed.

## Fix

A timeout note is **ground truth for any comms type**. Move the `timeoutMap` lookup to the very top of the function — before any `sbdSend` state checks — so it fires for cell, sat, cellsat, and unknown `via` alike. The two redundant guards are removed.

## Test plan

- [x] All 18 existing `determineCommandStatus` tests pass
- [x] New regression: sat command with `sbdSend state:1` + timeout note → `status: 'timeout'`
- [ ] Verify on `localhost:3000` that a sat-comms directive that timed out shows the timeout pill in Schedule History and the Schedule Event Details popup

Closes #604