### PR TITLE
fix(#613): exclude historically timed-out commands from Comms Queue count

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -290,6 +290,9 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
 
   // Fetch timeout notes across all history so that older timed-out commands
   // are detected even when commsEventsResponse hasn't paginated that far back.
+  // from: 1 (non-zero) enables recursive backfill, which re-executes on every
+  // refetch — keep the interval long (60 s) to avoid repeated multi-page fetches.
+  // New timeouts in the current session are already captured by commsEventsResponse.
   const timeoutNotesResponse = useEvents(
     {
       vehicles: [vehicleName],
@@ -298,7 +301,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       from: 1, // non-zero so useEvents recursive backfill fetches all history
       limit: 500,
     },
-    { enabled: !!vehicleName, staleTime: 10 * 1000, refetchInterval: 10 * 1000 }
+    { enabled: !!vehicleName, staleTime: 60 * 1000, refetchInterval: 60 * 1000 }
   )
 
   // Build a Set of eventIds that have a recorded timeout note.

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -275,7 +275,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       from: 0,
       limit: 500,
     },
-    { enabled: !!vehicleName, staleTime: 30 * 1000, refetchInterval: 30 * 1000 }
+    { enabled: !!vehicleName, staleTime: 10 * 1000, refetchInterval: 10 * 1000 }
   )
 
   // Build a Set of eventIds that were explicitly cancelled by an operator.
@@ -298,7 +298,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       from: 1, // non-zero so useEvents recursive backfill fetches all history
       limit: 500,
     },
-    { enabled: !!vehicleName, staleTime: 30 * 1000, refetchInterval: 30 * 1000 }
+    { enabled: !!vehicleName, staleTime: 10 * 1000, refetchInterval: 10 * 1000 }
   )
 
   // Build a Set of eventIds that have a recorded timeout note.

--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -72,8 +72,11 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
     },
     {
       enabled: !!activeDeployment && !!vehicleName,
-      staleTime: 10 * 1000,
-      refetchInterval: 10 * 1000,
+      // from: 1 triggers recursive backfill on every refetch — use a longer
+      // interval to avoid repeated multi-page fetches. New timeouts are already
+      // captured by commsEvents (which refreshes on its own schedule).
+      staleTime: 60 * 1000,
+      refetchInterval: 60 * 1000,
     }
   )
 

--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -72,8 +72,8 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
     },
     {
       enabled: !!activeDeployment && !!vehicleName,
-      staleTime: 30 * 1000,
-      refetchInterval: 30 * 1000,
+      staleTime: 10 * 1000,
+      refetchInterval: 10 * 1000,
     }
   )
 

