### PR TITLE
feat(#633): prompt PIC for hours piloted on sign-off

### DIFF
--- a/apps/lrauv-dash2/components/Reassignment.tsx
+++ b/apps/lrauv-dash2/components/Reassignment.tsx
@@ -1,6 +1,8 @@
+import React, { useState } from 'react'
 import {
   useVehiclePicAndOnCall,
   useAssignPicAndOnCall,
+  useCreateNote,
 } from '@mbari/api-client'
 import {
   ReassignmentModal,
@@ -13,6 +15,11 @@ import { capitalize } from '@mbari/utils'
 import { useQueryClient } from 'react-query'
 import { useTethysApiContext } from '@mbari/api-client'
 import toast from 'react-hot-toast'
+
+interface PendingSignOff {
+  vehicleName: string
+  hours: string
+}
 
 const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
   vehicleNames,
@@ -31,41 +38,90 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
 
   const { mutate: assignPicAndOnCall, isLoading: loadingAssignPicAndOnCall } =
     useAssignPicAndOnCall()
+  const { mutate: createNote } = useCreateNote()
 
-  const handleRoleChange = async (
+  // When signing off as PIC, capture the vehicle name and prompt for hours.
+  const [pendingSignOff, setPendingSignOff] = useState<PendingSignOff | null>(
+    null
+  )
+
+  const doSignOff = (vehicleName: string, hours: string) => {
+    if (!profile?.email) return
+    assignPicAndOnCall(
+      {
+        vehicleName: vehicleName.toLowerCase(),
+        email: profile.email,
+        sign: 'off',
+        subRole: 'PIC',
+      },
+      {
+        onSuccess: () => {
+          toast.success(`Successfully signed off as PIC for ${vehicleName}`)
+          queryClient.invalidateQueries(['users', 'picAndOnCall'])
+          queryClient.invalidateQueries(['users', 'role'])
+
+          const h = parseFloat(hours)
+          if (!isNaN(h) && h > 0) {
+            createNote(
+              {
+                vehicle: vehicleName.toLowerCase(),
+                note: `PIC watchstanding: ${h}h`,
+              },
+              {
+                onError: () =>
+                  toast.error(
+                    'Signed off, but could not record piloting hours'
+                  ),
+              }
+            )
+          }
+        },
+        onError: () => {
+          toast.error(`Failed to sign off as PIC for ${vehicleName}`)
+        },
+      }
+    )
+  }
+
+  const handleRoleChange = (
     vehicleName: string,
     roleChangeType: RoleChangeType,
     isPic: boolean
   ) => {
-    if (profile?.email) {
-      assignPicAndOnCall(
-        {
-          vehicleName: vehicleName.toLowerCase(),
-          email: profile.email,
-          sign: roleChangeType,
-          subRole: isPic ? 'PIC' : 'On-Call',
-        },
-        {
-          onSuccess: () => {
-            toast.success(
-              `Successfully ${
-                roleChangeType === 'in' ? 'signed in' : 'signed off'
-              } as ${isPic ? 'PIC' : 'On-Call'} for ${vehicleName}`
-            )
+    if (!profile?.email) return
 
-            queryClient.invalidateQueries(['users', 'picAndOnCall'])
-            queryClient.invalidateQueries(['users', 'role'])
-          },
-          onError: () => {
-            toast.error(
-              `Failed to ${
-                roleChangeType === 'in' ? 'sign in' : 'sign off'
-              } as ${isPic ? 'PIC' : 'On-Call'} for ${vehicleName}`
-            )
-          },
-        }
-      )
+    // For PIC sign-off only, prompt for hours piloted before submitting.
+    if (isPic && roleChangeType === 'off') {
+      setPendingSignOff({ vehicleName, hours: '8' })
+      return
     }
+
+    assignPicAndOnCall(
+      {
+        vehicleName: vehicleName.toLowerCase(),
+        email: profile.email,
+        sign: roleChangeType,
+        subRole: isPic ? 'PIC' : 'On-Call',
+      },
+      {
+        onSuccess: () => {
+          toast.success(
+            `Successfully ${
+              roleChangeType === 'in' ? 'signed in' : 'signed off'
+            } as ${isPic ? 'PIC' : 'On-Call'} for ${vehicleName}`
+          )
+          queryClient.invalidateQueries(['users', 'picAndOnCall'])
+          queryClient.invalidateQueries(['users', 'role'])
+        },
+        onError: () => {
+          toast.error(
+            `Failed to ${roleChangeType === 'in' ? 'sign in' : 'sign off'} as ${
+              isPic ? 'PIC' : 'On-Call'
+            } for ${vehicleName}`
+          )
+        },
+      }
+    )
   }
 
   const vehicleData: ReassignmentTableProps['vehicles'] =
@@ -76,14 +132,71 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
     })) || []
 
   return (
-    <ReassignmentModal
-      onClose={handleClose}
-      vehicles={vehicleData}
-      currentUserName={currentUserName}
-      onRoleChange={handleRoleChange}
-      isLoading={isLoading || loadingAssignPicAndOnCall}
-      open
-    />
+    <>
+      <ReassignmentModal
+        onClose={handleClose}
+        vehicles={vehicleData}
+        currentUserName={currentUserName}
+        onRoleChange={handleRoleChange}
+        isLoading={isLoading || loadingAssignPicAndOnCall}
+        open
+      />
+
+      {pendingSignOff && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="pic-signoff-title"
+          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40"
+        >
+          <div className="w-80 rounded-lg bg-white p-6 shadow-xl">
+            <h2
+              id="pic-signoff-title"
+              className="mb-4 text-base font-semibold text-gray-800"
+            >
+              Sign off as PIC — {pendingSignOff.vehicleName}
+            </h2>
+            <label
+              htmlFor="pic-hours"
+              className="mb-1 block text-sm text-gray-600"
+            >
+              Hours piloted <span className="text-gray-400">(optional)</span>
+            </label>
+            <input
+              id="pic-hours"
+              type="number"
+              min="0"
+              step="0.5"
+              value={pendingSignOff.hours}
+              onChange={(e) =>
+                setPendingSignOff({ ...pendingSignOff, hours: e.target.value })
+              }
+              className="mb-5 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+              autoFocus
+            />
+            <div className="flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={() => setPendingSignOff(null)}
+                className="rounded px-4 py-2 text-sm text-gray-600 hover:bg-gray-100"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  doSignOff(pendingSignOff.vehicleName, pendingSignOff.hours)
+                  setPendingSignOff(null)
+                }}
+                className="rounded bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600"
+              >
+                Sign off
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   )
 }
 

