### PR TITLE
fix(#606): timeout note overrides any API status, not just 'pending'

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -951,8 +951,9 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       if (commsStatusForTimeout === 'timeout') return 'timeout'
       // For any pending command with no specific future scheduled start,
       // use the comms lookup to upgrade status based on actual vehicle
-      // receipt. The API always returns TBD/'pending' for mission commands
-      // so comms data is the only reliable signal for missions too.
+      // receipt. The API status is not fully reliable for missions — it can
+      // return 'TBD' (pending), 'completed', or other values depending on
+      // the code path; comms lookup is the authoritative source for ack/timeout.
       if (raw === 'pending' && !(scheduleDate && scheduleDate !== 'asap')) {
         const commsStatus = commsStatusForTimeout
         if (commsStatus === 'ack') return 'ack'

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -944,11 +944,11 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         return 'sent'
       }
       const raw = toScheduleCellStatus(mission?.status ?? '')
-      // A timeout note is ground truth regardless of scheduled timestamp —
-      // always surface it so the pill displays correctly for any comms type.
+      // A timeout note is ground truth regardless of the API-reported status
+      // (pending, completed, etc.) or scheduled timestamp. Check it first so
+      // the pill always shows correctly for any comms type.
       const commsStatusForTimeout = commsLookup.get(mission.event.eventId)
-      if (raw === 'pending' && commsStatusForTimeout === 'timeout')
-        return 'timeout'
+      if (commsStatusForTimeout === 'timeout') return 'timeout'
       // For any pending command with no specific future scheduled start,
       // use the comms lookup to upgrade status based on actual vehicle
       // receipt. The API always returns TBD/'pending' for mission commands

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -1342,6 +1342,63 @@ test('timed-out command with explicit scheduled timestamp shows timeout pill and
   })
 })
 
+test('timed-out command reported as "completed" by API still shows timeout pill (#606b)', async () => {
+  // Regression: the API sometimes returns status:'completed' for a command
+  // that actually timed out. The previous fix only checked commsLookup when
+  // raw === 'pending', so 'completed' bypassed the timeout check entirely.
+  // A timeout note in commsLookup must override any API-reported status.
+  const missionEvent = {
+    data: 'load Science/profile_station.tl;run',
+    unixTime: Date.now() - 90 * 1000,
+    eventId: 900,
+    eventType: 'run',
+    text: null,
+    note: '[[via:cell, timeout:5min]]',
+    user: 'test-operator',
+  }
+  const timeoutNote = {
+    eventId: 901,
+    eventType: 'note',
+    unixTime: Date.now() - 60 * 1000,
+    isoTime: new Date(Date.now() - 60 * 1000).toISOString(),
+    data: null,
+    text: null,
+    note: 'id=900: Timeout while waiting for ack',
+    user: null,
+  }
+  server.use(
+    rest.get('/events', (req, res, ctx) => {
+      const eventTypes = req.url.searchParams.get('eventTypes') ?? ''
+      const isNoteQuery = eventTypes === 'note'
+      const isCommsQuery = eventTypes.includes('sbdSend')
+      const result = isNoteQuery
+        ? []
+        : isCommsQuery
+        ? [missionEvent, timeoutNote]
+        : [{ ...missionEvent, status: 'completed' }] // API says completed
+      return res(ctx.status(200), ctx.json({ result }))
+    }),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection
+        {...props}
+        currentDeploymentId={1}
+        deploymentStartTime={Date.now() - 3600 * 1000}
+      />
+    </MockProviders>
+  )
+
+  await waitFor(() => {
+    // Timeout pill must win over API 'completed' status
+    expect(screen.getByTitle(/timeout/i)).toBeInTheDocument()
+  })
+})
+
 test('parses legacy sched YYYYMMDD}T timestamp for backwards compatibility', async () => {
   // Simulate an event stored before the makeCommand } fix was deployed.
   const legacyStamp = '20991231}T2359'

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -1342,28 +1342,33 @@ test('timed-out command with explicit scheduled timestamp shows timeout pill and
   })
 })
 
