### PR TITLE
fix(#609): show 'Ended: N/A' for timed-out directives in Schedule History

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -1094,6 +1094,8 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
             ? 'Starts: scheduled time above'
             : cellStatus === 'running' || cellStatus === 'pending'
             ? 'Ended: TBD'
+            : cellStatus === 'timeout'
+            ? 'Ended: N/A'
             : mission.endedAt
             ? `Ended: ~${(() => {
                 const endDt = DateTime.fromMillis(mission.endedAt)

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -475,6 +475,8 @@ test('timed-out mission directive moves to history: Previous Vehicle Directives 
   await waitFor(() => {
     expect(screen.getByTitle(/timeout/i)).toBeInTheDocument()
     expect(screen.getByText('Previous Vehicle Directives')).toBeInTheDocument()
+    // #609: timed-out commands show "Ended: N/A" not a timestamp or TBD
+    expect(screen.getByText('Ended: N/A')).toBeInTheDocument()
   })
 })
 


### PR DESCRIPTION
## Summary

Timed-out directives were showing either a misleading mission-enriched end timestamp or the generic `'Ended: N/A (see Logs)'` fallback. Since the command never executed, neither is meaningful.

Added a `cellStatus === 'timeout'` branch in `description2` — before the `mission.endedAt` check — so timed-out rows always show `'Ended: N/A'`.

## Test plan

- [x] All 36 existing `ScheduleSection` tests pass
- [x] Assertion added to the timed-out mission regression test confirming `'Ended: N/A'` is rendered
- [ ] Verify on `localhost:3000` that timed-out rows show `Ended: N/A` in the Schedule History row

Closes #609