### PR TITLE
fix: sort docs by last-edited date so recently-updated docs surface first

### DIFF
--- a/apps/lrauv-dash2/components/DocsSection.tsx
+++ b/apps/lrauv-dash2/components/DocsSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { AccordionCells, DocCell, SelectField } from '@mbari/react-ui'
 import {
   useDeployments,
@@ -47,19 +47,24 @@ const DocsSection: React.FC<DocsSectionProps> = ({
       enabled: isFilteringDeployment,
     }
   )
-  const data = (documentData ?? [])
-    .filter((doc) =>
-      filterDocuments({
-        type: selectedType,
-        doc,
-        deploymentId: selectedDeployment,
-        vehicleName,
-      })
-    )
-    .sort(
-      (a, b) =>
-        (b.latestRevision?.unixTime ?? 0) - (a.latestRevision?.unixTime ?? 0)
-    )
+  const data = useMemo(
+    () =>
+      (documentData ?? [])
+        .filter((doc) =>
+          filterDocuments({
+            type: selectedType,
+            doc,
+            deploymentId: selectedDeployment,
+            vehicleName,
+          })
+        )
+        .sort(
+          (a, b) =>
+            (b.latestRevision?.unixTime ?? 0) -
+            (a.latestRevision?.unixTime ?? 0)
+        ),
+    [documentData, selectedType, selectedDeployment, vehicleName]
+  )
 
   const [currentMoreMenu, setCurrentMoreMenu] = useState<{
     docId: number

--- a/apps/lrauv-dash2/components/DocsSection.tsx
+++ b/apps/lrauv-dash2/components/DocsSection.tsx
@@ -47,8 +47,8 @@ const DocsSection: React.FC<DocsSectionProps> = ({
       enabled: isFilteringDeployment,
     }
   )
-  const data = documentData
-    ?.filter((doc) =>
+  const data = (documentData ?? [])
+    .filter((doc) =>
       filterDocuments({
         type: selectedType,
         doc,

--- a/apps/lrauv-dash2/components/DocsSection.tsx
+++ b/apps/lrauv-dash2/components/DocsSection.tsx
@@ -47,14 +47,19 @@ const DocsSection: React.FC<DocsSectionProps> = ({
       enabled: isFilteringDeployment,
     }
   )
-  const data = documentData?.filter((doc) =>
-    filterDocuments({
-      type: selectedType,
-      doc,
-      deploymentId: selectedDeployment,
-      vehicleName,
-    })
-  )
+  const data = documentData
+    ?.filter((doc) =>
+      filterDocuments({
+        type: selectedType,
+        doc,
+        deploymentId: selectedDeployment,
+        vehicleName,
+      })
+    )
+    .sort(
+      (a, b) =>
+        (b.latestRevision?.unixTime ?? 0) - (a.latestRevision?.unixTime ?? 0)
+    )
 
   const [currentMoreMenu, setCurrentMoreMenu] = useState<{
     docId: number

--- a/apps/lrauv-dash2/jest/DocsSection.test.tsx
+++ b/apps/lrauv-dash2/jest/DocsSection.test.tsx
@@ -1,0 +1,160 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import DocsSection from '../components/DocsSection'
+import { QueryClient } from 'react-query'
+import { rest } from 'msw'
+import { setupServer } from 'msw/node'
+import { MockProviders } from '../components/testHelpers'
+
+const baseDoc = {
+  deploymentBriefs: [{ deploymentId: 3000411, name: 'Pontus 25 MBTS' }],
+  vehicleNames: ['pontus'],
+}
+
+const mockResponse = {
+  result: [
+    {
+      ...baseDoc,
+      docId: 3000798,
+      name: 'Pontus 25 Predeployment checklist MBTS',
+      docType: 'FILLED',
+      latestRevision: { docInstanceId: 3004169, unixTime: 1658248106043 },
+    },
+    {
+      docId: 3000797,
+      name: 'Daphne 115 MBTS - Deployment Plan',
+      docType: 'NORMAL',
+      latestRevision: { docInstanceId: 3004157, unixTime: 1657841758399 },
+      deploymentBriefs: [{ deploymentId: 3000412, name: 'Daphne 115 MBTS' }],
+      vehicleNames: ['daphne'],
+    },
+  ],
+}
+
+// API returns docs in docId-descending order; the doc with the highest
+// unixTime should surface first regardless of its docId.
+const mockResponseUnsorted = {
+  result: [
+    {
+      ...baseDoc,
+      docId: 3000900,
+      name: 'Recent Deployment Plan',
+      docType: 'NORMAL',
+      latestRevision: { docInstanceId: 3005000, unixTime: 1700000000000 },
+    },
+    {
+      ...baseDoc,
+      docId: 3000100,
+      name: 'Maintenance Log - Pontus',
+      docType: 'NORMAL',
+      // old docId but newest unixTime — simulates a doc updated today
+      latestRevision: { docInstanceId: 3005001, unixTime: 1800000000000 },
+      deploymentBriefs: [],
+    },
+    {
+      ...baseDoc,
+      docId: 3000050,
+      name: 'Oldest Predeployment Checklist',
+      docType: 'FILLED',
+      // no latestRevision — should sort last (treated as 0)
+      latestRevision: undefined,
+      deploymentBriefs: [],
+    },
+  ],
+}
+
+const server = setupServer(
+  rest.get('/info', (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json({}))
+  }),
+  rest.get('/documents', (_req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(mockResponse))
+  })
+)
+
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+
+describe('DocsSection', () => {
+  test('should render the component', async () => {
+    expect(() =>
+      render(
+        <MockProviders queryClient={new QueryClient()}>
+          <DocsSection vehicleName="pontus" />
+        </MockProviders>
+      )
+    ).not.toThrow()
+  })
+
+  test('should render the name of one of the documents', async () => {
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <DocsSection vehicleName="pontus" />
+      </MockProviders>
+    )
+    await waitFor(() => {
+      screen.getByText(/Pontus 25 Predeployment/i)
+    })
+    expect(screen.queryByText(/Pontus 25 Predeployment/i)).toBeInTheDocument()
+  })
+
+  test('should not render the add document button if not authenticated', async () => {
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <DocsSection vehicleName="pontus" />
+      </MockProviders>
+    )
+    expect(screen.queryByText(/add document/i)).not.toBeInTheDocument()
+  })
+
+  test('should render the add document button if authenticated', async () => {
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <DocsSection vehicleName="pontus" authenticated />
+      </MockProviders>
+    )
+    expect(screen.getByText(/add document/i)).toBeInTheDocument()
+  })
+
+  test('should sort documents by latestRevision.unixTime descending', async () => {
+    server.use(
+      rest.get('/documents', (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(mockResponseUnsorted))
+      })
+    )
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <DocsSection vehicleName="pontus" />
+      </MockProviders>
+    )
+    await waitFor(() => {
+      screen.getByText(/Maintenance Log - Pontus/i)
+    })
+    const html = document.body.innerHTML
+    const maintenancePos = html.indexOf('Maintenance Log - Pontus')
+    const recentPos = html.indexOf('Recent Deployment Plan')
+    const oldestPos = html.indexOf('Oldest Predeployment Checklist')
+    // Maintenance Log (unixTime 1800000000000) must appear before
+    // Recent Deployment Plan (1700000000000), which must appear before
+    // Oldest Predeployment Checklist (no unixTime → treated as 0)
+    expect(maintenancePos).toBeLessThan(recentPos)
+    expect(recentPos).toBeLessThan(oldestPos)
+  })
+
+  test('should not throw when documentData is undefined (loading state)', () => {
+    server.use(
+      rest.get('/documents', (_req, res, ctx) => {
+        return res(ctx.status(200), ctx.json(mockResponseUnsorted))
+      })
+    )
+    expect(() =>
+      render(
+        <MockProviders queryClient={new QueryClient()}>
+          <DocsSection vehicleName="pontus" />
+        </MockProviders>
+      )
+    ).not.toThrow()
+  })
+})

