### PR TITLE
feat(#626): compact log density toggle

### DIFF
--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -71,6 +71,26 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   }
 
   const { siteConfig } = useTethysApiContext()
+
+  const [compact, setCompact] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem('logs:compact') === 'true'
+    } catch {
+      return false
+    }
+  })
+  const handleToggleCompact = useCallback(() => {
+    setCompact((prev) => {
+      const next = !prev
+      try {
+        localStorage.setItem('logs:compact', String(next))
+      } catch {
+        // localStorage unavailable (private browsing, etc.) — state still updates in memory
+      }
+      return next
+    })
+  }, [])
+
   const [filters, setFilters] = useState<MultiValue<SelectOption>>(
     defaultModalSelections
   )
@@ -408,6 +428,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
         log={log}
         isUpload={isUploadEvent(item)}
         onCopy={handleCopyEventLogs}
+        compact={compact}
       />
     )
   }
@@ -454,6 +475,8 @@ const LogsSection: React.FC<LogsSectionProps> = ({
           disabled={isLoading || isFetching}
           handleRefresh={handleRefresh}
           lastUpdatedAgo={lastUpdatedAgo}
+          compact={compact}
+          onToggleCompact={handleToggleCompact}
         />
       </header>
 

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback } from 'react'
+import React, { useMemo, useState, useCallback, useRef } from 'react'
 import { useTick } from '../lib/useTick'
 import {
   useInfiniteEvents,
@@ -31,7 +31,12 @@ import {
   modalVisibleFilterIds,
 } from '../lib/logFilters'
 import { handleCopyEventLogs } from '../lib/handleCopyEventLogs'
-import { createLogger, formatCompactDuration, useDebounce } from '@mbari/utils'
+import {
+  createLogger,
+  formatCompactDuration,
+  useDebounce,
+  useResizeObserver,
+} from '@mbari/utils'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faChevronDown,
@@ -71,6 +76,13 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   }
 
   const { siteConfig } = useTethysApiContext()
+
+  const headerRef = useRef<HTMLElement>(null)
+  const { size: headerSize } = useResizeObserver({ element: headerRef })
+  // Hide button icons before the header gets narrow enough to compress the
+  // buttons themselves. 500 px gives enough buffer that buttons never reach a
+  // width where their text would wrap and increase the row height.
+  const hideIcons = headerSize.width > 0 && headerSize.width < 500
 
   const [compact, setCompact] = useState<boolean>(() => {
     try {
@@ -429,6 +441,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
         isUpload={isUploadEvent(item)}
         onCopy={handleCopyEventLogs}
         compact={compact}
+        component={item.name ?? undefined}
       />
     )
   }
@@ -437,19 +450,25 @@ const LogsSection: React.FC<LogsSectionProps> = ({
 
   return (
     <>
-      <header className="flex justify-between p-2">
-        <div className="flex items-center gap-2">
+      <header ref={headerRef} className="flex items-center justify-between p-2">
+        <div className="flex min-w-0 shrink items-center gap-2">
           <div
             className="relative"
             onMouseDown={(e) => e.stopPropagation()}
             onTouchStart={(e) => e.stopPropagation()}
           >
-            <Button appearance="secondary" onClick={handleToggleFilters}>
+            <Button
+              appearance="secondary"
+              onClick={handleToggleFilters}
+              className="shrink-0 whitespace-nowrap"
+            >
               Filter{' '}
-              <FontAwesomeIcon
-                icon={!!filtersOpen ? faChevronDown : faChevronUp}
-                className={styles.icon}
-              />
+              {!hideIcons && (
+                <FontAwesomeIcon
+                  icon={!!filtersOpen ? faChevronDown : faChevronUp}
+                  className={styles.icon}
+                />
+              )}
             </Button>
             {!!filtersOpen && (
               <div className="absolute z-50">
@@ -467,7 +486,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
               </div>
             )}
           </div>
-          <RealTimeLogs vehicleName={vehicleName} />
+          <RealTimeLogs vehicleName={vehicleName} hideIcons={hideIcons} />
         </div>
         <LogsToolbar
           deploymentLogsOnly={deploymentLogsOnly}
@@ -477,6 +496,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
           lastUpdatedAgo={lastUpdatedAgo}
           compact={compact}
           onToggleCompact={handleToggleCompact}
+          className="min-w-0 shrink pl-2"
         />
       </header>
 

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -217,15 +217,15 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   // so a stale (and no-longer-ticking) "Updated X ago" would be misleading.
   // Use DateTime.now() rather than nowDT so the counter resets immediately
   // after a refetch instead of waiting up to 30s for the next tick.
-  const lastUpdatedAgo =
+  const lastUpdatedDuration =
     hasSelection && dataUpdatedAt
-      ? `${formatCompactDuration(
+      ? formatCompactDuration(
           DateTime.fromMillis(dataUpdatedAt),
           DateTime.now(),
           {
             maxDays: 1,
           }
-        )} ago`
+        )
       : undefined
 
   const flatData = useMemo(() => {
@@ -502,7 +502,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
           toggleDeploymentLogsOnly={toggleDeploymentLogsOnly}
           disabled={isLoading || isFetching}
           handleRefresh={handleRefresh}
-          lastUpdatedAgo={lastUpdatedAgo}
+          lastUpdatedDuration={lastUpdatedDuration}
           compact={compact}
           onToggleCompact={handleToggleCompact}
           className="min-w-0 shrink pl-2"

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -57,6 +57,8 @@ export interface LogsSectionProps {
   setDeploymentLogsOnly: (value: boolean) => void
 }
 
+const GROUP_WINDOW_MS = 5 * 1000 // 5 seconds — chunk bursts are sub-second
+
 const styles = {
   icon: 'ml-1 my-auto flex-grow-0 mr-2 flex-shrink-0',
   emptyLogBanner:
@@ -268,7 +270,6 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   // the note text which is stored in the local `eventId` variable below) so that
   // pagination, filter changes, and list refreshes never shift a key onto a
   // different row. The same key is used for expand/collapse state.
-  const GROUP_WINDOW_MS = 5 * 1000 // 5 seconds — chunk bursts are sub-second
   type TimeoutGroup = { all: GetEventsResponse[] }
   const { processedData, timeoutGroups } = useMemo(() => {
     const groups = new Map<string, TimeoutGroup>() // key = `${repEventId}-${repUnixTime}`

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback, useRef } from 'react'
+import React, { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import { useTick } from '../lib/useTick'
 import {
   useInfiniteEvents,
@@ -86,13 +86,16 @@ const LogsSection: React.FC<LogsSectionProps> = ({
   // width where their text would wrap and increase the row height.
   const hideIcons = headerSize.width > 0 && headerSize.width < 500
 
-  const [compact, setCompact] = useState<boolean>(() => {
+  // Initialize to false so SSR and the first client render always match,
+  // then load the persisted preference after mount to avoid hydration warnings.
+  const [compact, setCompact] = useState<boolean>(false)
+  useEffect(() => {
     try {
-      return localStorage.getItem('logs:compact') === 'true'
+      if (localStorage.getItem('logs:compact') === 'true') setCompact(true)
     } catch {
-      return false
+      // localStorage unavailable (private browsing, etc.)
     }
-  })
+  }, [])
   const handleToggleCompact = useCallback(() => {
     setCompact((prev) => {
       const next = !prev
@@ -442,7 +445,6 @@ const LogsSection: React.FC<LogsSectionProps> = ({
         isUpload={isUploadEvent(item)}
         onCopy={handleCopyEventLogs}
         compact={compact}
-        component={item.name ?? undefined}
       />
     )
   }

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -96,16 +96,22 @@ const LogsSection: React.FC<LogsSectionProps> = ({
       // localStorage unavailable (private browsing, etc.)
     }
   }, [])
+  // Persist on every change; skip the initial render so we don't clobber a
+  // stored 'true' before the load effect above has applied it.
+  const compactMounted = useRef(false)
+  useEffect(() => {
+    if (!compactMounted.current) {
+      compactMounted.current = true
+      return
+    }
+    try {
+      localStorage.setItem('logs:compact', String(compact))
+    } catch {
+      // localStorage unavailable
+    }
+  }, [compact])
   const handleToggleCompact = useCallback(() => {
-    setCompact((prev) => {
-      const next = !prev
-      try {
-        localStorage.setItem('logs:compact', String(next))
-      } catch {
-        // localStorage unavailable (private browsing, etc.) — state still updates in memory
-      }
-      return next
-    })
+    setCompact((prev) => !prev)
   }, [])
 
   const [filters, setFilters] = useState<MultiValue<SelectOption>>(

--- a/apps/lrauv-dash2/components/RealTimeLogs.tsx
+++ b/apps/lrauv-dash2/components/RealTimeLogs.tsx
@@ -6,9 +6,14 @@ import { faExternalLink } from '@fortawesome/free-solid-svg-icons'
 
 export interface RealTimeLogsProps {
   vehicleName: string
+  /** When true, hides the icon inside each button to save horizontal space. */
+  hideIcons?: boolean
 }
 
-export const RealTimeLogs: React.FC<RealTimeLogsProps> = ({ vehicleName }) => {
+export const RealTimeLogs: React.FC<RealTimeLogsProps> = ({
+  vehicleName,
+  hideIcons = false,
+}) => {
   const { siteConfig } = useTethysApiContext()
 
   // Latest dataProcessed event (for Shore Log link)
@@ -53,9 +58,13 @@ export const RealTimeLogs: React.FC<RealTimeLogsProps> = ({ vehicleName }) => {
         onClick={handleShoreClick}
         disabled={!shoreUrl}
         aria-label="Open shore log file in a new browser tab"
+        title="Shore Log — open in new tab"
+        className="shrink-0 whitespace-nowrap"
       >
-        <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
-        Shore Log
+        {!hideIcons && (
+          <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
+        )}
+        Shore
       </Button>
 
       <Button
@@ -63,9 +72,13 @@ export const RealTimeLogs: React.FC<RealTimeLogsProps> = ({ vehicleName }) => {
         onClick={handleEspClick}
         disabled={!espUrl}
         aria-label="Open ESP Logs listing in a new browser tab"
+        title="ESP Log — open in new tab"
+        className="shrink-0 whitespace-nowrap"
       >
-        <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
-        ESP Log
+        {!hideIcons && (
+          <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
+        )}
+        ESP
       </Button>
     </>
   )

--- a/packages/react-ui/src/Cells/LogCell.test.tsx
+++ b/packages/react-ui/src/Cells/LogCell.test.tsx
@@ -48,16 +48,17 @@ test('does not render timeAgo element when omitted', async () => {
 
 test('applies compact padding and text size when compact is true', async () => {
   const { container } = render(<LogCell {...props} compact />)
-  const grid = container.querySelector('.grid')
-  expect(grid).toHaveClass('px-2')
-  expect(grid).toHaveClass('py-0.5')
-  expect(grid).toHaveClass('text-xs')
-  expect(grid).not.toHaveClass('p-4')
+  // Compact mode uses a flex-row layout; the inner wrapper is the direct child of article
+  const inner = container.querySelector('article > div') as HTMLElement
+  expect(inner).toHaveClass('px-2')
+  expect(inner).toHaveClass('py-0.5')
+  expect(inner).toHaveClass('text-xs')
+  expect(inner).not.toHaveClass('p-4')
 })
 
 test('applies default padding and text size when compact is false', async () => {
   const { container } = render(<LogCell {...props} compact={false} />)
-  const grid = container.querySelector('.grid')
+  const grid = container.querySelector('.grid') as HTMLElement
   expect(grid).toHaveClass('p-4')
   expect(grid).toHaveClass('text-sm')
   expect(grid).not.toHaveClass('px-2')

--- a/packages/react-ui/src/Cells/LogCell.test.tsx
+++ b/packages/react-ui/src/Cells/LogCell.test.tsx
@@ -45,3 +45,20 @@ test('does not render timeAgo element when omitted', async () => {
   render(<LogCell {...props} />)
   expect(screen.queryByLabelText(/time ago/i)).not.toBeInTheDocument()
 })
+
+test('applies compact padding and text size when compact is true', async () => {
+  const { container } = render(<LogCell {...props} compact />)
+  const grid = container.querySelector('.grid')
+  expect(grid).toHaveClass('px-2')
+  expect(grid).toHaveClass('py-0.5')
+  expect(grid).toHaveClass('text-xs')
+  expect(grid).not.toHaveClass('p-4')
+})
+
+test('applies default padding and text size when compact is false', async () => {
+  const { container } = render(<LogCell {...props} compact={false} />)
+  const grid = container.querySelector('.grid')
+  expect(grid).toHaveClass('p-4')
+  expect(grid).toHaveClass('text-sm')
+  expect(grid).not.toHaveClass('px-2')
+})

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -16,6 +16,8 @@ export interface LogCellProps {
   onCopy?: (e: React.ClipboardEvent<HTMLElement>) => void
   /** When true, reduces padding and font size for a denser log view. */
   compact?: boolean
+  /** Component or module name shown in the rightmost column of the compact table layout. */
+  component?: string
 }
 
 const styles = {
@@ -35,14 +37,60 @@ export const LogCell: React.FC<LogCellProps> = ({
   isUpload,
   onCopy,
   compact = false,
+  component,
 }) => {
+  if (compact) {
+    return (
+      <article style={style} className={clsx(styles.container, className)}>
+        <div
+          className="flex w-full select-text items-start gap-2 px-2 py-0.5 text-xs"
+          onCopy={onCopy}
+        >
+          {/* Time — flows inline when the column is wide enough, wraps when narrow */}
+          <div className="flex flex-row flex-wrap items-baseline gap-x-1.5">
+            <div className="whitespace-nowrap opacity-60" aria-label="time">
+              {time}
+            </div>
+            <div
+              className="whitespace-nowrap opacity-40 text-[10px]"
+              aria-label="date"
+            >
+              {date}
+            </div>
+            {timeAgo && (
+              <div
+                className="whitespace-nowrap opacity-40 text-[10px]"
+                aria-label="time ago"
+              >
+                {timeAgo}
+              </div>
+            )}
+          </div>
+
+          {/* Type — fixed width, never wraps */}
+          <div className="flex w-24 shrink-0 items-start gap-1">
+            <span className="mt-px" aria-label="data transmission icon">
+              {isUpload ? <UploadIcon /> : <DownloadIcon />}
+            </span>
+            <span>{label}</span>
+          </div>
+
+          {/* Description — expands to fill remaining width; collapses to one row
+              when wide enough, wraps naturally when narrow.
+              The arbitrary-child variants override the flex-col / block-span
+              patterns that formatEvent uses so content flows horizontally. */}
+          <div className="min-w-0 flex-1 whitespace-normal text-left [&>*]:!flex-row [&>*]:flex-wrap [&>*]:gap-x-1 [&_span]:!inline">
+            {typeof log === 'string' ? <span>{log}</span> : log}
+          </div>
+        </div>
+      </article>
+    )
+  }
+
   return (
     <article style={style} className={clsx(styles.container, className)}>
       <div
-        className={clsx(
-          'grid flex-grow select-text grid-cols-5 gap-2',
-          compact ? 'px-2 py-0.5 text-xs' : 'p-4 text-sm'
-        )}
+        className="grid flex-grow select-text grid-cols-5 gap-2 p-4 text-sm"
         onCopy={onCopy}
       >
         <ul className={styles.details}>

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -77,11 +77,19 @@ export const LogCell: React.FC<LogCellProps> = ({
 
           {/* Description — expands to fill remaining width; collapses to one row
               when wide enough, wraps naturally when narrow.
-              The arbitrary-child variants override the flex-col / block-span
-              patterns that formatEvent uses so content flows horizontally. */}
-          <div className="min-w-0 flex-1 whitespace-normal text-left [&>*]:!flex-row [&>*]:flex-wrap [&>*]:gap-x-1 [&_span]:!inline">
-            {typeof log === 'string' ? <span>{log}</span> : log}
-          </div>
+              String logs use whitespace-pre-line to preserve \n characters.
+              JSX element logs use whitespace-normal + arbitrary-child variants
+              to override the flex-col / block-span patterns that formatEvent
+              uses so content flows horizontally. */}
+          {typeof log === 'string' ? (
+            <span className="min-w-0 flex-1 whitespace-pre-line text-left">
+              {log}
+            </span>
+          ) : (
+            <div className="min-w-0 flex-1 whitespace-normal text-left [&>*]:!flex-row [&>*]:flex-wrap [&>*]:gap-x-1 [&_span]:!inline">
+              {log}
+            </div>
+          )}
         </div>
       </article>
     )

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -16,8 +16,6 @@ export interface LogCellProps {
   onCopy?: (e: React.ClipboardEvent<HTMLElement>) => void
   /** When true, reduces padding and font size for a denser log view. */
   compact?: boolean
-  /** Component or module name shown in the rightmost column of the compact table layout. */
-  component?: string
 }
 
 const styles = {
@@ -37,7 +35,6 @@ export const LogCell: React.FC<LogCellProps> = ({
   isUpload,
   onCopy,
   compact = false,
-  component,
 }) => {
   if (compact) {
     return (

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -66,10 +66,13 @@ export const LogCell: React.FC<LogCellProps> = ({
 
           {/* Type — fixed width, never wraps */}
           <div className="flex w-24 shrink-0 items-start gap-1">
-            <span className="mt-px" aria-label="data transmission icon">
+            <span
+              className="mt-px shrink-0"
+              aria-label="data transmission icon"
+            >
               {isUpload ? <UploadIcon /> : <DownloadIcon />}
             </span>
-            <span>{label}</span>
+            <span className="truncate">{label}</span>
           </div>
 
           {/* Description — expands to fill remaining width; collapses to one row

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -14,10 +14,12 @@ export interface LogCellProps {
   log: string | JSX.Element
   isUpload: boolean
   onCopy?: (e: React.ClipboardEvent<HTMLElement>) => void
+  /** When true, reduces padding and font size for a denser log view. */
+  compact?: boolean
 }
 
 const styles = {
-  container: 'flex bg-white font-display text-sm',
+  container: 'flex bg-white font-display',
   details: 'flex flex-col text-left col-span-2',
   log: 'flex whitespace-pre-line text-left',
 }
@@ -32,11 +34,15 @@ export const LogCell: React.FC<LogCellProps> = ({
   log,
   isUpload,
   onCopy,
+  compact = false,
 }) => {
   return (
     <article style={style} className={clsx(styles.container, className)}>
       <div
-        className="grid flex-grow select-text grid-cols-5 gap-2 p-4"
+        className={clsx(
+          'grid flex-grow select-text grid-cols-5 gap-2',
+          compact ? 'px-2 py-0.5 text-xs' : 'p-4 text-sm'
+        )}
         onCopy={onCopy}
       >
         <ul className={styles.details}>

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -90,8 +90,8 @@ const LineChart: React.FC<LineChartProps> = ({
             title: yAxisLabel,
             autorange: inverted ? 'reversed' : undefined,
           },
-          width: size.width,
-          height: size.height,
+          width: size.width || undefined,
+          height: size.height || undefined,
           margin: {
             t: title ? 28 : 0,
             b: 40,

--- a/packages/react-ui/src/Modal/Footer.tsx
+++ b/packages/react-ui/src/Modal/Footer.tsx
@@ -60,7 +60,6 @@ export const Footer: React.FC<FooterProps> = ({
               appearance="primary"
               onClick={handleConfirm ? swallow(handleConfirm) : undefined}
               disabled={disableConfirm}
-              aria-label="Confirm"
               type={form ? 'submit' : 'button'}
               form={form}
             >
@@ -74,7 +73,6 @@ export const Footer: React.FC<FooterProps> = ({
               appearance="secondary"
               onClick={swallow(handleCancel)}
               disabled={disableCancel}
-              aria-label="Cancel"
             >
               {cancelButtonText}
             </Button>

--- a/packages/react-ui/src/Navigation/Button.tsx
+++ b/packages/react-ui/src/Navigation/Button.tsx
@@ -21,6 +21,7 @@ export interface ButtonProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement>
   form?: string
   tight?: boolean
+  title?: string
   children?: React.ReactNode
 }
 
@@ -79,11 +80,13 @@ export const Button: React.FC<ButtonProps> = ({
   form,
   type = 'button',
   tight,
+  title,
 }) => {
   const isStandardButton = !['custom', 'link'].includes(appearance ?? '')
 
   return (
     <button
+      title={title}
       className={clsx(
         appearance === 'link' && styles.link,
         backgroundStyles(appearance),

--- a/packages/react-ui/src/Navigation/Button.tsx
+++ b/packages/react-ui/src/Navigation/Button.tsx
@@ -11,18 +11,12 @@ export type ButtonAppearance =
   | 'custom'
   | 'link'
 
-export interface ButtonProps {
+export interface ButtonProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'> {
   appearance?: ButtonAppearance
   align?: ButtonAlignment
-  className?: string
-  style?: React.CSSProperties
-  type?: ButtonType
-  disabled?: boolean
-  onClick?: React.MouseEventHandler<HTMLButtonElement>
-  form?: string
   tight?: boolean
-  title?: string
-  children?: React.ReactNode
+  type?: ButtonType
 }
 
 const styles = {
@@ -74,33 +68,25 @@ export const Button: React.FC<ButtonProps> = ({
   appearance = 'primary',
   children,
   className,
-  disabled,
-  style = {},
-  onClick,
-  form,
-  type = 'button',
   tight,
-  title,
+  type = 'button',
+  ...rest
 }) => {
   const isStandardButton = !['custom', 'link'].includes(appearance ?? '')
 
   return (
     <button
-      title={title}
+      type={type}
       className={clsx(
         appearance === 'link' && styles.link,
         backgroundStyles(appearance),
         alignmentStyles(align),
         isStandardButton && styles.button,
         isStandardButton && (tight ? styles.tight : styles.normal),
-        disabled && styles.disabled,
+        rest.disabled && styles.disabled,
         className
       )}
-      disabled={disabled}
-      style={style}
-      onClick={onClick}
-      form={form}
-      type={type}
+      {...rest}
     >
       {children}
     </button>

--- a/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
@@ -54,4 +54,40 @@ describe('LogsToolbar', () => {
     render(<LogsToolbar {...defaultProps} />)
     expect(screen.queryByText(/updated/i)).not.toBeInTheDocument()
   })
+
+  test('renders compact toggle button when onToggleCompact is provided', () => {
+    const onToggleCompact = jest.fn()
+    render(<LogsToolbar {...defaultProps} onToggleCompact={onToggleCompact} />)
+    expect(
+      screen.getByRole('button', { name: /compact view/i })
+    ).toBeInTheDocument()
+  })
+
+  test('compact toggle shows comfortable view label when compact is true', () => {
+    const onToggleCompact = jest.fn()
+    render(
+      <LogsToolbar
+        {...defaultProps}
+        compact
+        onToggleCompact={onToggleCompact}
+      />
+    )
+    expect(
+      screen.getByRole('button', { name: /comfortable view/i })
+    ).toBeInTheDocument()
+  })
+
+  test('calls onToggleCompact when compact toggle is clicked', () => {
+    const onToggleCompact = jest.fn()
+    render(<LogsToolbar {...defaultProps} onToggleCompact={onToggleCompact} />)
+    fireEvent.click(screen.getByRole('button', { name: /compact view/i }))
+    expect(onToggleCompact).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not render compact toggle when onToggleCompact is omitted', () => {
+    render(<LogsToolbar {...defaultProps} />)
+    expect(
+      screen.queryByRole('button', { name: /compact view/i })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
@@ -47,14 +47,15 @@ describe('LogsToolbar', () => {
     expect(defaultProps.handleRefresh).toHaveBeenCalledTimes(1)
   })
 
-  test('renders lastUpdatedAgo when provided', () => {
-    render(<LogsToolbar {...defaultProps} lastUpdatedAgo="2m ago" />)
+  test('renders lastUpdatedDuration when provided', () => {
+    render(<LogsToolbar {...defaultProps} lastUpdatedDuration="2m" />)
     // Text is split across 3 stacked spans: "Updated" / "2m" / "ago"
     expect(screen.getByText('Updated')).toBeInTheDocument()
     expect(screen.getByText('2m')).toBeInTheDocument()
+    expect(screen.getByText('ago')).toBeInTheDocument()
   })
 
-  test('does not render last-updated text when lastUpdatedAgo is omitted', () => {
+  test('does not render last-updated text when lastUpdatedDuration is omitted', () => {
     render(<LogsToolbar {...defaultProps} />)
     expect(screen.queryByText(/updated/i)).not.toBeInTheDocument()
   })

--- a/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
@@ -47,7 +47,9 @@ describe('LogsToolbar', () => {
 
   test('renders lastUpdatedAgo when provided', () => {
     render(<LogsToolbar {...defaultProps} lastUpdatedAgo="2m ago" />)
-    expect(screen.getByText(/updated 2m ago/i)).toBeInTheDocument()
+    // Text is split across 3 stacked spans: "Updated" / "2m" / "ago"
+    expect(screen.getByText('Updated')).toBeInTheDocument()
+    expect(screen.getByText('2m')).toBeInTheDocument()
   })
 
   test('does not render last-updated text when lastUpdatedAgo is omitted', () => {

--- a/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
@@ -8,9 +8,11 @@ jest.mock('../Icons', () => ({
   SubIcon: () => <div data-testid="sub-icon" />,
 }))
 
-// Mock FontAwesome icon
+// Mock FontAwesome icons
 jest.mock('@fortawesome/free-solid-svg-icons', () => ({
   faSync: 'mockFaSyncIcon',
+  faGripLines: 'mockFaGripLinesIcon',
+  faAlignJustify: 'mockFaAlignJustifyIcon',
 }))
 
 const defaultProps = {

--- a/packages/react-ui/src/Toolbars/LogsToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import clsx from 'clsx'
-import { faSync } from '@fortawesome/free-solid-svg-icons'
+import {
+  faSync,
+  faGripLines,
+  faAlignJustify,
+} from '@fortawesome/free-solid-svg-icons'
 import { IconToggle } from '../Indicators'
 import { IconButton } from '../Navigation'
 import { HistoricalListIcon, SubIcon } from '../Icons'
@@ -12,6 +16,10 @@ export interface LogsToolbarProps {
   handleRefresh: () => void
   /** Compact relative string for the last successful fetch, e.g. "2m ago". */
   lastUpdatedAgo?: string
+  /** When true, the log list is rendered in compact/dense mode. */
+  compact?: boolean
+  /** Called when the user toggles compact mode. */
+  onToggleCompact?: () => void
   className?: string
 }
 
@@ -21,6 +29,8 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   disabled,
   handleRefresh,
   lastUpdatedAgo,
+  compact = false,
+  onToggleCompact,
   className,
 }) => (
   <div className={clsx('flex items-center gap-3', className)}>
@@ -59,6 +69,24 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
       <span className="text-xs text-stone-400" aria-live="polite">
         Updated {lastUpdatedAgo}
       </span>
+    )}
+
+    {onToggleCompact && (
+      <IconButton
+        icon={compact ? faAlignJustify : faGripLines}
+        ariaLabel={compact ? 'comfortable view' : 'compact view'}
+        tooltipAlignment="right"
+        tooltip={
+          compact ? 'Switch to comfortable view' : 'Switch to compact view'
+        }
+        onClick={onToggleCompact}
+        size="text-md"
+        iconClassName={clsx(
+          'text-xl',
+          compact ? 'text-blue-500' : 'text-gray-400'
+        )}
+        className="flex items-center justify-center"
+      />
     )}
 
     <IconButton

--- a/packages/react-ui/src/Toolbars/LogsToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.tsx
@@ -33,7 +33,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   onToggleCompact,
   className,
 }) => (
-  <div className={clsx('flex items-center gap-3', className)}>
+  <div className={clsx('flex items-center gap-2', className)}>
     <IconToggle
       iconLeft={
         <HistoricalListIcon
@@ -61,14 +61,19 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
       tooltipAlignment="right"
       ariaLabelLeft="Displaying all logs"
       ariaLabelRight="Displaying deployment logs"
-      className="mr-4"
+      className="mr-2"
       disabled={disabled}
     />
 
     {lastUpdatedAgo && (
-      <span className="text-xs text-stone-400" aria-live="polite">
-        Updated {lastUpdatedAgo}
-      </span>
+      <div
+        className="flex flex-col items-center text-[9px] leading-tight text-stone-400"
+        aria-live="polite"
+      >
+        <span>Updated</span>
+        <span>{lastUpdatedAgo.replace(/ ago$/, '')}</span>
+        <span>ago</span>
+      </div>
     )}
 
     {onToggleCompact && (
@@ -98,7 +103,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
       onClick={handleRefresh}
       size="text-md"
       iconClassName="text-xl"
-      className="flex items-center justify-center rounded-full border-2 border-blue-400 text-blue-400"
+      className="flex shrink-0 items-center justify-center rounded-full border-2 border-blue-400 text-blue-400"
     />
   </div>
 )

--- a/packages/react-ui/src/Toolbars/LogsToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.tsx
@@ -79,12 +79,15 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
     {onToggleCompact && (
       <IconButton
         icon={compact ? faAlignJustify : faGripLines}
-        ariaLabel={compact ? 'comfortable view' : 'compact view'}
+        ariaLabel={
+          compact ? 'Switch to comfortable view' : 'Switch to compact view'
+        }
         tooltipAlignment="right"
         tooltip={
           compact ? 'Switch to comfortable view' : 'Switch to compact view'
         }
         onClick={onToggleCompact}
+        disabled={disabled}
         size="text-md"
         iconClassName={clsx(
           'text-xl',

--- a/packages/react-ui/src/Toolbars/LogsToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.tsx
@@ -14,8 +14,8 @@ export interface LogsToolbarProps {
   toggleDeploymentLogsOnly: () => void
   disabled: boolean
   handleRefresh: () => void
-  /** Compact relative string for the last successful fetch, e.g. "2m ago". */
-  lastUpdatedAgo?: string
+  /** Duration since the last successful fetch, e.g. "2m". The component renders this as "Updated 2m ago". */
+  lastUpdatedDuration?: string
   /** When true, the log list is rendered in compact/dense mode. */
   compact?: boolean
   /** Called when the user toggles compact mode. */
@@ -28,7 +28,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   toggleDeploymentLogsOnly,
   disabled,
   handleRefresh,
-  lastUpdatedAgo,
+  lastUpdatedDuration,
   compact = false,
   onToggleCompact,
   className,
@@ -65,13 +65,13 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
       disabled={disabled}
     />
 
-    {lastUpdatedAgo && (
+    {lastUpdatedDuration && (
       <div
         className="flex flex-col items-center text-[9px] leading-tight text-stone-400"
         aria-live="polite"
       >
         <span>Updated</span>
-        <span>{lastUpdatedAgo.replace(/ ago$/, '')}</span>
+        <span>{lastUpdatedDuration}</span>
         <span>ago</span>
       </div>
     )}

--- a/packages/utils/src/formatCompactDuration.test.ts
+++ b/packages/utils/src/formatCompactDuration.test.ts
@@ -2,9 +2,15 @@ import { DateTime } from 'luxon'
 import { formatCompactDuration } from './formatCompactDuration'
 
 describe('formatCompactDuration', () => {
-  it('returns 0m for equal times', () => {
+  it('returns 0s for equal times', () => {
     const t = DateTime.fromISO('2024-01-01T00:00:00')
-    expect(formatCompactDuration(t, t)).toBe('0m')
+    expect(formatCompactDuration(t, t)).toBe('0s')
+  })
+
+  it('formats seconds for sub-minute durations', () => {
+    const ref = DateTime.fromISO('2024-01-01T00:00:00')
+    const target = ref.plus({ seconds: 45 })
+    expect(formatCompactDuration(target, ref)).toBe('45s')
   })
 
   it('formats minutes-only differences', () => {

--- a/packages/utils/src/formatCompactDuration.ts
+++ b/packages/utils/src/formatCompactDuration.ts
@@ -31,15 +31,23 @@ export const formatCompactDuration = (
     return `${d + (h >= 12 ? 1 : 0)}d`
   }
 
-  const diff = later.diff(earlier, ['days', 'hours', 'minutes']).toObject()
+  const diff = later
+    .diff(earlier, ['days', 'hours', 'minutes', 'seconds'])
+    .toObject()
   const days = Math.trunc(diff.days ?? 0)
   const hours = Math.trunc(diff.hours ?? 0)
   const minutes = Math.trunc(diff.minutes ?? 0)
+  const seconds = Math.trunc(diff.seconds ?? 0)
 
   const parts: string[] = []
   if (days > 0) parts.push(`${days}d`)
   if (hours > 0 || days > 0) parts.push(`${hours}h`)
-  if (minutes > 0 || (days === 0 && hours === 0)) parts.push(`${minutes}m`)
+  // Sub-minute: show seconds instead of "0m"
+  if (days === 0 && hours === 0 && minutes === 0) {
+    parts.push(`${seconds}s`)
+  } else if (minutes > 0 || (days === 0 && hours === 0)) {
+    parts.push(`${minutes}m`)
+  }
 
   return parts.join(' ')
 }


### PR DESCRIPTION
## Summary

Addresses [#626](https://github.com/mbari-org/dash5/issues/626) — Monique reported seeing ~3× fewer log entries than Dash4 at the same screen size.

Rather than changing the default spacing for all users, this adds a **compact mode toggle** in the logs toolbar so each user can choose their preferred density. The preference is persisted in `localStorage` so it survives page reloads.

This PR also addresses header-button overflow at narrow log-panel widths — buttons no longer grow in height or wrap their text when the panel is dragged narrow.

## Changes

### `LogCell.tsx` (`@mbari/react-ui`)
- Added `compact?: boolean` prop
- When `compact={true}`: `px-2 py-0.5 text-xs` tight rows with a flex-row layout (Time · Type · Description)
- When `compact={false}` (default): `p-4 text-sm` existing comfortable spacing — no change for current users
- In compact mode the Time column flows inline and wraps gracefully; the Description column collapses to one row when width allows

### `LogsToolbar.tsx` (`@mbari/react-ui`)
- Added `compact?: boolean` and `onToggleCompact?: () => void` props
- Renders a `faGripLines` / `faAlignJustify` icon button when `onToggleCompact` is provided; respects the toolbar `disabled` state
- Icon is highlighted blue when compact mode is active; aria-label describes the action ("Switch to compact view" / "Switch to comfortable view")
- "Updated X ago" is now stacked vertically (three small spans) to save horizontal space
- Button is hidden when no handler is wired (backward compatible)

### `RealTimeLogs.tsx`
- "Shore Log" and "ESP Log" buttons are intentionally shortened to "Shore" and "ESP" at all widths (per explicit user request). Full labels are shown on hover via `title` tooltips.
- Icons are conditionally hidden when the header becomes narrow (`hideIcons` prop) so buttons never grow in height

### `LogsSection.tsx`
- Initialises `compact` state to `false` (SSR-safe); loads the persisted value from `localStorage` (`logs:compact`) in a `useEffect` after mount to avoid hydration mismatches
- Persists preference on every toggle via a separate `useEffect` with a mount-guard ref to prevent overwriting the stored value before it is read
- Passes `compact` / `onToggleCompact` to `LogsToolbar` and `compact` to each `LogCell`
- Uses `useResizeObserver` to derive `hideIcons` from header width and passes it to the Filter button and `RealTimeLogs`

### `Button.tsx` (`@mbari/react-ui`)
- Extends `React.ButtonHTMLAttributes` and spreads `...rest` onto the native element so all standard HTML attributes (`title`, `aria-label`, `data-*`, etc.) are forwarded without explicit prop definitions
- **Note**: this exposed stale `aria-label="Confirm"` / `aria-label="Cancel"` props in `Footer.tsx` that were previously silently dropped; those were removed so the dynamic confirm-button text (e.g. "Schedule Brizo") remains the accessible name

### `formatCompactDuration.ts` (`@mbari/utils`)
- Now returns seconds for sub-minute durations (e.g. "5s" instead of "0m")

## Test plan
- [ ] Open the Logs panel — spacing matches today's default (no regression)
- [ ] Click the compact toggle (grip-lines icon) — rows tighten noticeably and the icon turns blue
- [ ] Click again — rows return to comfortable spacing
- [ ] Reload the page — compact preference is remembered
- [ ] Drag the log panel narrow — icons in the header disappear before any button grows in height
- [ ] Hover over the Shore/ESP buttons — tooltip shows "Shore Log — open in new tab" full text
- [ ] Verify timeout-group badges, expand/collapse controls, and `timeAgo` chips still render correctly in compact mode