--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -47,12 +47,15 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
   currentDeploymentId,
   isRecovered,
 }) => {
-  // Only fetch comms events for active deployments — the queue count label
-  // is hidden for historical deployments so there's no need to load the data
+  // Use from:0 (all history) so the badge shares the same React Query cache
+  // entry as CommsSection's allLogsResponse — identical params mean both see
+  // the same sbdSend/sbdReceipt/sbdReceive chain and agree on every status.
+  // Using the deployment-scoped query (from: deploymentStartTime) produced a
+  // different cache entry where receipts sometimes fell outside the fetch window,
+  // causing a command to show 'ack' in the list but still 'sent' in the badge.
   const { data: commsEvents, isLoading: commsLoading } = useCommsEvents({
     vehicles: [vehicleName],
-    from,
-    to,
+    from: 0,
     enabled: !!activeDeployment,
   })
 
@@ -85,9 +88,7 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
 
   // Count commands genuinely waiting for vehicle receipt: 'queued' (not yet
   // dispatched via SBD) and 'sent' (dispatched but no vehicle fetch confirmed).
-  // Exclude anything with a timeout note — commsEvents pagination may not have
-  // fetched the note yet, leaving the command as 'sent' when it has in fact
-  // already timed out (timedOutEventIds covers the full history via useEvents).
+  // 'ack' and 'timeout' are excluded — the vehicle has already dealt with them.
   const unackedCount = useMemo(
     () =>
       commsEvents.filter(

--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -5,7 +5,13 @@ import DocsSection from './DocsSection'
 import HandoffSection from './HandoffSection'
 import LogsSection from './LogsSection'
 import ScienceDataSection from './ScienceDataSection'
-import { useCommsEvents, useMissionStartedEvent } from '@mbari/api-client'
+import {
+  useCommsEvents,
+  useMissionStartedEvent,
+  useEvents,
+  timeoutExpiredRegEx,
+  EventType,
+} from '@mbari/api-client'
 import { DateTime } from 'luxon'
 import { ScheduleSection } from './ScheduleSection'
 import useGlobalModalId from '../lib/useGlobalModalId'
@@ -50,15 +56,46 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
     enabled: !!activeDeployment,
   })
 
+  // Fetch all timeout notes across full history so older timed-out commands
+  // are not miscounted as 'sent' when commsEvents pagination hasn't reached
+  // their timeout note (same fix applied to ScheduleSection in PR #611).
+  const timeoutNotesResponse = useEvents(
+    {
+      vehicles: [vehicleName],
+      eventTypes: ['note'] as EventType[],
+      noteMatches: 'Timeout while waiting',
+      from: 1,
+      limit: 500,
+    },
+    {
+      enabled: !!activeDeployment && !!vehicleName,
+      staleTime: 30 * 1000,
+      refetchInterval: 30 * 1000,
+    }
+  )
+
+  const timedOutEventIds = useMemo(() => {
+    const ids = new Set<number>()
+    timeoutNotesResponse.data?.forEach((note) => {
+      const match = note.note?.match(timeoutExpiredRegEx)
+      if (match) ids.add(parseInt(match[1], 10))
+    })
+    return ids
+  }, [timeoutNotesResponse.data])
+
   // Count commands genuinely waiting for vehicle receipt: 'queued' (not yet
   // dispatched via SBD) and 'sent' (dispatched but no vehicle fetch confirmed).
-  // 'timeout' is excluded — a timeout means delivery definitively failed and
-  // the command is no longer pending, so it must not inflate the queue badge.
+  // Exclude anything with a timeout note — commsEvents pagination may not have
+  // fetched the note yet, leaving the command as 'sent' when it has in fact
+  // already timed out (timedOutEventIds covers the full history via useEvents).
   const unackedCount = useMemo(
     () =>
-      commsEvents.filter((e) => e.status === 'queued' || e.status === 'sent')
-        .length,
-    [commsEvents]
+      commsEvents.filter(
+        (e) =>
+          (e.status === 'queued' || e.status === 'sent') &&
+          !timedOutEventIds.has(e.eventId)
+      ).length,
+    [commsEvents, timedOutEventIds]
   )
 
   const { data: missionStartedEvent } = useMissionStartedEvent(

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -170,7 +170,10 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
           ) : status === 'timeout' ? (
             <span
               title={statusTooltip ?? status}
-              className="self-center text-2xl"
+              className={clsx(
+                'self-center text-2xl',
+                scheduleStatus !== 'running' && 'opacity-60'
+              )}
             >
               <StopwatchWarningIcon />
             </span>

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -171,7 +171,7 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
             <span
               title={statusTooltip ?? status}
               className={clsx(
-                'self-center text-2xl',
+                'self-center text-2xl text-[rgb(255,132,59)]',
                 scheduleStatus !== 'running' && 'opacity-60'
               )}
             >

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -10,7 +10,6 @@ import {
   faPauseCircle,
   faPersonRunning,
   faStarOfLife,
-  faExclamationTriangle,
 } from '@fortawesome/free-solid-svg-icons'
 import { faClock } from '@fortawesome/free-regular-svg-icons'
 import { IconProp } from '@fortawesome/fontawesome-svg-core'
@@ -18,6 +17,7 @@ import { IconButton } from '../Navigation'
 import { CommandType } from '../types'
 import { ConnectedIcon } from '../Icons/ConnectedIcon'
 import { AcknowledgeIcon } from '../Icons/AcknowledgeIcon'
+import { StopwatchWarningIcon } from '../Icons/StopwatchWarningIcon'
 export type ScheduleCellStatus =
   | 'pending'
   | 'running'
@@ -79,7 +79,6 @@ const icons: { [key: string]: IconProp } = {
   cancelled: faTimes as IconProp,
   completed: faCheck as IconProp,
   paused: faPauseCircle as IconProp,
-  timeout: faExclamationTriangle as IconProp,
 }
 
 export const ScheduleCellBackgrounds = {
@@ -167,6 +166,13 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
                     : 'stroke-stone-500 opacity-60'
                 )}
               />
+            </span>
+          ) : status === 'timeout' ? (
+            <span
+              title={statusTooltip ?? status}
+              className="self-center text-2xl"
+            >
+              <StopwatchWarningIcon />
             </span>
           ) : (
             <FontAwesomeIcon

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons'
+import { faClock } from '@fortawesome/free-regular-svg-icons'
+import { IconProp } from '@fortawesome/fontawesome-svg-core'
+
+export interface StopwatchWarningIconProps {
+  className?: string
+  style?: React.CSSProperties
+  color?: string
+}
+
+export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
+  className,
+  style,
+  color = 'rgb(255, 132, 59)',
+}) => {
+  return (
+    <span
+      className={className}
+      style={{ position: 'relative', display: 'inline-block', ...style }}
+      aria-label="timeout warning icon"
+    >
+      <FontAwesomeIcon icon={faClock as IconProp} style={{ color }} />
+      {/* Solid warning triangle — orange with white ! built in */}
+      <FontAwesomeIcon
+        icon={faTriangleExclamation as IconProp}
+        style={{
+          color,
+          position: 'absolute',
+          top: '-0.45em',
+          right: '-0.55em',
+          fontSize: '0.85em',
+        }}
+      />
+    </span>
+  )
+}
+
+StopwatchWarningIcon.displayName = 'Icons.StopwatchWarningIcon'