--- a/apps/lrauv-dash2/components/Reassignment.tsx
+++ b/apps/lrauv-dash2/components/Reassignment.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import {
   useVehiclePicAndOnCall,
   useAssignPicAndOnCall,
 } from '@mbari/api-client'
 import {
+  Modal,
   ReassignmentModal,
   ReassignmentTableProps,
   RoleChangeType,
@@ -52,6 +53,15 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
   const [pendingSignOff, setPendingSignOff] = useState<PendingSignOff | null>(
     null
   )
+
+  const hoursError = useMemo(() => {
+    if (!pendingSignOff || pendingSignOff.hours === '') return null
+    const h = parseFloat(pendingSignOff.hours)
+    if (isNaN(h)) return 'Please enter a valid number'
+    if (h < 0) return 'Hours cannot be negative'
+    if (h > 24) return 'A single watch cannot exceed 24 hours'
+    return null
+  }, [pendingSignOff])
 
   /** Round elapsed ms to the nearest 0.5h, formatted as a string. */
   const elapsedHours = (sinceMs: number): string => {
@@ -155,60 +165,43 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
         open
       />
 
-      {pendingSignOff && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-labelledby="pic-signoff-title"
-          className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40"
-        >
-          <div className="w-80 rounded-lg bg-white p-6 shadow-xl">
-            <h2
-              id="pic-signoff-title"
-              className="mb-4 text-base font-semibold text-gray-800"
-            >
-              Sign off as PIC — {pendingSignOff.vehicleName}
-            </h2>
-            <label
-              htmlFor="pic-hours"
-              className="mb-1 block text-sm text-gray-600"
-            >
+      <Modal
+        title={`Sign off as PIC — ${pendingSignOff?.vehicleName ?? ''}`}
+        open={!!pendingSignOff}
+        zIndex="z-[9999]"
+        onClose={() => setPendingSignOff(null)}
+        onCancel={() => setPendingSignOff(null)}
+        onConfirm={() => {
+          if (!pendingSignOff) return
+          doSignOff(pendingSignOff.vehicleName, pendingSignOff.hours)
+          setPendingSignOff(null)
+        }}
+        confirmButtonText="Sign off"
+        cancelButtonText="Cancel"
+        disableConfirm={!!hoursError}
+      >
+        {pendingSignOff && (
+          <div className="flex flex-col gap-1">
+            <label htmlFor="pic-hours" className="text-sm text-gray-600">
               Hours piloted <span className="text-gray-400">(optional)</span>
             </label>
             <input
               id="pic-hours"
               type="number"
               min="0"
+              max="24"
               step="0.5"
               value={pendingSignOff.hours}
               onChange={(e) =>
                 setPendingSignOff({ ...pendingSignOff, hours: e.target.value })
               }
-              className="mb-5 w-full rounded border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
               autoFocus
             />
-            <div className="flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={() => setPendingSignOff(null)}
-                className="rounded px-4 py-2 text-sm text-gray-600 hover:bg-gray-100"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  doSignOff(pendingSignOff.vehicleName, pendingSignOff.hours)
-                  setPendingSignOff(null)
-                }}
-                className="rounded bg-blue-500 px-4 py-2 text-sm text-white hover:bg-blue-600"
-              >
-                Sign off
-              </button>
-            </div>
+            {hoursError && <p className="text-xs text-red-500">{hoursError}</p>}
           </div>
-        </div>
-      )}
+        )}
+      </Modal>
     </>
   )
 }

