### PR TITLE
fix(#606): always show timeout pill for commands with explicit scheduled timestamps

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -649,26 +649,23 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
 
     const rawText = v.event?.data ?? v.event?.text ?? ''
 
-    // If comms confirmed a timeout, demote to history so the operator sees
-    // it alongside completed/cancelled items and can re-run from there.
-    // Only skip demotion when the payload carries an explicit scheduled
-    // timestamp (not asap) — such items are deliberately queued and the
-    // operator needs them to remain visible above the separator. Note: we
-    // do not compare the timestamp against Date.now() here; the presence
-    // of any explicit start time is treated as "intentionally scheduled".
+    // A timeout note is ground truth — always demote to history so the
+    // operator sees the failed command alongside completed/cancelled items.
+    // This applies even when the payload carries an explicit scheduled
+    // timestamp: once the schedule time passes and the vehicle fails to
+    // receive the command the timeout overrides the "intentionally queued"
+    // intent and the row must move to history.
+    if (v.event?.eventId != null) {
+      if (commsLookup.get(v.event.eventId) === 'timeout') return false
+    }
+
     const schedDateMatch = rawText.match(/sched\s+(\d{8}}?T\d{2,4})/i)
     const scheduleDate = rawText.match(/sched\s+asap/i)
       ? 'asap'
       : schedDateMatch
       ? schedDateMatch[1]
       : undefined
-    // hasScheduledTimestamp is true when the payload names a specific start
-    // time (not asap/ASAP). It does NOT verify whether that time is in the
-    // future — it only confirms a concrete start was requested.
     const hasScheduledTimestamp = !!(scheduleDate && scheduleDate !== 'asap')
-    if (!hasScheduledTimestamp && v.event?.eventId != null) {
-      if (commsLookup.get(v.event.eventId) === 'timeout') return false
-    }
 
     if (isMissionCommand(v.event?.data, v.event?.text)) return true
     // Non-mission commands: only stay above separator if they have a specific
@@ -947,14 +944,18 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         return 'sent'
       }
       const raw = toScheduleCellStatus(mission?.status ?? '')
+      // A timeout note is ground truth regardless of scheduled timestamp —
+      // always surface it so the pill displays correctly for any comms type.
+      const commsStatusForTimeout = commsLookup.get(mission.event.eventId)
+      if (raw === 'pending' && commsStatusForTimeout === 'timeout')
+        return 'timeout'
       // For any pending command with no specific future scheduled start,
       // use the comms lookup to upgrade status based on actual vehicle
       // receipt. The API always returns TBD/'pending' for mission commands
       // so comms data is the only reliable signal for missions too.
       if (raw === 'pending' && !(scheduleDate && scheduleDate !== 'asap')) {
-        const commsStatus = commsLookup.get(mission.event.eventId)
+        const commsStatus = commsStatusForTimeout
         if (commsStatus === 'ack') return 'ack'
-        if (commsStatus === 'timeout') return 'timeout'
         if (commsStatus === 'sent') return 'sent'
         // Non-mission commands are always dispatched immediately. If no comms
         // entry exists (outside the fetch window), default to 'sent'. But if

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -1277,6 +1277,71 @@ test('parses corrected sched YYYYMMDDT timestamp without }', async () => {
   })
 })
 
+test('timed-out command with explicit scheduled timestamp shows timeout pill and moves to history (#606)', async () => {
+  // Regression for #606:
+  // Commands scheduled with a specific timestamp (e.g. `sched 20991231T1200 run ...`)
+  // that subsequently time out must:
+  //   (a) be demoted to the "Previous Vehicle Directives" history section, and
+  //   (b) display the timeout pill (cellStatus = 'timeout'), not 'pending'.
+  //
+  // Before this fix, isAboveSeparator() and cellStatus both skipped the
+  // commsLookup timeout check when hasScheduledTimestamp was true, leaving
+  // the command stuck as 'pending' in the active zone forever.
+  const futureStamp = '20991231T1200'
+  const missionEvent = {
+    data: `sched ${futureStamp} load Science/profile_station.tl;run`,
+    unixTime: Date.now() - 90 * 1000,
+    eventId: 800,
+    eventType: 'run',
+    text: null,
+    note: '[[via:cell, timeout:5min]]',
+    user: 'test-operator',
+  }
+  const timeoutNote = {
+    eventId: 801,
+    eventType: 'note',
+    unixTime: Date.now() - 60 * 1000,
+    isoTime: new Date(Date.now() - 60 * 1000).toISOString(),
+    data: null,
+    text: null,
+    note: 'id=800: Timeout while waiting for ack',
+    user: null,
+  }
+  server.use(
+    rest.get('/events', (req, res, ctx) => {
+      const eventTypes = req.url.searchParams.get('eventTypes') ?? ''
+      const isNoteQuery = eventTypes === 'note'
+      const isCommsQuery = eventTypes.includes('sbdSend')
+      const result = isNoteQuery
+        ? []
+        : isCommsQuery
+        ? [missionEvent, timeoutNote]
+        : [missionEvent]
+      return res(ctx.status(200), ctx.json({ result }))
+    }),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection
+        {...props}
+        currentDeploymentId={1}
+        deploymentStartTime={Date.now() - 3600 * 1000}
+      />
+    </MockProviders>
+  )
+
+  await waitFor(() => {
+    // (a) Timeout pill must appear
+    expect(screen.getByTitle(/timeout/i)).toBeInTheDocument()
+    // (b) Must be in history section, not stuck above separator
+    expect(screen.getByText('Previous Vehicle Directives')).toBeInTheDocument()
+  })
+})
+
 test('parses legacy sched YYYYMMDD}T timestamp for backwards compatibility', async () => {
   // Simulate an event stored before the makeCommand } fix was deployed.
   const legacyStamp = '20991231}T2359'


### PR DESCRIPTION
## Problem

Commands scheduled with an explicit timestamp (e.g. `sched 20991231T1200 run mission.xml`) that timed out were stuck as `pending` in the active zone forever — the timeout pill never appeared.

Two places in `ScheduleSection.tsx` gated the `commsLookup` timeout check behind `!hasScheduledTimestamp`:

1. **`isAboveSeparator`** — only demoted to history when there was no scheduled timestamp. Commands with one never moved to the "Previous Vehicle Directives" section.
2. **`cellStatus`** — only checked `commsLookup` for `'timeout'` when there was no scheduled timestamp, so the pill stayed `'pending'`.

The original intent was to keep future-queued commands visible above the separator. But once the schedule time passes and the vehicle fails to receive the command, the timeout note is ground truth and must override everything.

## Fix

- **`isAboveSeparator`**: always demote when `commsLookup` returns `'timeout'`, regardless of `hasScheduledTimestamp`.
- **`cellStatus`**: check `commsLookup` for `'timeout'` before the `scheduleDate`-gated block.

## Test plan

- [x] All 36 existing `ScheduleSection` tests pass
- [x] New regression test: timed-out command with explicit timestamp shows timeout pill and "Previous Vehicle Directives" separator
- [ ] Verify on `localhost:3000` that a scheduled+timed-out directive shows the timeout pill

Closes #606