### PR TITLE
fix(#629): sync DocViewer extensions with DocEditorTipTap

### DIFF
--- a/apps/lrauv-dash2/components/docs/DocViewer.tsx
+++ b/apps/lrauv-dash2/components/docs/DocViewer.tsx
@@ -1,8 +1,19 @@
 import React, { useEffect } from 'react'
 import { useEditor, EditorContent } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { TextStyle } from '@tiptap/extension-text-style'
+import { TextStyle, FontSize } from '@tiptap/extension-text-style'
 import { Color } from '@tiptap/extension-color'
+import { Highlight } from '@tiptap/extension-highlight'
+import { TextAlign } from '@tiptap/extension-text-align'
+import { Underline } from '@tiptap/extension-underline'
+import { Link } from '@tiptap/extension-link'
+import { Subscript } from '@tiptap/extension-subscript'
+import { Superscript } from '@tiptap/extension-superscript'
+import { HorizontalRule } from '@tiptap/extension-horizontal-rule'
+import { Table } from '@tiptap/extension-table'
+import { TableRow } from '@tiptap/extension-table-row'
+import { TableCell } from '@tiptap/extension-table-cell'
+import { TableHeader } from '@tiptap/extension-table-header'
 import { CheckboxNode } from './extensions/CheckboxNode'
 import { RadioNode } from './extensions/RadioNode'
 import { TextFieldNode } from './extensions/TextFieldNode'
@@ -91,7 +102,9 @@ export default function DocViewer(props: DocViewerProps) {
     extensions: [
       StarterKit.configure({
         heading: { levels: [1, 2, 3, 4, 5, 6] },
+        horizontalRule: false,
       }),
+      TextAlign.configure({ types: ['heading', 'paragraph'] }),
       TextStyle.extend({
         addAttributes() {
           return {
@@ -99,24 +112,53 @@ export default function DocViewer(props: DocViewerProps) {
             style: {
               default: null,
               parseHTML: (element: HTMLElement) => {
-                const el = element as HTMLElement
-                const style = el.getAttribute('style')
-                // Preserve style attribute if it contains color
-                if (style && /color:/i.test(style)) {
-                  return style
-                }
-                return null
+                const raw = (element as HTMLElement).getAttribute('style')
+                if (!raw) return null
+                // Whitelist only safe CSS properties to prevent style injection.
+                // font-family is included for dash4 <font face="..."> compatibility.
+                const allowed = [
+                  'color',
+                  'font-size',
+                  'background-color',
+                  'font-family',
+                ]
+                const filtered = raw
+                  .split(';')
+                  .map((s) => s.trim())
+                  .filter((s) =>
+                    allowed.some((prop) =>
+                      s.toLowerCase().startsWith(prop + ':')
+                    )
+                  )
+                  .join('; ')
+                return filtered || null
               },
               renderHTML: (attributes: { style?: string }) => {
-                if (!attributes.style) {
-                  return {}
-                }
+                if (!attributes.style) return {}
                 return { style: attributes.style }
               },
             },
           }
         },
       }),
+      FontSize,
+      Highlight.configure({ multicolor: true }),
+      Underline,
+      Link.configure({
+        openOnClick: true,
+        protocols: ['http', 'https', 'mailto'],
+        HTMLAttributes: {
+          target: '_blank',
+          rel: 'noopener noreferrer',
+        },
+      }),
+      Subscript,
+      Superscript,
+      HorizontalRule,
+      Table.configure({ resizable: false }),
+      TableRow,
+      TableHeader,
+      TableCell,
       Color.extend({
         addAttributes() {
           return {

--- a/apps/lrauv-dash2/jest.config.js
+++ b/apps/lrauv-dash2/jest.config.js
@@ -10,6 +10,6 @@ module.exports = {
     '^.+\\.(js|jsx|ts|tsx)$': ['babel-jest', { presets: ['next/babel'] }],
   },
   transformIgnorePatterns: [
-    '/node_modules/(?!(react-dnd|react-dnd-html5-backend|@react-dnd|dnd-core)/)',
+    '/node_modules/(?!(react-dnd|react-dnd-html5-backend|@react-dnd|dnd-core|@tiptap|prosemirror-[^/]+|orderedmap)/)',
   ],
 }

--- a/apps/lrauv-dash2/jest/DocViewer.test.tsx
+++ b/apps/lrauv-dash2/jest/DocViewer.test.tsx
@@ -1,0 +1,112 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { render } from '@testing-library/react'
+import DocViewer from '../components/docs/DocViewer'
+
+// TipTap requires getSelection/createRange in jsdom
+if (!global.document.createRange) {
+  global.document.createRange = () =>
+    ({
+      setStart: () => {},
+      setEnd: () => {},
+      commonAncestorContainer: {
+        nodeName: 'BODY',
+        ownerDocument: document,
+      },
+    } as unknown as Range)
+}
+if (!global.window.getSelection) {
+  global.window.getSelection = () => null
+}
+
+/** Return the inner HTML of the ProseMirror editor produced by DocViewer. */
+function getEditorHtml(html: string): string {
+  const { container } = render(<DocViewer html={html} />)
+  const editor = container.querySelector('.ProseMirror')
+  return editor?.innerHTML ?? ''
+}
+
+describe('DocViewer formatting preservation', () => {
+  it('renders highlight (mark element with background colour)', () => {
+    const html = `<p><mark data-color="#ffff00" style="background-color: #ffff00; color: inherit">highlighted text</mark></p>`
+    const { container } = render(<DocViewer html={html} />)
+    const mark = container.querySelector('mark')
+    expect(mark).toBeInTheDocument()
+    expect(mark?.getAttribute('data-color')).toBe('#ffff00')
+  })
+
+  it('renders text-align: center on paragraphs', () => {
+    const html = `<p style="text-align: center">centered text</p>`
+    const editorHtml = getEditorHtml(html)
+    expect(editorHtml).toMatch(/text-align:\s*center/)
+  })
+
+  it('renders text-align: right on paragraphs', () => {
+    const html = `<p style="text-align: right">right-aligned text</p>`
+    const editorHtml = getEditorHtml(html)
+    expect(editorHtml).toMatch(/text-align:\s*right/)
+  })
+
+  it('preserves font-size in inline styles', () => {
+    const html = `<p><span style="font-size: 24px">big text</span></p>`
+    const { container } = render(<DocViewer html={html} />)
+    const spans = Array.from(container.querySelectorAll('span'))
+    const sized = spans.find((s) =>
+      s.getAttribute('style')?.includes('font-size')
+    )
+    expect(sized).toBeInTheDocument()
+    expect(sized?.getAttribute('style')).toMatch(/font-size:\s*24px/)
+  })
+
+  it('preserves text colour in inline styles', () => {
+    const html = `<p><span style="color: rgb(255, 0, 0)">red text</span></p>`
+    const { container } = render(<DocViewer html={html} />)
+    const spans = Array.from(container.querySelectorAll('span'))
+    const coloured = spans.find((s) =>
+      s.getAttribute('style')?.includes('color')
+    )
+    expect(coloured).toBeInTheDocument()
+    expect(coloured?.getAttribute('style')).toMatch(/color/)
+  })
+
+  it('preserves font-family for dash4 <font face> compatibility', () => {
+    // The convertedHtml step converts <font face="Arial"> to
+    // <span style="font-family: Arial">. That font-family must survive
+    // the TextStyle.parseHTML whitelist.
+    const html = `<p><span style="font-family: Arial">legacy font</span></p>`
+    const { container } = render(<DocViewer html={html} />)
+    const spans = Array.from(container.querySelectorAll('span'))
+    const fonted = spans.find((s) =>
+      s.getAttribute('style')?.includes('font-family')
+    )
+    expect(fonted).toBeInTheDocument()
+    expect(fonted?.getAttribute('style')).toMatch(/font-family/)
+  })
+
+  it('strips disallowed CSS properties from inline styles (security)', () => {
+    const html = `<p><span style="font-size: 18px; position: fixed; top: 0">text</span></p>`
+    const { container } = render(<DocViewer html={html} />)
+    const spans = Array.from(container.querySelectorAll('span'))
+    const allStyles = spans.map((s) => s.getAttribute('style') ?? '').join(' ')
+    expect(allStyles).not.toMatch(/position/)
+  })
+
+  it('renders links with safe rel and target attributes', () => {
+    const html = `<p><a href="https://mbari.org">MBARI</a></p>`
+    const { container } = render(<DocViewer html={html} />)
+    const link = container.querySelector('a')
+    expect(link).toBeInTheDocument()
+    expect(link?.getAttribute('rel')).toContain('noopener')
+    expect(link?.getAttribute('target')).toBe('_blank')
+  })
+
+  it('does not open javascript: protocol links', () => {
+    const html = `<p><a href="javascript:alert(1)">xss</a></p>`
+    const { container } = render(<DocViewer html={html} />)
+    const link = container.querySelector('a')
+    // Link should either not render or have its href stripped
+    if (link) {
+      expect(link.getAttribute('href')).not.toMatch(/javascript:/i)
+    }
+  })
+})


### PR DESCRIPTION
## Problem

DocViewer was missing several TipTap extensions that DocEditorTipTap uses, so persisted rich-text formatting (font size, highlight, text alignment, underline, tables, links, etc.) was silently dropped when viewing a saved document.

Closes #629.

## Changes

### `DocViewer.tsx`
- Added missing extensions to match the editor: `FontSize`, `Highlight`, `TextAlign`, `Underline`, `Link`, `Subscript`, `Superscript`, `HorizontalRule`, `Table` suite
- `TextStyle.parseHTML` now uses a **CSS property whitelist** (`color`, `font-size`, `background-color`, `font-family`) — preserves all editor-applied inline styles while blocking CSS injection; `font-family` included for dash4 `<font face>` backward compatibility
- `Link` configured with safe protocols (`http`, `https`, `mailto`), `target: '_blank'`, `rel: 'noopener noreferrer'`

### `jest/DocViewer.test.tsx` _(new)_
9 regression tests: highlight, text-align (center/right), font-size, colour, font-family, CSS injection stripping, link rel/target safety, and `javascript:` protocol blocking.

### `jest.config.js`
Extended `transformIgnorePatterns` to allow Jest to transpile `@tiptap` and `prosemirror-*` packages.

## Test plan
- [ ] Open a document saved with highlight, centred text, font-size change, and a hyperlink — all render correctly in view mode
- [ ] `yarn workspace @mbari/lrauv-dash2 test:ci` — all 9 DocViewer tests green