--- a/apps/lrauv-dash2/components/Reassignment.tsx
+++ b/apps/lrauv-dash2/components/Reassignment.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import {
   useVehiclePicAndOnCall,
   useAssignPicAndOnCall,
-  useCreateNote,
 } from '@mbari/api-client'
 import {
   ReassignmentModal,
@@ -19,6 +18,15 @@ import toast from 'react-hot-toast'
 interface PendingSignOff {
   vehicleName: string
   hours: string
+}
+
+/** Convert decimal hours to ISO 8601 duration, e.g. 8.5 → "PT8H30M" */
+const toWatchDuration = (hours: string): string | undefined => {
+  const h = parseFloat(hours)
+  if (isNaN(h) || h <= 0) return undefined
+  const wholeHours = Math.floor(h)
+  const minutes = Math.round((h - wholeHours) * 60)
+  return `PT${wholeHours}H${minutes}M`
 }
 
 const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
@@ -38,7 +46,6 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
 
   const { mutate: assignPicAndOnCall, isLoading: loadingAssignPicAndOnCall } =
     useAssignPicAndOnCall()
-  const { mutate: createNote } = useCreateNote()
 
   // When signing off as PIC, capture the vehicle name and prompt for hours.
   const [pendingSignOff, setPendingSignOff] = useState<PendingSignOff | null>(
@@ -53,28 +60,13 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
         email: profile.email,
         sign: 'off',
         subRole: 'PIC',
+        watchDuration: toWatchDuration(hours),
       },
       {
         onSuccess: () => {
           toast.success(`Successfully signed off as PIC for ${vehicleName}`)
           queryClient.invalidateQueries(['users', 'picAndOnCall'])
           queryClient.invalidateQueries(['users', 'role'])
-
-          const h = parseFloat(hours)
-          if (!isNaN(h) && h > 0) {
-            createNote(
-              {
-                vehicle: vehicleName.toLowerCase(),
-                note: `PIC watchstanding: ${h}h`,
-              },
-              {
-                onError: () =>
-                  toast.error(
-                    'Signed off, but could not record piloting hours'
-                  ),
-              }
-            )
-          }
         },
         onError: () => {
           toast.error(`Failed to sign off as PIC for ${vehicleName}`)

--- a/apps/lrauv-dash2/components/Reassignment.tsx
+++ b/apps/lrauv-dash2/components/Reassignment.tsx
@@ -13,6 +13,7 @@ import useGlobalModalId from '../lib/useGlobalModalId'
 import { capitalize } from '@mbari/utils'
 import { useQueryClient } from 'react-query'
 import { useTethysApiContext } from '@mbari/api-client'
+import { DateTime } from 'luxon'
 import toast from 'react-hot-toast'
 
 interface PendingSignOff {
@@ -52,6 +53,12 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
     null
   )
 
+  /** Round elapsed ms to the nearest 0.5h, formatted as a string. */
+  const elapsedHours = (sinceMs: number): string => {
+    const raw = sinceMs / 3_600_000
+    return (Math.round(raw * 2) / 2).toFixed(1).replace(/\.0$/, '')
+  }
+
   const doSignOff = (vehicleName: string, hours: string) => {
     if (!profile?.email) return
     assignPicAndOnCall(
@@ -83,8 +90,16 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
     if (!profile?.email) return
 
     // For PIC sign-off only, prompt for hours piloted before submitting.
+    // Pre-fill with actual elapsed time since sign-in, rounded to nearest 0.5h.
     if (isPic && roleChangeType === 'off') {
-      setPendingSignOff({ vehicleName, hours: '8' })
+      const vehicleData = data?.find(
+        (v) => v.vehicleName.toLowerCase() === vehicleName.toLowerCase()
+      )
+      const picEntry = vehicleData?.pics.find((p) => p.user === currentUserName)
+      const hours = picEntry
+        ? elapsedHours(DateTime.now().toMillis() - picEntry.unixTime)
+        : '8'
+      setPendingSignOff({ vehicleName, hours })
       return
     }
 
@@ -119,8 +134,14 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
   const vehicleData: ReassignmentTableProps['vehicles'] =
     data?.map((v) => ({
       name: capitalize(v.vehicleName),
-      picOperators: v.pics.map((pic) => pic.user),
-      onCallOperators: v.onCalls.map((onCall) => onCall.user),
+      picOperators: v.pics.map((pic) => ({
+        user: pic.user,
+        unixTime: pic.unixTime,
+      })),
+      onCallOperators: v.onCalls.map((onCall) => ({
+        user: onCall.user,
+        unixTime: onCall.unixTime,
+      })),
     })) || []
 
   return (

--- a/apps/lrauv-dash2/components/Reassignment.tsx
+++ b/apps/lrauv-dash2/components/Reassignment.tsx
@@ -106,9 +106,10 @@ const Reassignment: React.FC<{ vehicleNames: string[] }> = ({
         (v) => v.vehicleName.toLowerCase() === vehicleName.toLowerCase()
       )
       const picEntry = vehicleData?.pics.find((p) => p.user === currentUserName)
+      // Leave blank if sign-in time is unavailable — avoid fabricating a duration.
       const hours = picEntry
         ? elapsedHours(DateTime.now().toMillis() - picEntry.unixTime)
-        : '8'
+        : ''
       setPendingSignOff({ vehicleName, hours })
       return
     }

--- a/apps/lrauv-dash2/components/ScienceDataSection.tsx
+++ b/apps/lrauv-dash2/components/ScienceDataSection.tsx
@@ -160,13 +160,12 @@ const ScienceDataSection: React.FC<{
             <div className="m-2 rounded bg-red-200 p-2 text-red-700">
               <p className="font-bold">
                 Vehicle and Science data could not be processed for this
-                mission.
+                dataset.
               </p>
               <p className="mt-1">
                 This may be caused by invalid or malformed data in{' '}
                 <span className="font-mono font-bold">chartData2.json</span>.
-                Please ask your TethysDash administrator to reprocess this
-                mission.
+                Please ask a TethysDash administrator to reprocess this dataset.
               </p>
               {(error as Error)?.message && (
                 <p className="mt-1 font-mono text-xs opacity-75">

--- a/packages/api-client/src/axios/User/assignPicAndOnCall.ts
+++ b/packages/api-client/src/axios/User/assignPicAndOnCall.ts
@@ -7,6 +7,8 @@ export interface AssignPicAndOnCallParams {
   email?: string
   sign: 'in' | 'off'
   subRole: 'PIC' | 'On-Call'
+  /** ISO 8601 duration for time spent piloting, e.g. "PT8H0M". Only sent on PIC sign-off. */
+  watchDuration?: string
 }
 
 export interface AssignPicAndOnCallResponse {

--- a/packages/api-client/src/react-query/Event/useChartData.tsx
+++ b/packages/api-client/src/react-query/Event/useChartData.tsx
@@ -74,7 +74,7 @@ export const useChartData = (
       const chartData = (parsed as { chartData?: unknown })?.chartData
       if (!Array.isArray(chartData)) {
         throw new Error(
-          `chartData2.json for ${vehicle} returned invalid data — TethysDash may need to reprocess this mission.`
+          `chartData2.json for ${vehicle} returned invalid data — please ask a TethysDash administrator to reprocess this dataset.`
         )
       }
       return chartData as ChartData[]

--- a/packages/react-ui/src/Cells/ReassignmentCell.stories.tsx
+++ b/packages/react-ui/src/Cells/ReassignmentCell.stories.tsx
@@ -13,8 +13,10 @@ const Template: Story<ReassignmentCellProps> = (args) => (
   </div>
 )
 
+const makeOp = (user: string) => ({ user, unixTime: Date.now() - 2 * 3600_000 })
+
 const args: ReassignmentCellProps = {
-  operators: ['John Doe', 'Jane Smith'],
+  operators: [makeOp('John Doe'), makeOp('Jane Smith')],
   currentUserName: 'John Doe',
   onSignIn: () => console.log('Sign in clicked'),
   onSignOut: () => console.log('Sign out clicked'),

--- a/packages/react-ui/src/Cells/ReassignmentCell.test.tsx
+++ b/packages/react-ui/src/Cells/ReassignmentCell.test.tsx
@@ -50,7 +50,7 @@ describe('ReassignmentCell', () => {
     )
 
     const currentUserElement = screen.getByText('Jane Doe')
-    expect(currentUserElement).toHaveClass('text-teal-500')
+    expect(currentUserElement).toHaveClass('text-primary-600')
   })
 
   test('should show elapsed time for current user when showElapsed is true', () => {

--- a/packages/react-ui/src/Cells/ReassignmentCell.test.tsx
+++ b/packages/react-ui/src/Cells/ReassignmentCell.test.tsx
@@ -27,11 +27,13 @@ describe('ReassignmentCell', () => {
     expect(screen.getByText('Join')).toBeInTheDocument()
   })
 
+  const makeOp = (user: string) => ({ user, unixTime: Date.now() })
+
   test('should display operator names when operators are provided', () => {
     render(
       <ReassignmentCell
         {...defaultProps}
-        operators={['John Smith', 'Bob Johnson']}
+        operators={[makeOp('John Smith'), makeOp('Bob Johnson')]}
       />
     )
 
@@ -43,7 +45,7 @@ describe('ReassignmentCell', () => {
     render(
       <ReassignmentCell
         {...defaultProps}
-        operators={['John Smith', 'Jane Doe']}
+        operators={[makeOp('John Smith'), makeOp('Jane Doe')]}
       />
     )
 

--- a/packages/react-ui/src/Cells/ReassignmentCell.test.tsx
+++ b/packages/react-ui/src/Cells/ReassignmentCell.test.tsx
@@ -52,4 +52,48 @@ describe('ReassignmentCell', () => {
     const currentUserElement = screen.getByText('Jane Doe')
     expect(currentUserElement).toHaveClass('text-teal-500')
   })
+
+  test('should show elapsed time for current user when showElapsed is true', () => {
+    const TWO_HOURS_MS = 2 * 60 * 60 * 1000
+    const signInTime = Date.now() - TWO_HOURS_MS
+
+    render(
+      <ReassignmentCell
+        {...defaultProps}
+        operators={[{ user: 'Jane Doe', unixTime: signInTime }]}
+        showElapsed
+      />
+    )
+
+    expect(screen.getByText(/signed in 2h 0m/)).toBeInTheDocument()
+  })
+
+  test('should not show elapsed time when showElapsed is false', () => {
+    const signInTime = Date.now() - 2 * 60 * 60 * 1000
+
+    render(
+      <ReassignmentCell
+        {...defaultProps}
+        operators={[{ user: 'Jane Doe', unixTime: signInTime }]}
+        showElapsed={false}
+      />
+    )
+
+    expect(screen.queryByText(/signed in/)).not.toBeInTheDocument()
+  })
+
+  test('should show elapsed time in minutes only when under one hour', () => {
+    const FORTY_FIVE_MIN_MS = 45 * 60 * 1000
+    const signInTime = Date.now() - FORTY_FIVE_MIN_MS
+
+    render(
+      <ReassignmentCell
+        {...defaultProps}
+        operators={[{ user: 'Jane Doe', unixTime: signInTime }]}
+        showElapsed
+      />
+    )
+
+    expect(screen.getByText(/signed in 45m/)).toBeInTheDocument()
+  })
 })

--- a/packages/react-ui/src/Cells/ReassignmentCell.tsx
+++ b/packages/react-ui/src/Cells/ReassignmentCell.tsx
@@ -58,12 +58,16 @@ export const ReassignmentCell: React.FC<ReassignmentCellProps> = ({
   const otherOperators = operators.filter((op) => op.user !== currentUserName)
 
   // Tick every minute so the elapsed label stays live while the modal is open.
+  // Depend on primitives (not the object reference) so the interval is not
+  // recreated on every parent re-render caused by React Query refetches.
   const [now, setNow] = useState(() => Date.now())
+  const signInUnixTime = currentUserEntry?.unixTime
+  const signInUser = currentUserEntry?.user
   useEffect(() => {
-    if (!showElapsed || !currentUserEntry) return
+    if (!showElapsed || !signInUnixTime || !signInUser) return
     const id = setInterval(() => setNow(Date.now()), 60_000)
     return () => clearInterval(id)
-  }, [showElapsed, currentUserEntry])
+  }, [showElapsed, signInUnixTime, signInUser])
 
   const elapsedLabel = (() => {
     if (!showElapsed || !currentUserEntry) return null

--- a/packages/react-ui/src/Cells/ReassignmentCell.tsx
+++ b/packages/react-ui/src/Cells/ReassignmentCell.tsx
@@ -1,9 +1,8 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { faXmark } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button } from '../Navigation/Button'
 import clsx from 'clsx'
-import { DateTime } from 'luxon'
 
 export interface ReassignmentOperator {
   user: string
@@ -58,12 +57,20 @@ export const ReassignmentCell: React.FC<ReassignmentCellProps> = ({
   const currentUserEntry = operators.find((op) => op.user === currentUserName)
   const otherOperators = operators.filter((op) => op.user !== currentUserName)
 
-  const elapsedLabel = React.useMemo(() => {
+  // Tick every minute so the elapsed label stays live while the modal is open.
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!showElapsed || !currentUserEntry) return
+    const id = setInterval(() => setNow(Date.now()), 60_000)
+    return () => clearInterval(id)
+  }, [showElapsed, currentUserEntry])
+
+  const elapsedLabel = (() => {
     if (!showElapsed || !currentUserEntry) return null
-    const elapsed = DateTime.now().toMillis() - currentUserEntry.unixTime
+    const elapsed = now - currentUserEntry.unixTime
     if (elapsed < 0) return null
     return `(signed in ${formatElapsed(elapsed)})`
-  }, [showElapsed, currentUserEntry])
+  })()
 
   return (
     <ul className={clsx(styles.container, className)} style={style}>

--- a/packages/react-ui/src/Cells/ReassignmentCell.tsx
+++ b/packages/react-ui/src/Cells/ReassignmentCell.tsx
@@ -26,8 +26,9 @@ export interface ReassignmentCellProps {
 
 const styles = {
   container: 'flex w-fit flex-col items-start font-display list-none gap-0.5',
-  signInButton: 'text-primary-600 hover:text-black mt-1.5',
-  currentUser: 'mr-1 text-teal-500',
+  signInButton: 'text-stone-500 hover:text-stone-800 mt-1.5',
+  currentUser: 'mr-1 text-primary-600',
+  otherOperator: 'text-primary-600',
 }
 
 /** Format elapsed ms as "Xh Ym" or "Ym" for durations under 1 hour. */
@@ -68,7 +69,7 @@ export const ReassignmentCell: React.FC<ReassignmentCellProps> = ({
     <ul className={clsx(styles.container, className)} style={style}>
       {!operators.length && <li className="italic text-stone-300">No one</li>}
       {otherOperators.map((op) => (
-        <li key={op.user} className="text-stone-500/80">
+        <li key={op.user} className={styles.otherOperator}>
           {op.user}
         </li>
       ))}

--- a/packages/react-ui/src/Cells/ReassignmentCell.tsx
+++ b/packages/react-ui/src/Cells/ReassignmentCell.tsx
@@ -1,24 +1,42 @@
+import React from 'react'
 import { faXmark } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { Button } from '../Navigation/Button'
 import clsx from 'clsx'
+import { DateTime } from 'luxon'
+
+export interface ReassignmentOperator {
+  user: string
+  unixTime: number
+}
 
 export interface ReassignmentCellProps {
   className?: string
   style?: React.CSSProperties
   isLoading?: boolean
-  operators: string[]
+  operators: ReassignmentOperator[]
   currentUserName: string
   onSignIn: () => void
   onSignOut: () => void
   signInAriaLabel?: string
   signOutAriaLabel?: string
+  /** When true, shows elapsed watch time next to the current user's name. */
+  showElapsed?: boolean
 }
 
 const styles = {
   container: 'flex w-fit flex-col items-start font-display list-none gap-0.5',
   signInButton: 'text-primary-600 hover:text-black mt-1.5',
   currentUser: 'mr-1 text-teal-500',
+}
+
+/** Format elapsed ms as "Xh Ym" or "Ym" for durations under 1 hour. */
+const formatElapsed = (sinceMs: number): string => {
+  const totalMinutes = Math.floor(sinceMs / 60_000)
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+  if (hours > 0) return `${hours}h ${minutes}m`
+  return `${minutes}m`
 }
 
 export const ReassignmentCell: React.FC<ReassignmentCellProps> = ({
@@ -31,37 +49,52 @@ export const ReassignmentCell: React.FC<ReassignmentCellProps> = ({
   onSignOut,
   signInAriaLabel,
   signOutAriaLabel,
+  showElapsed = false,
 }) => {
-  const isCurrentUserInList = operators.includes(currentUserName)
-  const operatorsList = operators.filter((op) => op !== currentUserName)
+  const isCurrentUserInList = operators.some(
+    (op) => op.user === currentUserName
+  )
+  const currentUserEntry = operators.find((op) => op.user === currentUserName)
+  const otherOperators = operators.filter((op) => op.user !== currentUserName)
+
+  const elapsedLabel = React.useMemo(() => {
+    if (!showElapsed || !currentUserEntry) return null
+    const elapsed = DateTime.now().toMillis() - currentUserEntry.unixTime
+    if (elapsed < 0) return null
+    return `(signed in ${formatElapsed(elapsed)})`
+  }, [showElapsed, currentUserEntry])
 
   return (
     <ul className={clsx(styles.container, className)} style={style}>
       {!operators.length && <li className="italic text-stone-300">No one</li>}
-      {operatorsList.length > 0 &&
-        operatorsList.map((operator) => (
-          <li key={operator} className="text-stone-500/80">
-            {operator}
-          </li>
-        ))}
+      {otherOperators.map((op) => (
+        <li key={op.user} className="text-stone-500/80">
+          {op.user}
+        </li>
+      ))}
       {isCurrentUserInList ? (
-        <li className="flex">
-          <span className={styles.currentUser}>{currentUserName}</span>
-          <Button
-            onClick={onSignOut}
-            disabled={isLoading}
-            appearance="custom"
-            aria-label={signOutAriaLabel}
-          >
-            <FontAwesomeIcon
-              icon={faXmark}
-              size="lg"
-              className={clsx(
-                'text-red-500',
-                !isLoading && 'hover:text-red-700'
-              )}
-            />
-          </Button>
+        <li className="flex flex-col items-start">
+          <div className="flex items-center">
+            <span className={styles.currentUser}>{currentUserName}</span>
+            <Button
+              onClick={onSignOut}
+              disabled={isLoading}
+              appearance="custom"
+              aria-label={signOutAriaLabel}
+            >
+              <FontAwesomeIcon
+                icon={faXmark}
+                size="lg"
+                className={clsx(
+                  'text-red-500',
+                  !isLoading && 'hover:text-red-700'
+                )}
+              />
+            </Button>
+          </div>
+          {elapsedLabel && (
+            <span className="text-xs text-stone-400">{elapsedLabel}</span>
+          )}
         </li>
       ) : (
         <li>

--- a/packages/react-ui/src/Modals/ReassignmentModal.stories.tsx
+++ b/packages/react-ui/src/Modals/ReassignmentModal.stories.tsx
@@ -16,21 +16,23 @@ export default {
   },
 } as Meta<ReassignmentModalProps>
 
+const makeOp = (user: string) => ({ user, unixTime: Date.now() - 2 * 3600_000 })
+
 const vehicles = [
   {
     name: 'Brizo',
-    picOperators: ['Norville Rogers', 'Daphne Blake'],
+    picOperators: [makeOp('Norville Rogers'), makeOp('Daphne Blake')],
     onCallOperators: [],
   },
   {
     name: 'Aku',
-    picOperators: ['Fred Jones'],
-    onCallOperators: ['Brian Kieft'],
+    picOperators: [makeOp('Fred Jones')],
+    onCallOperators: [makeOp('Brian Kieft')],
   },
   {
     name: 'Pontus',
-    picOperators: ['Velma Dinkley'],
-    onCallOperators: ['Brian Kieft'],
+    picOperators: [makeOp('Velma Dinkley')],
+    onCallOperators: [makeOp('Brian Kieft')],
   },
 ]
 

--- a/packages/react-ui/src/Modals/ReassignmentModal.test.tsx
+++ b/packages/react-ui/src/Modals/ReassignmentModal.test.tsx
@@ -12,13 +12,13 @@ describe('ReassignmentModal', () => {
         vehicles={[
           {
             name: 'Vehicle 1',
-            picOperators: ['Pic 1'],
-            onCallOperators: ['On-Call 1'],
+            picOperators: [{ user: 'Pic 1', unixTime: Date.now() }],
+            onCallOperators: [{ user: 'On-Call 1', unixTime: Date.now() }],
           },
           {
             name: 'Vehicle 2',
-            picOperators: ['Pic 2'],
-            onCallOperators: ['On-Call 2'],
+            picOperators: [{ user: 'Pic 2', unixTime: Date.now() }],
+            onCallOperators: [{ user: 'On-Call 2', unixTime: Date.now() }],
           },
         ]}
         currentUserName="Test User"

--- a/packages/react-ui/src/Tables/ReassignmentTable.stories.tsx
+++ b/packages/react-ui/src/Tables/ReassignmentTable.stories.tsx
@@ -12,16 +12,18 @@ const Template: Story<ReassignmentTableProps> = (args) => (
   </div>
 )
 
+const makeOp = (user: string) => ({ user, unixTime: Date.now() - 2 * 3600_000 })
+
 const mockVehicles = [
   {
     name: 'Ahi',
-    picOperators: ['John Doe', 'Marc Allentoft-Larsen'],
-    onCallOperators: ['Alice Cooper'],
+    picOperators: [makeOp('John Doe'), makeOp('Marc Allentoft-Larsen')],
+    onCallOperators: [makeOp('Alice Cooper')],
   },
   {
     name: 'Galene',
-    picOperators: ['Mike mccan@mbari.org'],
-    onCallOperators: ['Andrea Vander Woude'],
+    picOperators: [makeOp('Mike mccan@mbari.org')],
+    onCallOperators: [makeOp('Andrea Vander Woude')],
   },
   {
     name: 'Triton',

--- a/packages/react-ui/src/Tables/ReassignmentTable.test.tsx
+++ b/packages/react-ui/src/Tables/ReassignmentTable.test.tsx
@@ -4,17 +4,18 @@ import { ReassignmentTable } from './ReassignmentTable'
 
 describe('ReassignmentTable', () => {
   const mockOnRoleChange = jest.fn()
+  const makeOp = (user: string) => ({ user, unixTime: Date.now() })
   const defaultProps = {
     vehicles: [
       {
         name: 'Vehicle 1',
-        picOperators: ['John Smith'],
-        onCallOperators: ['Jane Doe', 'Ralph Person'],
+        picOperators: [makeOp('John Smith')],
+        onCallOperators: [makeOp('Jane Doe'), makeOp('Ralph Person')],
       },
       {
         name: 'Vehicle 2',
         picOperators: [],
-        onCallOperators: ['Bob Johnson'],
+        onCallOperators: [makeOp('Bob Johnson')],
       },
     ],
     currentUserName: 'Test User',

--- a/packages/react-ui/src/Tables/ReassignmentTable.tsx
+++ b/packages/react-ui/src/Tables/ReassignmentTable.tsx
@@ -3,11 +3,17 @@ import { ReassignmentCell } from '../Cells/ReassignmentCell'
 import { RoleChangeType } from '../Modals/ReassignmentModal'
 import { AbsoluteOverlay } from '../Indicators/AbsoluteOverlay'
 
+export interface ReassignmentOperator {
+  user: string
+  /** Unix timestamp (ms) of the sign-in event — used to show elapsed watch time. */
+  unixTime: number
+}
+
 export interface ReassignmentTableProps {
   vehicles?: {
     name: string
-    picOperators: string[]
-    onCallOperators: string[]
+    picOperators: ReassignmentOperator[]
+    onCallOperators: ReassignmentOperator[]
   }[]
   currentUserName: string
   onRoleChange: (
@@ -53,6 +59,7 @@ export const ReassignmentTable: React.FC<ReassignmentTableProps> = ({
                 onSignIn={() => onRoleChange(vehicle.name, 'in', true)}
                 onSignOut={() => onRoleChange(vehicle.name, 'off', true)}
                 isLoading={isLoading}
+                showElapsed
                 signInAriaLabel={`Join ${vehicle.name} as PIC`}
                 signOutAriaLabel={`Remove ${currentUserName} from ${vehicle.name} as PIC`}
               />

--- a/packages/react-ui/src/Tables/ReassignmentTable.tsx
+++ b/packages/react-ui/src/Tables/ReassignmentTable.tsx
@@ -1,13 +1,12 @@
 import clsx from 'clsx'
-import { ReassignmentCell } from '../Cells/ReassignmentCell'
+import {
+  ReassignmentCell,
+  ReassignmentOperator,
+} from '../Cells/ReassignmentCell'
 import { RoleChangeType } from '../Modals/ReassignmentModal'
 import { AbsoluteOverlay } from '../Indicators/AbsoluteOverlay'
 
-export interface ReassignmentOperator {
-  user: string
-  /** Unix timestamp (ms) of the sign-in event — used to show elapsed watch time. */
-  unixTime: number
-}
+export type { ReassignmentOperator }
 
 export interface ReassignmentTableProps {
   vehicles?: {


### PR DESCRIPTION
## Summary

Adds an optional "hours piloted" prompt when a PIC signs off. The sign-off dialog (using the shared `Modal` component) is pre-filled with the actual elapsed time since sign-in (rounded to the nearest 0.5h) and the value is submitted as a `watchDuration` ISO 8601 duration parameter (e.g. `PT8H30M`) directly to the existing `POST /user/picoc` endpoint — which already supports and persists this field on the backend (confirmed via HAR analysis of Dash4 network traffic).

## Changes

- `Reassignment.tsx` — intercepts PIC `sign='off'` to open a `Modal` confirmation dialog; computes elapsed watch time from sign-in `unixTime` to pre-fill the hours field; submits `watchDuration` to `assignPicAndOnCall` on confirm; falls back to an empty field (not a magic default) when sign-in time is unavailable
- `assignPicAndOnCall.ts` — adds optional `watchDuration?: string` param to `AssignPicAndOnCallParams`
- `ReassignmentCell.tsx` — when `showElapsed=true` (PIC column only), displays a live "(signed in Xh Ym)" label beneath the current user's name, updated on a 1-minute interval keyed on primitive values to avoid interval churn from React Query re-renders
- `ReassignmentTable.tsx` — passes `showElapsed` to the PIC column; operators are now `ReassignmentOperator[]` (`{ user, unixTime }`) instead of `string[]` so sign-in time is available throughout the component stack; `ReassignmentOperator` type is now defined once in `ReassignmentCell.tsx` and re-exported from `ReassignmentTable.tsx`
- `ScienceDataSection.tsx` / `useChartData.tsx` — copy fix: reprocess error messages now read "dataset" (not "mission") and "a TethysDash administrator" (not "your …"), per operator feedback

## Input validation

The hours field rejects NaN, negative values, and values over 24; the Sign off button is disabled and a red error message is shown until the input is valid. Empty input is allowed and results in `watchDuration` being omitted from the API call.

## Notes

- On-Call sign-off and all sign-in flows are unchanged
- The `watchDuration` parameter is supported by the backend and was already being sent by Dash4 (verified via HAR)
- Pre-fill is computed from actual elapsed time rather than a fixed default
