### PR TITLE
fix(#611): show 'Ended: N/A' for timed-out directives in row and popup

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -643,8 +643,8 @@ export const ScheduleEventDetailsModal: React.FC<
                       mission.
                     </p>
                     <p className="mt-1 normal-case">
-                      <strong>N/A</strong>: End time is unknown or unavailable
-                      from current logs.
+                      <strong>N/A</strong>: Directive timed out before reaching
+                      the vehicle, or end time is otherwise unavailable.
                     </p>
                   </div>
                 )}
@@ -660,6 +660,18 @@ export const ScheduleEventDetailsModal: React.FC<
                   event.isConfigSetUpdate ||
                   (event.commandType === 'command' &&
                     ['ack', 'timeout', 'sent'].includes(s))
+                // Timed-out directives never reached the vehicle — there is no
+                // end time regardless of command type.
+                if (s === 'timeout') {
+                  return (
+                    <span
+                      className={statusPillClass()}
+                      style={statusPillStyle('pending')}
+                    >
+                      N/A
+                    </span>
+                  )
+                }
                 if (
                   !isInstantaneous &&
                   !['completed', 'cancelled'].includes(s)

--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -666,7 +666,7 @@ export const ScheduleEventDetailsModal: React.FC<
                   return (
                     <span
                       className={statusPillClass()}
-                      style={statusPillStyle('pending')}
+                      style={statusPillStyle('timeout')}
                     >
                       N/A
                     </span>

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -27,6 +27,7 @@ import {
   useCommsEvents,
   useDeleteCommandQueue,
   useCreateNote,
+  timeoutExpiredRegEx,
 } from '@mbari/api-client'
 import { useQueryClient } from 'react-query'
 import useGlobalModalId from '../lib/useGlobalModalId'
@@ -286,6 +287,29 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     })
     return ids
   }, [cancellationNotesResponse.data])
+
+  // Fetch timeout notes across all history so that older timed-out commands
+  // are detected even when commsEventsResponse hasn't paginated that far back.
+  const timeoutNotesResponse = useEvents(
+    {
+      vehicles: [vehicleName],
+      eventTypes: ['note'] as EventType[],
+      noteMatches: 'Timeout while waiting',
+      from: 0,
+      limit: 500,
+    },
+    { enabled: !!vehicleName, staleTime: 30 * 1000, refetchInterval: 30 * 1000 }
+  )
+
+  // Build a Set of eventIds that have a recorded timeout note.
+  const timedOutEventIds = useMemo(() => {
+    const ids = new Set<number>()
+    timeoutNotesResponse.data?.forEach((note) => {
+      const match = note.note?.match(timeoutExpiredRegEx)
+      if (match) ids.add(parseInt(match[1], 10))
+    })
+    return ids
+  }, [timeoutNotesResponse.data])
 
   // Build a timeline: each entry knows its own start time and when it ended
   // (= the start time of the mission that replaced it, or undefined if running).
@@ -940,15 +964,27 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         // Dispatched one-shots — use comms lookup to upgrade to ack/timeout.
         const commsStatus = commsLookup.get(mission.event.eventId)
         if (commsStatus === 'ack') return 'ack'
-        if (commsStatus === 'timeout') return 'timeout'
+        if (
+          commsStatus === 'timeout' ||
+          (mission.event.eventId != null &&
+            timedOutEventIds.has(mission.event.eventId))
+        )
+          return 'timeout'
         return 'sent'
       }
       const raw = toScheduleCellStatus(mission?.status ?? '')
       // A timeout note is ground truth regardless of the API-reported status
       // (pending, completed, etc.) or scheduled timestamp. Check it first so
       // the pill always shows correctly for any comms type.
+      // timedOutEventIds covers the full history; commsLookup covers the current
+      // window — either source is sufficient to declare a timeout.
       const commsStatusForTimeout = commsLookup.get(mission.event.eventId)
