### PR TITLE
feat(#612): use StopwatchWarningIcon for timeout status in ScheduleCell

### DIFF
--- a/packages/react-ui/src/Cells/ScheduleCell.test.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.test.tsx
@@ -94,6 +94,40 @@ test('should render secondary text when secondary prop is provided', () => {
   expect(screen.getByText('breakfast of champions')).toBeInTheDocument()
 })
 
+test('should render the timeout icon with its tooltip when status is timeout', () => {
+  render(
+    <ScheduleCell {...props} status={'timeout'} statusTooltip="Timed out" />
+  )
+
+  expect(screen.getByTitle('Timed out')).toBeInTheDocument()
+  expect(screen.getByLabelText('timeout warning icon')).toBeInTheDocument()
+})
+
+test('timeout icon span is dimmed when schedule is not running', () => {
+  render(
+    <ScheduleCell {...props} status={'timeout'} scheduleStatus={undefined} />
+  )
+
+  // The outer span (title wrapper) gets opacity-60 for non-running schedules;
+  // the inner span is the icon's own wrapper, so use parentElement to reach the outer one.
+  expect(
+    screen.getByLabelText('timeout warning icon').parentElement
+  ).toHaveClass('opacity-60')
+})
+
+test('timeout icon span is not dimmed when schedule is running', () => {
+  render(
+    <ScheduleCell
+      {...props}
+      status={'timeout'}
+      scheduleStatus="running"
+      statusTooltip="Timed out"
+    />
+  )
+
+  expect(screen.getByTitle('Timed out')).not.toHaveClass('opacity-60')
+})
+
 test('should not render an empty secondary row when secondary is undefined', () => {
   // Previously ScheduleCell always rendered the secondary <li> even when
   // secondary was undefined, leaving an empty subtitle row for non-mission

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -170,7 +170,7 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
           ) : status === 'timeout' ? (
             <span
               title={statusTooltip ?? status}
-              className="self-center text-[1.65rem]"
+              className="self-center text-3xl"
             >
               <StopwatchWarningIcon />
             </span>

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -170,7 +170,7 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
           ) : status === 'timeout' ? (
             <span
               title={statusTooltip ?? status}
-              className="self-center text-3xl"
+              className="self-center text-2xl"
             >
               <StopwatchWarningIcon />
             </span>

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -170,7 +170,10 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
           ) : status === 'timeout' ? (
             <span
               title={statusTooltip ?? status}
-              className="self-center text-2xl"
+              className={clsx(
+                'self-center text-2xl',
+                scheduleStatus !== 'running' && 'opacity-60'
+              )}
             >
               <StopwatchWarningIcon />
             </span>

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -171,7 +171,7 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
             <span
               title={statusTooltip ?? status}
               className={clsx(
-                'self-center text-2xl',
+                'self-center text-2xl text-[rgb(255,132,59)]',
                 scheduleStatus !== 'running' && 'opacity-60'
               )}
             >

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -170,7 +170,7 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
           ) : status === 'timeout' ? (
             <span
               title={statusTooltip ?? status}
-              className="self-center text-[1.688rem]"
+              className="self-center text-2xl"
             >
               <StopwatchWarningIcon />
             </span>

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -170,7 +170,7 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
           ) : status === 'timeout' ? (
             <span
               title={statusTooltip ?? status}
-              className="self-center text-3xl"
+              className="self-center text-[1.65rem]"
             >
               <StopwatchWarningIcon />
             </span>

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -170,7 +170,7 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
           ) : status === 'timeout' ? (
             <span
               title={statusTooltip ?? status}
-              className="self-center text-2xl"
+              className="self-center text-[1.688rem]"
             >
               <StopwatchWarningIcon />
             </span>

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -168,7 +168,7 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
               />
             </span>
           ) : status === 'timeout' ? (
-            <span title={statusTooltip ?? status} className="text-xl">
+            <span title={statusTooltip ?? status} className="text-2xl">
               <StopwatchWarningIcon />
             </span>
           ) : (

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -168,7 +168,10 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
               />
             </span>
           ) : status === 'timeout' ? (
-            <span title={statusTooltip ?? status} className="text-2xl">
+            <span
+              title={statusTooltip ?? status}
+              className="self-center text-3xl"
+            >
               <StopwatchWarningIcon />
             </span>
           ) : (

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -10,7 +10,6 @@ import {
   faPauseCircle,
   faPersonRunning,
   faStarOfLife,
-  faExclamationTriangle,
 } from '@fortawesome/free-solid-svg-icons'
 import { faClock } from '@fortawesome/free-regular-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
@@ -18,6 +17,7 @@ import { IconButton } from '../Navigation'
 import { CommandType } from '../types'
 import { ConnectedIcon } from '../Icons/ConnectedIcon'
 import { AcknowledgeIcon } from '../Icons/AcknowledgeIcon'
+import { StopwatchWarningIcon } from '../Icons/StopwatchWarningIcon'
 export type ScheduleCellStatus =
   | 'pending'
   | 'running'
@@ -79,7 +79,6 @@ const icons: { [key: string]: IconProp } = {
   cancelled: faTimes as IconProp,
   completed: faCheck as IconProp,
   paused: faPauseCircle as IconProp,
-  timeout: faExclamationTriangle as IconProp,
 }
 
 export const ScheduleCellBackgrounds = {
@@ -167,6 +166,10 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
                     : 'stroke-stone-500 opacity-60'
                 )}
               />
+            </span>
+          ) : status === 'timeout' ? (
+            <span title={statusTooltip ?? status} className="text-xl">
+              <StopwatchWarningIcon />
             </span>
           ) : (
             <FontAwesomeIcon

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.stories.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Story, Meta } from '@storybook/react/types-6-0'
+import {
+  StopwatchWarningIcon,
+  StopwatchWarningIconProps,
+} from './StopwatchWarningIcon'
+
+export default {
+  title: 'Icons/StopwatchWarningIcon',
+  component: StopwatchWarningIcon,
+} as Meta
+
+const Template: Story<StopwatchWarningIconProps> = (args) => (
+  <StopwatchWarningIcon {...args} />
+)
+
+const args: StopwatchWarningIconProps = {
+  // Pass the orange explicitly; default is currentColor (inherits from parent)
+  color: 'rgb(255, 132, 59)',
+}
+
+export const Standard = Template.bind({})
+Standard.args = args
+
+export const Large = Template.bind({})
+Large.args = { ...args, style: { fontSize: '3rem' } }

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.test.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import {
+  StopwatchWarningIcon,
+  StopwatchWarningIconProps,
+} from './StopwatchWarningIcon'
+
+const props: StopwatchWarningIconProps = {}
+
+test('should render without throwing', () => {
+  expect(() => render(<StopwatchWarningIcon {...props} />)).not.toThrow()
+})
+
+test('should have accessible label', () => {
+  render(<StopwatchWarningIcon {...props} />)
+
+  expect(screen.getByLabelText('timeout warning icon')).toBeInTheDocument()
+})
+
+test('should apply className to the wrapper span', () => {
+  render(<StopwatchWarningIcon className="my-custom-class" />)
+
+  expect(screen.getByLabelText('timeout warning icon')).toHaveClass(
+    'my-custom-class'
+  )
+})
+
+test('caller style is applied but position/display are still enforced', () => {
+  render(
+    <StopwatchWarningIcon style={{ fontSize: '3rem', position: 'static' }} />
+  )
+
+  const wrapper = screen.getByLabelText('timeout warning icon')
+  // position must remain 'relative' regardless of caller style
+  expect(wrapper).toHaveStyle({ position: 'relative' })
+  expect(wrapper).toHaveStyle({ display: 'inline-block' })
+})

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons'
-import { faTriangleExclamation } from '@fortawesome/free-regular-svg-icons'
+import {
+  faClockRotateLeft,
+  faTriangleExclamation,
+} from '@fortawesome/free-solid-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 
 export interface StopwatchWarningIconProps {
@@ -23,38 +25,17 @@ export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
     >
       {/* Clock with circular arc — closest free FA match to the reference icon */}
       <FontAwesomeIcon icon={faClockRotateLeft as IconProp} style={{ color }} />
-      {/*
-       * Warning triangle badge — two layers to get the white-fill + orange-stroke
-       * look from the reference: a white square punched behind, then the outline
-       * triangle on top in orange.
-       */}
-      <span
+      {/* Solid warning triangle — orange with white ! built in */}
+      <FontAwesomeIcon
+        icon={faTriangleExclamation as IconProp}
         style={{
+          color,
           position: 'absolute',
           top: '-0.45em',
           right: '-0.55em',
           fontSize: '0.85em',
-          display: 'inline-flex',
-          alignItems: 'center',
-          justifyContent: 'center',
         }}
-      >
-        {/* White fill behind the outline triangle */}
-        <span
-          style={{
-            position: 'absolute',
-            width: '0.55em',
-            height: '0.5em',
-            backgroundColor: 'white',
-            bottom: '0.1em',
-          }}
-        />
-        {/* Outline triangle (orange border, inherits white fill from behind) */}
-        <FontAwesomeIcon
-          icon={faTriangleExclamation as IconProp}
-          style={{ color, position: 'relative' }}
-        />
-      </span>
+      />
     </span>
   )
 }

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faExclamation } from '@fortawesome/free-solid-svg-icons'
-import { faHourglass } from '@fortawesome/free-regular-svg-icons'
+import {
+  faExclamation,
+  faHourglassEnd,
+} from '@fortawesome/free-solid-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 
 export interface StopwatchWarningIconProps {
@@ -21,7 +23,7 @@ export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
       style={{ position: 'relative', display: 'inline-block', ...style }}
       aria-label="timeout warning icon"
     >
-      <FontAwesomeIcon icon={faHourglass as IconProp} style={{ color }} />
+      <FontAwesomeIcon icon={faHourglassEnd as IconProp} style={{ color }} />
       <FontAwesomeIcon
         icon={faExclamation as IconProp}
         style={{

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faExclamation,
-  faHourglassEnd,
-} from '@fortawesome/free-solid-svg-icons'
+import { faExclamation } from '@fortawesome/free-solid-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 
 export interface StopwatchWarningIconProps {
@@ -17,13 +14,40 @@ export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
   style,
   color = 'rgb(255, 132, 59)',
 }) => {
+  // Derive a light sand fill from the stroke color
+  const sandFill = color.startsWith('rgb(')
+    ? color.replace('rgb(', 'rgba(').replace(')', ', 0.3)')
+    : 'rgba(255, 132, 59, 0.3)'
+
   return (
     <span
       className={className}
       style={{ position: 'relative', display: 'inline-block', ...style }}
       aria-label="timeout warning icon"
     >
-      <FontAwesomeIcon icon={faHourglassEnd as IconProp} style={{ color }} />
+      {/* Custom two-tone hourglass: stroke-only frame + light orange sand */}
+      <svg
+        viewBox="0 0 100 100"
+        width="0.8em"
+        height="1em"
+        aria-hidden="true"
+        style={{ display: 'block' }}
+      >
+        {/* Top cap bar */}
+        <rect x="5" y="2" width="90" height="11" rx="4" fill={color} />
+        {/* Bottom cap bar */}
+        <rect x="5" y="87" width="90" height="11" rx="4" fill={color} />
+        {/* Sand at bottom — light orange fill */}
+        <path d="M50,50 L90,87 L10,87 Z" fill={sandFill} />
+        {/* Hourglass frame — stroke only, no fill */}
+        <path
+          d="M10,13 L90,13 L50,50 L90,87 L10,87 L50,50 Z"
+          fill="none"
+          stroke={color}
+          strokeWidth="6"
+          strokeLinejoin="round"
+        />
+      </svg>
       <FontAwesomeIcon
         icon={faExclamation as IconProp}
         style={{

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faExclamation,
-  faHourglassEnd,
-} from '@fortawesome/free-solid-svg-icons'
+import { faClockRotateLeft } from '@fortawesome/free-solid-svg-icons'
+import { faTriangleExclamation } from '@fortawesome/free-regular-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 
 export interface StopwatchWarningIconProps {
@@ -23,17 +21,40 @@ export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
       style={{ position: 'relative', display: 'inline-block', ...style }}
       aria-label="timeout warning icon"
     >
-      <FontAwesomeIcon icon={faHourglassEnd as IconProp} style={{ color }} />
-      <FontAwesomeIcon
-        icon={faExclamation as IconProp}
+      {/* Clock with circular arc — closest free FA match to the reference icon */}
+      <FontAwesomeIcon icon={faClockRotateLeft as IconProp} style={{ color }} />
+      {/*
+       * Warning triangle badge — two layers to get the white-fill + orange-stroke
+       * look from the reference: a white square punched behind, then the outline
+       * triangle on top in orange.
+       */}
+      <span
         style={{
-          color,
           position: 'absolute',
-          top: '-0.4em',
-          right: '-0.5em',
-          fontSize: '1em',
+          top: '-0.45em',
+          right: '-0.55em',
+          fontSize: '0.85em',
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
         }}
-      />
+      >
+        {/* White fill behind the outline triangle */}
+        <span
+          style={{
+            position: 'absolute',
+            width: '0.55em',
+            height: '0.5em',
+            backgroundColor: 'white',
+            bottom: '0.1em',
+          }}
+        />
+        {/* Outline triangle (orange border, inherits white fill from behind) */}
+        <FontAwesomeIcon
+          icon={faTriangleExclamation as IconProp}
+          style={{ color, position: 'relative' }}
+        />
+      </span>
     </span>
   )
 }

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faExclamation } from '@fortawesome/free-solid-svg-icons'
+import {
+  faExclamation,
+  faHourglassEnd,
+} from '@fortawesome/free-solid-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 
 export interface StopwatchWarningIconProps {
@@ -14,40 +17,13 @@ export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
   style,
   color = 'rgb(255, 132, 59)',
 }) => {
-  // Derive a light sand fill from the stroke color
-  const sandFill = color.startsWith('rgb(')
-    ? color.replace('rgb(', 'rgba(').replace(')', ', 0.3)')
-    : 'rgba(255, 132, 59, 0.3)'
-
   return (
     <span
       className={className}
       style={{ position: 'relative', display: 'inline-block', ...style }}
       aria-label="timeout warning icon"
     >
-      {/* Custom two-tone hourglass: stroke-only frame + light orange sand */}
-      <svg
-        viewBox="0 0 100 100"
-        width="0.8em"
-        height="1em"
-        aria-hidden="true"
-        style={{ display: 'block' }}
-      >
-        {/* Top cap bar */}
-        <rect x="5" y="2" width="90" height="11" rx="4" fill={color} />
-        {/* Bottom cap bar */}
-        <rect x="5" y="87" width="90" height="11" rx="4" fill={color} />
-        {/* Sand at bottom — light orange fill */}
-        <path d="M50,50 L90,87 L10,87 Z" fill={sandFill} />
-        {/* Hourglass frame — stroke only, no fill */}
-        <path
-          d="M10,13 L90,13 L50,50 L90,87 L10,87 L50,50 Z"
-          fill="none"
-          stroke={color}
-          strokeWidth="6"
-          strokeLinejoin="round"
-        />
-      </svg>
+      <FontAwesomeIcon icon={faHourglassEnd as IconProp} style={{ color }} />
       <FontAwesomeIcon
         icon={faExclamation as IconProp}
         style={{

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -29,7 +29,7 @@ export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
           position: 'absolute',
           top: '-0.4em',
           right: '-0.5em',
-          fontSize: '0.55em',
+          fontSize: '0.75em',
         }}
       />
     </span>

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faExclamation } from '@fortawesome/free-solid-svg-icons'
+import { faHourglass } from '@fortawesome/free-regular-svg-icons'
+import { IconProp } from '@fortawesome/fontawesome-svg-core'
+
+export interface StopwatchWarningIconProps {
+  className?: string
+  style?: React.CSSProperties
+  color?: string
+}
+
+export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
+  className,
+  style,
+  color = 'rgb(255, 132, 59)',
+}) => {
+  return (
+    <span
+      className={className}
+      style={{ position: 'relative', display: 'inline-block', ...style }}
+      aria-label="timeout warning icon"
+    >
+      <FontAwesomeIcon icon={faHourglass as IconProp} style={{ color }} />
+      <FontAwesomeIcon
+        icon={faExclamation as IconProp}
+        style={{
+          color,
+          position: 'absolute',
+          top: '-0.4em',
+          right: '-0.5em',
+          fontSize: '0.55em',
+        }}
+      />
+    </span>
+  )
+}
+
+StopwatchWarningIcon.displayName = 'Icons.StopwatchWarningIcon'

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import {
-  faClockRotateLeft,
-  faTriangleExclamation,
-} from '@fortawesome/free-solid-svg-icons'
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons'
+import { faClock } from '@fortawesome/free-regular-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
 
 export interface StopwatchWarningIconProps {
@@ -23,8 +21,7 @@ export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
       style={{ position: 'relative', display: 'inline-block', ...style }}
       aria-label="timeout warning icon"
     >
-      {/* Clock with circular arc — closest free FA match to the reference icon */}
-      <FontAwesomeIcon icon={faClockRotateLeft as IconProp} style={{ color }} />
+      <FontAwesomeIcon icon={faClock as IconProp} style={{ color }} />
       {/* Solid warning triangle — orange with white ! built in */}
       <FontAwesomeIcon
         icon={faTriangleExclamation as IconProp}

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -13,16 +13,18 @@ export interface StopwatchWarningIconProps {
 export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
   className,
   style,
-  color = 'rgb(255, 132, 59)',
+  color = 'currentColor',
 }) => {
   return (
     <span
       className={className}
-      style={{ position: 'relative', display: 'inline-block', ...style }}
+      // Spread caller style first so the required overlay positioning cannot
+      // be accidentally overridden by a parent's style prop.
+      style={{ ...style, position: 'relative', display: 'inline-block' }}
       aria-label="timeout warning icon"
     >
       <FontAwesomeIcon icon={faClock as IconProp} style={{ color }} />
-      {/* Solid warning triangle — orange with white ! built in */}
+      {/* Solid warning triangle — inherits the same color as the clock */}
       <FontAwesomeIcon
         icon={faTriangleExclamation as IconProp}
         style={{

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -29,7 +29,7 @@ export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
           position: 'absolute',
           top: '-0.4em',
           right: '-0.5em',
-          fontSize: '0.75em',
+          fontSize: '1em',
         }}
       />
     </span>


### PR DESCRIPTION
## Summary

Replaces the generic warning triangle (`faExclamationTriangle`) used for timed-out directives in Schedule History with the new `StopwatchWarningIcon` — giving timeout rows a distinct, purpose-built icon that immediately communicates "timed out waiting for vehicle."

## Changes

- **`ScheduleCell.tsx`**: Import `StopwatchWarningIcon` from `../Icons/StopwatchWarningIcon`; remove `faExclamationTriangle` from imports and `icons` map; add a `status === 'timeout'` branch in the icon render (alongside the existing `'sent'` → `ConnectedIcon` and `'ack'` → `AcknowledgeIcon` special cases). The icon is wrapped in `<span title={statusTooltip ?? status}>` so all existing `getByTitle(/timeout/i)` tests and screen-reader accessibility continue to work unchanged.

## Test plan
- All 38 existing `ScheduleSection` Jest tests pass, including every `getByTitle(/timeout/i)` assertion.
- Preview the icon via `yarn workspace react-ui storybook` → **StopwatchWarningIcon** story.