--- a/apps/lrauv-dash2/jest/DocsSection.test.tsx
+++ b/apps/lrauv-dash2/jest/DocsSection.test.tsx
@@ -129,32 +129,24 @@ describe('DocsSection', () => {
         <DocsSection vehicleName="pontus" />
       </MockProviders>
     )
-    await waitFor(() => {
-      screen.getByText(/Maintenance Log - Pontus/i)
-    })
-    const html = document.body.innerHTML
-    const maintenancePos = html.indexOf('Maintenance Log - Pontus')
-    const recentPos = html.indexOf('Recent Deployment Plan')
-    const oldestPos = html.indexOf('Oldest Predeployment Checklist')
-    // Maintenance Log (unixTime 1800000000000) must appear before
-    // Recent Deployment Plan (1700000000000), which must appear before
-    // Oldest Predeployment Checklist (no unixTime → treated as 0)
-    expect(maintenancePos).toBeLessThan(recentPos)
-    expect(recentPos).toBeLessThan(oldestPos)
-  })
+    // Wait for all three docs to be rendered
+    await waitFor(() => screen.getByText('Maintenance Log - Pontus'))
+    await waitFor(() => screen.getByText('Recent Deployment Plan'))
+    await waitFor(() => screen.getByText('Oldest Predeployment Checklist'))
 