-test('timed-out command reported as "completed" by API still shows timeout pill (#606b)', async () => {
-  // Regression: the API sometimes returns status:'completed' for a command
-  // that actually timed out. The previous fix only checked commsLookup when
-  // raw === 'pending', so 'completed' bypassed the timeout check entirely.
-  // A timeout note in commsLookup must override any API-reported status.
+test('timed-out command enriched to "completed" via isRecovered still shows timeout pill (#606b)', async () => {
+  // Regression: when isRecovered=true, every remaining 'TBD'/'pending' item is
+  // promoted to 'completed' so the history looks clean. Before this fix,
+  // cellStatus skipped commsLookup when raw!=='pending', so the command showed
+  // 'completed' even when a timeout note existed. A timeout note must always win.
+  //
+  // Strategy: pass isRecovered={true} so the command becomes 'completed' via
+  // the recovered-deployment enrichment path, then assert the timeout pill wins.
+  const eventId = 910
+  const ts = Date.now() - 90 * 1000
   const missionEvent = {
     data: 'load Science/profile_station.tl;run',
-    unixTime: Date.now() - 90 * 1000,
-    eventId: 900,
+    unixTime: ts,
+    eventId,
     eventType: 'run',
     text: null,
     note: '[[via:cell, timeout:5min]]',
     user: 'test-operator',
   }
   const timeoutNote = {
-    eventId: 901,
+    eventId: 911,
     eventType: 'note',
-    unixTime: Date.now() - 60 * 1000,
-    isoTime: new Date(Date.now() - 60 * 1000).toISOString(),
+    unixTime: ts + 60 * 1000,
+    isoTime: new Date(ts + 60 * 1000).toISOString(),
     data: null,
     text: null,
-    note: 'id=900: Timeout while waiting for ack',
+    note: `id=${eventId}: Timeout while waiting for ack`,
     user: null,
   }
   server.use(
@@ -1375,7 +1380,7 @@ test('timed-out command reported as "completed" by API still shows timeout pill 
         ? []
         : isCommsQuery
         ? [missionEvent, timeoutNote]
-        : [{ ...missionEvent, status: 'completed' }] // API says completed
+        : [missionEvent]
       return res(ctx.status(200), ctx.json({ result }))
     }),
     rest.get('/events/mission-started', (_req, res, ctx) =>
@@ -1389,12 +1394,13 @@ test('timed-out command reported as "completed" by API still shows timeout pill 
         {...props}
         currentDeploymentId={1}
         deploymentStartTime={Date.now() - 3600 * 1000}
+        isRecovered={true}
       />
     </MockProviders>
   )
 
   await waitFor(() => {
-    // Timeout pill must win over API 'completed' status
+    // Timeout pill must win over the isRecovered-enriched 'completed' status
     expect(screen.getByTitle(/timeout/i)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Problem

Commands that timed out were showing a **"Completed" pill** instead of "Timeout" because the API returns `status:'completed'` for those directives.

The previous fix (#607) only checked `commsLookup` for `'timeout'` when `raw === 'pending'`. Commands the API already marked as `'completed'` bypassed the timeout check entirely and returned `raw` (`'completed'`) as the cell status.

## Fix

Remove the `raw === 'pending'` guard from the upfront timeout check. A timeout note in `commsLookup` is ground truth and must override **any** API-reported status — `pending`, `completed`, or otherwise.

```ts
// Before (only fired for pending):
if (raw === 'pending' && commsStatusForTimeout === 'timeout') return 'timeout'

// After (fires for any status):
if (commsStatusForTimeout === 'timeout') return 'timeout'
```

## Test plan

- [x] All 37 existing `ScheduleSection` tests pass
- [x] New regression: API `status:'completed'` + timeout note → timeout pill renders
- [ ] Verify on `localhost:3000` that directives showing "Completed" now show "Timeout" when a timeout note exists

Closes #606 (follow-up to #607)