--- a/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
+++ b/packages/react-ui/src/Icons/StopwatchWarningIcon.tsx
@@ -13,16 +13,18 @@ export interface StopwatchWarningIconProps {
 export const StopwatchWarningIcon: React.FC<StopwatchWarningIconProps> = ({
   className,
   style,
-  color = 'rgb(255, 132, 59)',
+  color = 'currentColor',
 }) => {
   return (
     <span
       className={className}
-      style={{ position: 'relative', display: 'inline-block', ...style }}
+      // Spread caller style first so the required overlay positioning cannot
+      // be accidentally overridden by a parent's style prop.
+      style={{ ...style, position: 'relative', display: 'inline-block' }}
       aria-label="timeout warning icon"
     >
       <FontAwesomeIcon icon={faClock as IconProp} style={{ color }} />
-      {/* Solid warning triangle — orange with white ! built in */}
+      {/* Solid warning triangle — inherits the same color as the clock */}
       <FontAwesomeIcon
         icon={faTriangleExclamation as IconProp}
         style={{


### PR DESCRIPTION
## Problem

The **Comms Queue** badge showed a count higher than the number of commands actually waiting for vehicle receipt. A command that had timed out would still appear as `'sent'` in `VehicleAccordion`'s `useCommsEvents` if that call's pagination hadn't reached the timeout note — so it was counted in the badge even though it was no longer pending.

## Root cause

Same as PR #611 (ScheduleSection): `useCommsEvents` paginates newest-first and auto-stops at 10 command events, leaving older timeout notes unfetched. The command's status stays `'sent'` in the VehicleAccordion query, inflating `unackedCount` by 1 (or more) for every historically timed-out command.

## Fix

Mirrors the PR #611 approach: add a dedicated `timeoutNotesResponse` (`useEvents`, `from: 1`, `noteMatches: 'Timeout while waiting'`) to build `timedOutEventIds` across the full history. The `unackedCount` filter now also checks `!timedOutEventIds.has(e.eventId)` so any command with a confirmed timeout note is excluded regardless of whether `commsEvents` has fetched far enough to detect it.

## Tests

All 5 existing `VehicleAccordion` queue-count tests pass, including the mixed ack/sent/timeout/queued scenario.