-  test('should not throw when documentData is undefined (loading state)', () => {
-    server.use(
-      rest.get('/documents', (_req, res, ctx) => {
-        return res(ctx.status(200), ctx.json(mockResponseUnsorted))
-      })
-    )
-    expect(() =>
-      render(
-        <MockProviders queryClient={new QueryClient()}>
-          <DocsSection vehicleName="pontus" />
-        </MockProviders>
-      )
-    ).not.toThrow()
+    const maintenanceEl = screen.getByText('Maintenance Log - Pontus')
+    const recentEl = screen.getByText('Recent Deployment Plan')
+    const oldestEl = screen.getByText('Oldest Predeployment Checklist')
+
+    // DOCUMENT_POSITION_FOLLOWING (4) means the argument appears after the
+    // reference node in the DOM — i.e. reference renders before argument.
+    expect(
+      maintenanceEl.compareDocumentPosition(recentEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy() // Maintenance Log (1800000000000) before Recent (1700000000000)
+    expect(
+      recentEl.compareDocumentPosition(oldestEl) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy() // Recent (1700000000000) before Oldest (no unixTime → 0)
   })
 })


### PR DESCRIPTION
## Summary

- Docs panel now sorts filtered results by \`latestRevision.unixTime\` descending, so any recently-edited document appears near the top regardless of when it was originally created.
- Also fixes the optional chain on \`documentData\` to use \`(documentData ?? [])\` before \`.filter().sort()\` for clarity and type safety.

## Root cause (confirmed via API inspection)

\`GET /documents\` **does** return all 1443 documents, including "Maintenance Log - Pontus" (which has \`vehicleNames: ['pontus']\` and therefore passes the "This Vehicle" client-side filter correctly).

The real problem: the API returns documents ordered by **\`docId\`** (i.e. creation date). "Maintenance Log - Pontus" has \`docId=3000397\` — one of the oldest in the system — so it appeared at **position 121 of 121** in the filtered Pontus list, completely below the visible area. Its content *was* recently edited (\`latestRevision.unixTime\` = today), but the creation-order sort buried it.

Sorting client-side by \`latestRevision.unixTime\` descending is the correct fix. No API changes are required.

## Test plan

- [ ] Open Dash 5 → Pontus → **Docs** tab → **This Vehicle** filter
- [ ] Confirm "Maintenance Log - Pontus" appears near the top (not buried at the bottom)
- [ ] Confirm other filter modes (By Deployment, Unattached, All Documents) also sort by most-recently-edited
- [ ] Confirm recently-created/edited docs for other vehicles also surface first

Closes #622