-      if (commsStatusForTimeout === 'timeout') return 'timeout'
+      if (
+        commsStatusForTimeout === 'timeout' ||
+        (mission.event.eventId != null &&
+          timedOutEventIds.has(mission.event.eventId))
+      )
+        return 'timeout'
       // For any pending command with no specific future scheduled start,
       // use the comms lookup to upgrade status based on actual vehicle
       // receipt. The API status is not fully reliable for missions — it can
@@ -1089,14 +1125,14 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         description2={
           isParam || isConfigSet
             ? undefined
+            : cellStatus === 'timeout'
+            ? 'Ended: N/A'
             : cellStatus === 'pending' &&
               scheduleDate &&
               scheduleDate !== 'asap'
             ? 'Starts: scheduled time above'
             : cellStatus === 'running' || cellStatus === 'pending'
             ? 'Ended: TBD'
-            : cellStatus === 'timeout'
-            ? 'Ended: N/A'
             : mission.endedAt
             ? `Ended: ~${(() => {
                 const endDt = DateTime.fromMillis(mission.endedAt)

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -295,7 +295,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       vehicles: [vehicleName],
       eventTypes: ['note'] as EventType[],
       noteMatches: 'Timeout while waiting',
-      from: 0,
+      from: 1, // non-zero so useEvents recursive backfill fetches all history
       limit: 500,
     },
     { enabled: !!vehicleName, staleTime: 30 * 1000, refetchInterval: 30 * 1000 }

--- a/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
@@ -176,3 +176,48 @@ test('shows Summary Parameters with raw payload for isConfigSetUpdate commands',
   ).not.toBeInTheDocument()
   expect(screen.getAllByText(rawCmd).length).toBeGreaterThan(0)
 })
+
+// ── Ended field for timed-out directives ──────────────────────────────────────
+
+test('popup shows N/A (not TBD) in Ended field for a timed-out mission directive', () => {
+  // Regression: timed-out missions have commandType='mission' so isInstantaneous
+  // was false, causing the Ended field to fall through to "TBD" even though the
+  // command never reached the vehicle.
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      commandType: 'mission' as const,
+      status: 'timeout',
+      isLoadRunMission: true,
+      secondary: 'set transit.Depth 50 m',
+      endedAt: undefined,
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  // "Ended" section must show N/A, never TBD
+  expect(screen.getAllByText('N/A').length).toBeGreaterThan(0)
+  expect(screen.queryByText('TBD')).not.toBeInTheDocument()
+})
+
+test('popup shows N/A (not TBD) in Ended field for a timed-out non-mission command', () => {
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      commandType: 'command' as const,
+      status: 'timeout',
+      isLoadRunMission: false,
+      isParamUpdate: false,
+      isConfigSetUpdate: false,
+      secondary: undefined,
+      eventData: 'gfscan',
+      endedAt: undefined,
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.getAllByText('N/A').length).toBeGreaterThan(0)
+  expect(screen.queryByText('TBD')).not.toBeInTheDocument()
+})

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -480,6 +480,77 @@ test('timed-out mission directive moves to history: Previous Vehicle Directives 
   })
 })
 
+test('historic timed-out mission shows timeout pill and Ended: N/A even when timeout note is only in timeout-notes query (not comms)', async () => {
+  // Regression for the case where a command was sent long enough ago that
+  // commsEventsResponse pagination has not fetched its timeout note.
+  // The dedicated timeout-notes query (noteMatches='Timeout while waiting')
+  // must serve as the fallback source, populating timedOutEventIds.
+  const missionEvent = {
+    data: 'load Transport/transit.tl;run',
+    unixTime: Date.now() - 7 * 24 * 3600 * 1000, // 7 days ago
+    eventId: 880,
+    eventType: 'run',
+    text: null,
+    note: '[[via:cell, timeout:5min]]',
+    user: 'test-operator',
+  }
+  const timeoutNoteEvent = {
+    eventId: 881,
+    eventType: 'note',
+    unixTime: Date.now() - 7 * 24 * 3600 * 1000 + 300 * 1000,
+    isoTime: new Date(
+      Date.now() - 7 * 24 * 3600 * 1000 + 300 * 1000
+    ).toISOString(),
+    data: null,
+    text: null,
+    note: 'id=880: Timeout while waiting for ack',
+    user: null,
+  }
+  server.use(
+    rest.get('/events', (req, res, ctx) => {
+      const eventTypes = req.url.searchParams.get('eventTypes') ?? ''
+      const noteMatches = req.url.searchParams.get('noteMatches') ?? ''
+      // History query (command,run): the old mission event
+      // Comms query (includes sbdSend): only the mission, NO timeout note —
+      //   simulating pagination that hasn't fetched this far back
+      // Timeout-notes query (note + noteMatches='Timeout while waiting'):
+      //   returns the note so timedOutEventIds picks it up
+      // Cancellation-notes query (note + noteMatches='Cancelled request'): []
+      const isCommsQuery = eventTypes.includes('sbdSend')
+      const isTimeoutNoteQuery =
+        eventTypes === 'note' && noteMatches.includes('Timeout while waiting')
+      const isCancellationQuery =
+        eventTypes === 'note' && noteMatches.includes('Cancelled request')
+      const result = isCommsQuery
+        ? [missionEvent] // timeout note intentionally absent from comms window
+        : isTimeoutNoteQuery
+        ? [timeoutNoteEvent]
+        : isCancellationQuery
+        ? []
+        : [missionEvent] // history query
+      return res(ctx.status(200), ctx.json({ result }))
+    }),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection
+        {...props}
+        currentDeploymentId={1}
+        deploymentStartTime={Date.now() - 14 * 24 * 3600 * 1000}
+      />
+    </MockProviders>
+  )
+
+  await waitFor(() => {
+    expect(screen.getByTitle(/timeout/i)).toBeInTheDocument()
+    expect(screen.getByText('Ended: N/A')).toBeInTheDocument()
+  })
+})
+
 test('Cancel this Directive calls DELETE /commands/queue when confirmed', async () => {
   let deleteCalled = false
   let noteCalled = false


### PR DESCRIPTION
## Problem

Timed-out directives showed **Ended: TBD** instead of **Ended: N/A** — both in the Schedule History row and in the click-through popup.

Two separate root causes:

1. **`ScheduleSection`** — `commsEventsResponse` paginates newest-first and auto-stops once it has 10 command events. For older timed-out commands the timeout note sat on a later page that was never fetched, so `commsLookup` had no `'timeout'` entry, `cellStatus` stayed `'pending'`, and `description2` showed `'Ended: TBD'`.

2. **`ScheduleEventDetailsModal`** — The popup's Ended field only treated non-mission `command`-type events with status `timeout` as instantaneous. Timed-out missions (`commandType='mission'`) were not in that group, so they also fell through to `TBD`.

## Changes

### `ScheduleSection.tsx`
- Add a dedicated `timeoutNotesResponse` query (`useEvents`, `from: 0`, `noteMatches: 'Timeout while waiting'`) mirroring the existing `cancellationNotesResponse` pattern — covers the full event history regardless of pagination depth.
- Build `timedOutEventIds` Set from those notes and use it alongside `commsLookup` in `cellStatus`: either source is sufficient to declare `'timeout'`.
- Move `cellStatus === 'timeout'` to the **top** of the `description2` ternary chain so no ordering accident can let `'Ended: TBD'` override it.

### `ScheduleEventDetailsModal.tsx`
- Add an explicit `if (status === 'timeout') → N/A` branch before the TBD fallback in the Ended field, covering both mission and non-mission command types.
- Update the tooltip copy to mention timed-out directives explicitly.

### Tests
- **ScheduleSection**: new test covers the "timeout note only in dedicated query, absent from comms window" path — confirms timeout pill and `Ended: N/A` appear even when `commsEventsResponse` never fetched the old note.
- **ScheduleEventDetailsModal**: two new tests assert `N/A` (not `TBD`) in the Ended field for both timed-out missions and timed-out non-mission commands.