### PR TITLE
fix(#636): migrate WebSocket auth from URL token to first-frame message

### DIFF
--- a/apps/lrauv-dash2/jest/useWebSocketListeners.test.tsx
+++ b/apps/lrauv-dash2/jest/useWebSocketListeners.test.tsx
@@ -23,12 +23,23 @@ class MockWebSocket {
   close() {}
 }
 
+const originalWebSocket = global.WebSocket
+const originalWsUrl = process.env.NEXT_PUBLIC_WEBSOCKET_URL
+const originalAppVersion = process.env.NEXT_PUBLIC_APP_VERSION
+
 beforeEach(() => {
   MockWebSocket.instances = []
   // @ts-expect-error mocking global WebSocket
   global.WebSocket = MockWebSocket
   process.env.NEXT_PUBLIC_WEBSOCKET_URL = 'wss://okeanids.mbari.org/ws/'
   process.env.NEXT_PUBLIC_APP_VERSION = '5.1.31'
+})
+
+afterEach(() => {
+  // @ts-expect-error restoring global WebSocket
+  global.WebSocket = originalWebSocket
+  process.env.NEXT_PUBLIC_WEBSOCKET_URL = originalWsUrl
+  process.env.NEXT_PUBLIC_APP_VERSION = originalAppVersion
 })
 
 const makeWrapper = (token: string | null, email: string | null) => {

--- a/apps/lrauv-dash2/jest/useWebSocketListeners.test.tsx
+++ b/apps/lrauv-dash2/jest/useWebSocketListeners.test.tsx
@@ -1,0 +1,110 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { render } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from 'react-query'
+import { TethysApiContext } from '@mbari/api-client'
+import { useTethysSubscription } from '../lib/useWebSocketListeners'
+
+// Mock WebSocket globally
+class MockWebSocket {
+  static instances: MockWebSocket[] = []
+  url: string
+  onopen: (() => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  sentMessages: string[] = []
+
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+  send(data: string) {
+    this.sentMessages.push(data)
+  }
+  close() {}
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = []
+  // @ts-expect-error mocking global WebSocket
+  global.WebSocket = MockWebSocket
+  process.env.NEXT_PUBLIC_WEBSOCKET_URL = 'wss://okeanids.mbari.org/ws/'
+  process.env.NEXT_PUBLIC_APP_VERSION = '5.1.31'
+})
+
+const makeWrapper = (token: string | null, email: string | null) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => {
+    const queryClient = new QueryClient()
+    return (
+      <QueryClientProvider client={queryClient}>
+        <TethysApiContext.Provider
+          value={
+            {
+              token,
+              profile: email
+                ? { email, firstName: 'Test', lastName: 'User' }
+                : null,
+              axiosInstance: {} as any,
+            } as any
+          }
+        >
+          {children}
+        </TethysApiContext.Provider>
+      </QueryClientProvider>
+    )
+  }
+  Wrapper.displayName = 'TestWrapper'
+  return Wrapper
+}
+
+const Probe: React.FC = () => {
+  useTethysSubscription()
+  return null
+}
+
+describe('useTethysSubscription', () => {
+  test('connects to NEXT_PUBLIC_WEBSOCKET_URL without token in URL', () => {
+    const wrapper = makeWrapper('test-token-123', 'user@mbari.org')
+    render(<Probe />, { wrapper })
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(MockWebSocket.instances[0].url).toBe('wss://okeanids.mbari.org/ws')
+  })
+
+  test('strips trailing slash from base URL', () => {
+    process.env.NEXT_PUBLIC_WEBSOCKET_URL = 'wss://okeanids.mbari.org/ws/'
+    const wrapper = makeWrapper('test-token-123', 'user@mbari.org')
+    render(<Probe />, { wrapper })
+
+    expect(MockWebSocket.instances[0].url).not.toMatch(/\/$/)
+  })
+
+  test('sends auth frame with token, tduiv, and aem on open', () => {
+    const wrapper = makeWrapper('test-token-123', 'user@mbari.org')
+    render(<Probe />, { wrapper })
+
+    const ws = MockWebSocket.instances[0]
+    ws.onopen?.()
+
+    expect(ws.sentMessages).toHaveLength(1)
+    const frame = JSON.parse(ws.sentMessages[0])
+    expect(frame).toEqual({
+      auth: 'test-token-123',
+      tduiv: '5.1.31',
+      aem: 'user@mbari.org',
+    })
+  })
+
+  test('does not connect when token is missing', () => {
+    const wrapper = makeWrapper(null, 'user@mbari.org')
+    render(<Probe />, { wrapper })
+
+    expect(MockWebSocket.instances).toHaveLength(0)
+  })
+
+  test('does not connect when profile email is missing', () => {
+    const wrapper = makeWrapper('test-token-123', null)
+    render(<Probe />, { wrapper })
+
+    expect(MockWebSocket.instances).toHaveLength(0)
+  })
+})

--- a/apps/lrauv-dash2/jest/useWebSocketListeners.test.tsx
+++ b/apps/lrauv-dash2/jest/useWebSocketListeners.test.tsx
@@ -70,12 +70,12 @@ describe('useTethysSubscription', () => {
     expect(MockWebSocket.instances[0].url).toBe('wss://okeanids.mbari.org/ws')
   })
 
-  test('strips trailing slash from base URL', () => {
-    process.env.NEXT_PUBLIC_WEBSOCKET_URL = 'wss://okeanids.mbari.org/ws/'
+  test('strips trailing slashes from base URL', () => {
+    process.env.NEXT_PUBLIC_WEBSOCKET_URL = 'wss://okeanids.mbari.org/ws//'
     const wrapper = makeWrapper('test-token-123', 'user@mbari.org')
     render(<Probe />, { wrapper })
 
-    expect(MockWebSocket.instances[0].url).not.toMatch(/\/$/)
+    expect(MockWebSocket.instances[0].url).toBe('wss://okeanids.mbari.org/ws')
   })
 
   test('sends auth frame with token, tduiv, and aem on open', () => {

--- a/apps/lrauv-dash2/lib/useWebSocketListeners.ts
+++ b/apps/lrauv-dash2/lib/useWebSocketListeners.ts
@@ -34,7 +34,7 @@ export const useTethysSubscription = () => {
   const { token, profile } = useTethysApiContext()
   const queryClient = useQueryClient()
 
-  // Strip all trailing slashes so the URL is exactly the /ws endpoint.
+  // Strip trailing slashes so we don't end up with /ws/ or /ws//.
   const baseUrl = (process.env.NEXT_PUBLIC_WEBSOCKET_URL as string)?.replace(
     /\/+$/,
     ''

--- a/apps/lrauv-dash2/lib/useWebSocketListeners.ts
+++ b/apps/lrauv-dash2/lib/useWebSocketListeners.ts
@@ -34,9 +34,9 @@ export const useTethysSubscription = () => {
   const { token, profile } = useTethysApiContext()
   const queryClient = useQueryClient()
 
-  // Strip trailing slash so the URL is exactly the /ws endpoint.
+  // Strip all trailing slashes so the URL is exactly the /ws endpoint.
   const baseUrl = (process.env.NEXT_PUBLIC_WEBSOCKET_URL as string)?.replace(
-    /\/$/,
+    /\/+$/,
     ''
   )
 

--- a/apps/lrauv-dash2/lib/useWebSocketListeners.ts
+++ b/apps/lrauv-dash2/lib/useWebSocketListeners.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useTethysApiContext } from '@mbari/api-client'
 import { useQuery, useQueryClient } from 'react-query'
+import pkg from '../../package.json'
 
 type SubscriptionEventType =
   | 'VehicleConnected'
@@ -34,22 +35,33 @@ export const useTethysSubscription = () => {
   const { token, profile } = useTethysApiContext()
   const queryClient = useQueryClient()
 
-  const url =
-    profile?.email &&
-    token &&
-    `${process.env.NEXT_PUBLIC_WEBSOCKET_URL as string}/${token}?aem=${
-      profile?.email
-    }`
+  // Strip trailing slash so the URL is exactly the /ws endpoint.
+  const baseUrl = (process.env.NEXT_PUBLIC_WEBSOCKET_URL as string)?.replace(
+    /\/$/,
+    ''
+  )
 
   useEffect(() => {
-    if (!url) {
+    if (!baseUrl || !profile?.email) {
       return
     }
-    const accountEmail = profile?.email
-    const websocket = new WebSocket(url)
+    const accountEmail = profile.email
+
+    const websocket = new WebSocket(baseUrl)
+
     websocket.onopen = () => {
-      console.log('connected')
+      // Send auth as the first frame per the new /ws security protocol
+      // (mbari-org/tethysdash#66). The server validates within ~5s and
+      // closes the connection on failure; silence means success.
+      websocket.send(
+        JSON.stringify({
+          auth: token ?? '-',
+          tduiv: pkg.version,
+          aem: accountEmail,
+        })
+      )
     }
+
     websocket.onmessage = (event) => {
       const data = JSON.parse(event.data) as TethysSubscriptionEvent
       if (
@@ -71,7 +83,7 @@ export const useTethysSubscription = () => {
     return () => {
       websocket.close()
     }
-  }, [queryClient, url, profile?.email])
+  }, [queryClient, baseUrl, token, profile?.email])
 }
 
 /**

--- a/apps/lrauv-dash2/lib/useWebSocketListeners.ts
+++ b/apps/lrauv-dash2/lib/useWebSocketListeners.ts
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
 import { useTethysApiContext } from '@mbari/api-client'
 import { useQuery, useQueryClient } from 'react-query'
-import pkg from '../../package.json'
 
 type SubscriptionEventType =
   | 'VehicleConnected'
@@ -56,7 +55,7 @@ export const useTethysSubscription = () => {
       websocket.send(
         JSON.stringify({
           auth: token ?? '-',
-          tduiv: pkg.version,
+          tduiv: process.env.NEXT_PUBLIC_APP_VERSION ?? 'dev',
           aem: accountEmail,
         })
       )

--- a/apps/lrauv-dash2/lib/useWebSocketListeners.ts
+++ b/apps/lrauv-dash2/lib/useWebSocketListeners.ts
@@ -41,7 +41,7 @@ export const useTethysSubscription = () => {
   )
 
   useEffect(() => {
-    if (!baseUrl || !profile?.email) {
+    if (!baseUrl || !token || !profile?.email) {
       return
     }
     const accountEmail = profile.email
@@ -54,7 +54,7 @@ export const useTethysSubscription = () => {
       // closes the connection on failure; silence means success.
       websocket.send(
         JSON.stringify({
-          auth: token ?? '-',
+          auth: token,
           tduiv: process.env.NEXT_PUBLIC_APP_VERSION ?? 'dev',
           aem: accountEmail,
         })

--- a/apps/lrauv-dash2/next.config.js
+++ b/apps/lrauv-dash2/next.config.js
@@ -1,5 +1,10 @@
 // This is a workaround for Next.js 15 to handle TypeScript files in workspace packages
+const pkg = require('./package.json')
+
 const nextConfig = {
+  env: {
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+  },
   output: 'export',
   reactStrictMode: true,
   // Fix for Next.js 15 image optimization with static export


### PR DESCRIPTION
## Summary

Implements the new \`/ws\` security protocol from mbari-org/tethysdash#66. Carlos confirmed the backend is live in production as of May 14, 2026.

## Change

**Before:** token embedded in the URL — \`new WebSocket(\`\${baseURL}/\${token}?aem=\${email}\`)\`

**After:** connect clean, send auth as the first frame:
\`\`\`ts
const websocket = new WebSocket(baseUrl)
websocket.onopen = () => {
  websocket.send(JSON.stringify({ auth: token, tduiv: process.env.NEXT_PUBLIC_APP_VERSION, aem: accountEmail }))
}
\`\`\`

- The hook only connects when both \`token\` and \`profile.email\` are present — Dash5 has no anonymous WebSocket sessions
- \`tduiv\` is injected at build time via \`NEXT_PUBLIC_APP_VERSION\` (set from \`package.json\` in \`next.config.js\`) — only the version string is bundled
- All trailing slashes are stripped from \`NEXT_PUBLIC_WEBSOCKET_URL\` before connecting
- All existing message handling, keep-alive, and reconnect logic is unchanged
- \`NEXT_PUBLIC_WEBSOCKET_URL\` env var unchanged (already points to \`/ws\`)
- Legacy \`/ws/{token}\` endpoint remains live — no regression risk

## Tests

5 new tests with a mocked \`WebSocket\`: clean URL (no token), trailing-slash stripping, correct \`{auth,tduiv,aem}\` first frame, no-connection guards for missing token and email.