### PR TITLE
fix(#264): disable auto-capitalize on login email field (iPad/Chrome)

### DIFF
--- a/packages/react-ui/src/Fields/Input.test.tsx
+++ b/packages/react-ui/src/Fields/Input.test.tsx
@@ -21,3 +21,21 @@ test('should indicate a disabled state', async () => {
     'cursor-not-allowed opacity-50'
   )
 })
+
+test('should default to autoCapitalize="none" to prevent mobile auto-caps on login fields', async () => {
+  render(<Input name="email" placeholder="Email" />)
+  expect(screen.getByPlaceholderText('Email')).toHaveAttribute(
+    'autocapitalize',
+    'none'
+  )
+})
+
+test('should allow autoCapitalize to be overridden for name fields', async () => {
+  render(
+    <Input name="firstName" placeholder="First name" autoCapitalize="words" />
+  )
+  expect(screen.getByPlaceholderText('First name')).toHaveAttribute(
+    'autocapitalize',
+    'words'
+  )
+})

--- a/packages/react-ui/src/Fields/Input.tsx
+++ b/packages/react-ui/src/Fields/Input.tsx
@@ -19,7 +19,7 @@ export interface InputProps {
    *  prevent browsers from capitalising the first character of email/password
    *  fields. Pass "words" or "sentences" for name fields where capitalisation
    *  is appropriate. */
-  autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters'
+  autoCapitalize?: React.HTMLAttributes<HTMLInputElement>['autoCapitalize']
 }
 
 const style = {

--- a/packages/react-ui/src/Fields/Input.tsx
+++ b/packages/react-ui/src/Fields/Input.tsx
@@ -65,6 +65,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         type={type}
         autoComplete="off"
         autoCorrect="off"
+        autoCapitalize="none"
         {...controlledInputProps}
       />
     )

--- a/packages/react-ui/src/Fields/Input.tsx
+++ b/packages/react-ui/src/Fields/Input.tsx
@@ -15,6 +15,11 @@ export interface InputProps {
   onKeyUp?: React.KeyboardEventHandler<HTMLInputElement>
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>
   type?: string
+  /** Controls mobile keyboard auto-capitalisation. Defaults to "none" to
+   *  prevent browsers from capitalising the first character of email/password
+   *  fields. Pass "words" or "sentences" for name fields where capitalisation
+   *  is appropriate. */
+  autoCapitalize?: 'none' | 'sentences' | 'words' | 'characters'
 }
 
 const style = {
@@ -38,6 +43,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
       onKeyUp,
       onKeyDown,
       type = 'text',
+      autoCapitalize = 'none',
       ...props
     },
     forwardedRef
@@ -65,7 +71,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         type={type}
         autoComplete="off"
         autoCorrect="off"
-        autoCapitalize="none"
+        autoCapitalize={autoCapitalize}
         {...controlledInputProps}
       />
     )


### PR DESCRIPTION
## Summary

Fixes #264 — on iPad/Chrome (and mobile browsers generally), the email field on the login form was auto-capitalising the first character, making it impossible to log in without manually correcting the case.

## Change

Added `autoCapitalize="none"` to the base `Input` component in `packages/react-ui/src/Fields/Input.tsx`, alongside the existing `autoCorrect="off"` that was already there. This applies to all form inputs (email, password, etc.) which is the correct behaviour — none of them should auto-capitalise.

## Testing

1. Open the login modal on an iPad or iPhone in Chrome or Safari
2. Tap the email field — first letter should no longer be capitalised automatically