### PR TITLE
feat(#627): auto-refresh logs + relative timestamps + last-updated indicator

### DIFF
--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -128,11 +128,14 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   // the extra load is negligible. A future improvement could use a separate
   // lightweight query for the newest slice and merge results.
   //
-  // Only poll the query that is currently displayed; the inactive one is kept
-  // enabled so its cache stays warm but does not generate background traffic.
+  // Only the active view polls. The inactive query keeps its cache warm but has
+  // refetchInterval, refetchOnWindowFocus, and refetchOnReconnect all disabled so
+  // it cannot generate background traffic in any scenario.
   const deploymentResponse = useInfiniteEvents(deploymentParams, {
     enabled: hasSelection,
     refetchInterval: hasSelection && deploymentLogsOnly ? 30_000 : false,
+    refetchOnWindowFocus: deploymentLogsOnly,
+    refetchOnReconnect: deploymentLogsOnly,
   })
 
   const allLogsParams = useMemo(
@@ -148,6 +151,8 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   const allLogsResponse = useInfiniteEvents(allLogsParams, {
     enabled: hasSelection,
     refetchInterval: hasSelection && !deploymentLogsOnly ? 30_000 : false,
+    refetchOnWindowFocus: !deploymentLogsOnly,
+    refetchOnReconnect: !deploymentLogsOnly,
   })
 
   const {
@@ -161,7 +166,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     dataUpdatedAt,
   } = deploymentLogsOnly ? deploymentResponse : allLogsResponse
 
-  const nowMs = useTick(30_000)
+  const nowMs = useTick(30_000, hasSelection)
   const nowDT = DateTime.fromMillis(nowMs)
 
   // Use DateTime.now() rather than nowDT so the indicator resets immediately
@@ -327,11 +332,11 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     const diff = eventDT.diffNow('days').days
     const date = Math.abs(diff) < 1 ? 'Today' : eventDT.toFormat('yyyy-MM-dd')
     const time = eventDT.toFormat('H:mm:ss')
-    // Show a relative duration for events within the last 7 days. No maxDays cap
-    // is needed here — the < 7 gate already prevents anything ≥ 7 days from being
-    // formatted, so formatCompactDuration's natural output is always appropriate.
+    // Show a relative duration for past events within the last 7 days. The diff
+    // is negative when eventDT is in the past (diffNow measures now→target), so
+    // diff <= 0 guards against future timestamps caused by clock skew.
     const timeAgo =
-      Math.abs(diff) < 7
+      diff <= 0 && Math.abs(diff) < 7
         ? `${formatCompactDuration(eventDT, nowDT)} ago`
         : undefined
 

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react'
+import useTick from '../lib/useTick'
 import {
   useInfiniteEvents,
   useTethysApiContext,
@@ -30,7 +31,7 @@ import {
   modalVisibleFilterIds,
 } from '../lib/logFilters'
 import { handleCopyEventLogs } from '../lib/handleCopyEventLogs'
-import { createLogger, useDebounce } from '@mbari/utils'
+import { createLogger, formatCompactDuration, useDebounce } from '@mbari/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faChevronDown,
@@ -122,7 +123,9 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     [vehicleName, eventTypes, from, to]
   )
 
-  const deploymentResponse = useInfiniteEvents(deploymentParams)
+  const deploymentResponse = useInfiniteEvents(deploymentParams, {
+    refetchInterval: 60_000,
+  })
 
   const allLogsParams = useMemo(
     () => ({
@@ -134,7 +137,9 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     [vehicleName, eventTypes]
   )
 
-  const allLogsResponse = useInfiniteEvents(allLogsParams)
+  const allLogsResponse = useInfiniteEvents(allLogsParams, {
+    refetchInterval: 60_000,
+  })
 
   const {
     data,
@@ -144,7 +149,17 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     fetchNextPage,
     hasNextPage,
     refetch,
+    dataUpdatedAt,
   } = deploymentLogsOnly ? deploymentResponse : allLogsResponse
+
+  const nowMs = useTick(30_000)
+  const nowDT = DateTime.fromMillis(nowMs)
+
+  const lastUpdatedAgo = dataUpdatedAt
+    ? `${formatCompactDuration(DateTime.fromMillis(dataUpdatedAt), nowDT, {
+        maxDays: 1,
+      })} ago`
+    : undefined
 
   const flatData = useMemo(() => {
     if (!hasSelection) return []
@@ -293,12 +308,14 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     if (!item) return <span />
 
     const isoTime = item.isoTime ?? ''
-    const diff = DateTime.fromISO(isoTime).diffNow('days').days
-    const date =
-      Math.abs(diff) < 1
-        ? 'Today'
-        : DateTime.fromISO(isoTime).toFormat('yyyy-MM-dd')
-    const time = DateTime.fromISO(isoTime).toFormat('H:mm:ss')
+    const eventDT = DateTime.fromISO(isoTime)
+    const diff = eventDT.diffNow('days').days
+    const date = Math.abs(diff) < 1 ? 'Today' : eventDT.toFormat('yyyy-MM-dd')
+    const time = eventDT.toFormat('H:mm:ss')
+    const timeAgo =
+      Math.abs(diff) < 7
+        ? `${formatCompactDuration(eventDT, nowDT, { maxDays: 6 })} ago`
+        : undefined
 
     // Check if this item is the representative of a multi-note timeout group.
     // The stable group key mirrors what was set during processedData construction:
@@ -359,6 +376,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
         className="border-b border-slate-200"
         date={date}
         time={time}
+        timeAgo={timeAgo}
         label={displayNameForEventType(item)}
         log={log}
         isUpload={isUploadEvent(item)}
@@ -408,6 +426,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
           toggleDeploymentLogsOnly={toggleDeploymentLogsOnly}
           disabled={isLoading || isFetching}
           handleRefresh={handleRefresh}
+          lastUpdatedAgo={lastUpdatedAgo}
         />
       </header>
 

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -124,7 +124,8 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   )
 
   const deploymentResponse = useInfiniteEvents(deploymentParams, {
-    refetchInterval: 60_000,
+    enabled: hasSelection,
+    refetchInterval: hasSelection ? 60_000 : false,
   })
 
   const allLogsParams = useMemo(
@@ -138,7 +139,8 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   )
 
   const allLogsResponse = useInfiniteEvents(allLogsParams, {
-    refetchInterval: 60_000,
+    enabled: hasSelection,
+    refetchInterval: hasSelection ? 60_000 : false,
   })
 
   const {
@@ -155,10 +157,16 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   const nowMs = useTick(30_000)
   const nowDT = DateTime.fromMillis(nowMs)
 
+  // Use DateTime.now() rather than nowDT so the indicator resets immediately
+  // after a refetch instead of waiting up to 30s for the next tick.
   const lastUpdatedAgo = dataUpdatedAt
-    ? `${formatCompactDuration(DateTime.fromMillis(dataUpdatedAt), nowDT, {
-        maxDays: 1,
-      })} ago`
+    ? `${formatCompactDuration(
+        DateTime.fromMillis(dataUpdatedAt),
+        DateTime.now(),
+        {
+          maxDays: 1,
+        }
+      )} ago`
     : undefined
 
   const flatData = useMemo(() => {

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -127,9 +127,12 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   // tick, not just the first page. In practice, most sessions stay on page 1 so
   // the extra load is negligible. A future improvement could use a separate
   // lightweight query for the newest slice and merge results.
+  //
+  // Only poll the query that is currently displayed; the inactive one is kept
+  // enabled so its cache stays warm but does not generate background traffic.
   const deploymentResponse = useInfiniteEvents(deploymentParams, {
     enabled: hasSelection,
-    refetchInterval: hasSelection ? 30_000 : false,
+    refetchInterval: hasSelection && deploymentLogsOnly ? 30_000 : false,
   })
 
   const allLogsParams = useMemo(
@@ -144,7 +147,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
 
   const allLogsResponse = useInfiniteEvents(allLogsParams, {
     enabled: hasSelection,
-    refetchInterval: hasSelection ? 30_000 : false,
+    refetchInterval: hasSelection && !deploymentLogsOnly ? 30_000 : false,
   })
 
   const {

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -123,6 +123,10 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     [vehicleName, eventTypes, from, to]
   )
 
+  // Note: refetchInterval on useInfiniteQuery re-fetches all loaded pages on each
+  // tick, not just the first page. In practice, most sessions stay on page 1 so
+  // the extra load is negligible. A future improvement could use a separate
+  // lightweight query for the newest slice and merge results.
   const deploymentResponse = useInfiniteEvents(deploymentParams, {
     enabled: hasSelection,
     refetchInterval: hasSelection ? 30_000 : false,
@@ -320,9 +324,12 @@ const LogsSection: React.FC<LogsSectionProps> = ({
     const diff = eventDT.diffNow('days').days
     const date = Math.abs(diff) < 1 ? 'Today' : eventDT.toFormat('yyyy-MM-dd')
     const time = eventDT.toFormat('H:mm:ss')
+    // Show a relative duration for events within the last 7 days. No maxDays cap
+    // is needed here — the < 7 gate already prevents anything ≥ 7 days from being
+    // formatted, so formatCompactDuration's natural output is always appropriate.
     const timeAgo =
       Math.abs(diff) < 7
-        ? `${formatCompactDuration(eventDT, nowDT, { maxDays: 6 })} ago`
+        ? `${formatCompactDuration(eventDT, nowDT)} ago`
         : undefined
 
     // Check if this item is the representative of a multi-note timeout group.

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -125,7 +125,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
 
   const deploymentResponse = useInfiniteEvents(deploymentParams, {
     enabled: hasSelection,
-    refetchInterval: hasSelection ? 60_000 : false,
+    refetchInterval: hasSelection ? 30_000 : false,
   })
 
   const allLogsParams = useMemo(
@@ -140,7 +140,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
 
   const allLogsResponse = useInfiniteEvents(allLogsParams, {
     enabled: hasSelection,
-    refetchInterval: hasSelection ? 60_000 : false,
+    refetchInterval: hasSelection ? 30_000 : false,
   })
 
   const {

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react'
-import useTick from '../lib/useTick'
+import { useTick } from '../lib/useTick'
 import {
   useInfiniteEvents,
   useTethysApiContext,

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -128,9 +128,9 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   // the extra load is negligible. A future improvement could use a separate
   // lightweight query for the newest slice and merge results.
   //
-  // Only the active view polls. The inactive query keeps its cache warm but has
-  // refetchInterval, refetchOnWindowFocus, and refetchOnReconnect all disabled so
-  // it cannot generate background traffic in any scenario.
+  // Only the active view polls. The inactive query keeps its cache warm on
+  // initial mount and param changes, but does not poll on an interval or
+  // refetch on window focus / reconnect while inactive.
   const deploymentResponse = useInfiniteEvents(deploymentParams, {
     enabled: hasSelection,
     refetchInterval: hasSelection && deploymentLogsOnly ? 30_000 : false,
@@ -169,17 +169,21 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   const nowMs = useTick(30_000, hasSelection)
   const nowDT = DateTime.fromMillis(nowMs)
 
-  // Use DateTime.now() rather than nowDT so the indicator resets immediately
+  // Only show the last-updated indicator when logs are actively displayed.
+  // When hasSelection is false the toolbar prompts the user to choose filters,
+  // so a stale (and no-longer-ticking) "Updated X ago" would be misleading.
+  // Use DateTime.now() rather than nowDT so the counter resets immediately
   // after a refetch instead of waiting up to 30s for the next tick.
-  const lastUpdatedAgo = dataUpdatedAt
-    ? `${formatCompactDuration(
-        DateTime.fromMillis(dataUpdatedAt),
-        DateTime.now(),
-        {
-          maxDays: 1,
-        }
-      )} ago`
-    : undefined
+  const lastUpdatedAgo =
+    hasSelection && dataUpdatedAt
+      ? `${formatCompactDuration(
+          DateTime.fromMillis(dataUpdatedAt),
+          DateTime.now(),
+          {
+            maxDays: 1,
+          }
+        )} ago`
+      : undefined
 
   const flatData = useMemo(() => {
     if (!hasSelection) return []

--- a/apps/lrauv-dash2/jest/LogsSection.test.tsx
+++ b/apps/lrauv-dash2/jest/LogsSection.test.tsx
@@ -48,6 +48,59 @@ const makeTimeoutNote = (eventId: number, chunkNum: number): object => {
   }
 }
 
+// ── Auto-refresh / relative timestamp tests (#627) ────────────────────────────
+
+test('shows "Updated ... ago" in toolbar after a successful data load', async () => {
+  renderLogs([makeTimeoutNote(1, 1)])
+
+  await waitFor(() => {
+    expect(screen.getByText(/Updated .+ ago/)).toBeInTheDocument()
+  })
+})
+
+test('shows timeAgo for events within the last 7 days', async () => {
+  const ts = Date.now() - 3 * 24 * 60 * 60 * 1000
+  renderLogs([
+    {
+      eventId: 5001,
+      vehicleName: 'triton',
+      eventType: 'note',
+      unixTime: ts,
+      isoTime: new Date(ts).toISOString(),
+      note: 'Some 3-day-old event',
+      user: null,
+      state: 0,
+    },
+  ])
+
+  await waitFor(() => {
+    // Should render a relative duration like "3d 0h ago" or "2d 23h ago"
+    expect(screen.getByText(/\d+d.+ago/)).toBeInTheDocument()
+  })
+})
+
+test('hides timeAgo for events older than 7 days', async () => {
+  const ts = Date.now() - 8 * 24 * 60 * 60 * 1000
+  renderLogs([
+    {
+      eventId: 5002,
+      vehicleName: 'triton',
+      eventType: 'note',
+      unixTime: ts,
+      isoTime: new Date(ts).toISOString(),
+      note: 'Some 8-day-old event',
+      user: null,
+      state: 0,
+    },
+  ])
+
+  await waitFor(() => {
+    expect(screen.getByText(/Note/i)).toBeInTheDocument()
+  })
+  // 8 days old → no timeAgo chip should appear
+  expect(screen.queryByText(/\d+d.+ago/)).not.toBeInTheDocument()
+})
+
 // ── Grouping regression tests (#596) ──────────────────────────────────────────
 
 test('single timeout note renders normally (no grouping needed)', async () => {

--- a/apps/lrauv-dash2/lib/useTick.ts
+++ b/apps/lrauv-dash2/lib/useTick.ts
@@ -11,10 +11,15 @@ import { useEffect, useState } from 'react'
  * (e.g., “next comms in X minutes”) without relying on constant renders.
  */
 
-export const useTick = (intervalMs: number = 60_000) => {
+export const useTick = (
+  intervalMs: number = 60_000,
+  enabled: boolean = true
+) => {
   const [nowMs, setNowMs] = useState<number>(Date.now())
 
   useEffect(() => {
+    if (!enabled) return
+
     let timer: ReturnType<typeof setInterval> | null = null
 
     const start = () => {
@@ -50,7 +55,7 @@ export const useTick = (intervalMs: number = 60_000) => {
         document.removeEventListener('visibilitychange', handleVisibility)
       }
     }
-  }, [intervalMs])
+  }, [intervalMs, enabled])
 
   return nowMs
 }

--- a/packages/react-ui/src/Cells/LogCell.test.tsx
+++ b/packages/react-ui/src/Cells/LogCell.test.tsx
@@ -35,3 +35,13 @@ test('should contain the download data icon when downloading data', async () => 
 
   expect(screen.getByLabelText(/download data/i)).toBeInTheDocument()
 })
+
+test('renders timeAgo when provided', async () => {
+  render(<LogCell {...props} timeAgo="3m ago" />)
+  expect(screen.getByLabelText(/time ago/i)).toHaveTextContent('3m ago')
+})
+
+test('does not render timeAgo element when omitted', async () => {
+  render(<LogCell {...props} />)
+  expect(screen.queryByLabelText(/time ago/i)).not.toBeInTheDocument()
+})

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -8,6 +8,8 @@ export interface LogCellProps {
   style?: React.CSSProperties
   label: string
   time: string
+  /** Compact relative time string, e.g. "3m ago". Shown below the absolute time. */
+  timeAgo?: string
   date: string
   log: string | JSX.Element
   isUpload: boolean
@@ -25,6 +27,7 @@ export const LogCell: React.FC<LogCellProps> = ({
   style,
   label,
   time,
+  timeAgo,
   date,
   log,
   isUpload,
@@ -38,13 +41,18 @@ export const LogCell: React.FC<LogCellProps> = ({
       >
         <ul className={styles.details}>
           <li>{label}</li>
-          <li className="flex flex-row">
-            <span className="pr-2 opacity-60" aria-label="time">
+          <li className="flex flex-row items-baseline gap-1">
+            <span className="pr-1 opacity-60" aria-label="time">
               {time}
             </span>
             <span aria-label="data transmission icon">
               {isUpload ? <UploadIcon /> : <DownloadIcon />}
             </span>
+            {timeAgo && (
+              <span className="text-xs opacity-40" aria-label="time ago">
+                {timeAgo}
+              </span>
+            )}
           </li>
           <li className="opacity-60" aria-label="date">
             {date}

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -8,7 +8,7 @@ export interface LogCellProps {
   style?: React.CSSProperties
   label: string
   time: string
-  /** Compact relative time string, e.g. "3m ago". Shown below the absolute time. */
+  /** Compact relative time string, e.g. "3m ago". Rendered inline after the transmission icon. */
   timeAgo?: string
   date: string
   log: string | JSX.Element

--- a/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
@@ -44,4 +44,14 @@ describe('LogsToolbar', () => {
     fireEvent.click(refreshButton)
     expect(defaultProps.handleRefresh).toHaveBeenCalledTimes(1)
   })
+
+  test('renders lastUpdatedAgo when provided', () => {
+    render(<LogsToolbar {...defaultProps} lastUpdatedAgo="2m ago" />)
+    expect(screen.getByText(/updated 2m ago/i)).toBeInTheDocument()
+  })
+
+  test('does not render last-updated text when lastUpdatedAgo is omitted', () => {
+    render(<LogsToolbar {...defaultProps} />)
+    expect(screen.queryByText(/updated/i)).not.toBeInTheDocument()
+  })
 })

--- a/packages/react-ui/src/Toolbars/LogsToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.tsx
@@ -10,6 +10,8 @@ export interface LogsToolbarProps {
   toggleDeploymentLogsOnly: () => void
   disabled: boolean
   handleRefresh: () => void
+  /** Compact relative string for the last successful fetch, e.g. "2m ago". */
+  lastUpdatedAgo?: string
   className?: string
 }
 
@@ -18,9 +20,10 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   toggleDeploymentLogsOnly,
   disabled,
   handleRefresh,
+  lastUpdatedAgo,
   className,
 }) => (
-  <div className={clsx('flex items-center', className)}>
+  <div className={clsx('flex items-center gap-3', className)}>
     <IconToggle
       iconLeft={
         <HistoricalListIcon
@@ -51,6 +54,12 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
       className="mr-4"
       disabled={disabled}
     />
+
+    {lastUpdatedAgo && (
+      <span className="text-xs text-stone-400" aria-live="polite">
+        Updated {lastUpdatedAgo}
+      </span>
+    )}
 
     <IconButton
       icon={faSync}


### PR DESCRIPTION
## Summary

Addresses [#627](https://github.com/mbari-org/dash5/issues/627) — log pane feedback from Monique:

- Logs now auto-refresh every 30 seconds without requiring the manual Refresh button
- Each log entry shows a compact relative time (e.g. `3m ago`) beside the absolute `H:mm:ss` timestamp
- The toolbar shows `Updated Xm ago` next to the refresh button, ticking every 30 seconds

## Changes

### `LogsSection.tsx`
- Added `refetchInterval: 30_000` to both `useInfiniteEvents` calls (deployment + all-logs), gated so only the currently-displayed query polls — the inactive one keeps its cache warm without generating background traffic
- Extracted `dataUpdatedAt` from the query result to drive the last-updated display
- Added `useTick(30_000)` + `formatCompactDuration` to compute `lastUpdatedAgo` and `timeAgo` per row
- Events older than 7 days do not show a relative time (not useful at that scale)

### `LogCell.tsx` (`@mbari/react-ui`)
- Added optional `timeAgo?: string` prop — rendered as small muted text beside the transmission icon

### `LogsToolbar.tsx` (`@mbari/react-ui`)
- Added optional `lastUpdatedAgo?: string` prop — renders `Updated Xm ago` with `aria-live="polite"` so screen readers announce updates

## Test plan
- [ ] Open the Logs panel for an active vehicle — entries show `Xm ago` beside each timestamp
- [ ] Wait 30 seconds — new events appear without clicking Refresh
- [ ] `Updated Xm ago` in the toolbar increments every ~30 seconds
- [ ] Clicking Refresh resets the `Updated` counter immediately
- [ ] Toggle between deployment-only and all-logs — only the visible mode polls; switching modes resumes polling on the newly active query