### PR TITLE
feat(#640): match Dash4 log color syntax highlighting

### DIFF
--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -21,6 +21,7 @@ import { DateTime } from 'luxon'
 import formatEvent, {
   displayNameForEventType,
   isUploadEvent,
+  labelBoldForEventType,
   labelColorForEventType,
 } from '../lib/formatEvent'
 import {
@@ -449,6 +450,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
         timeAgo={timeAgo}
         label={displayNameForEventType(item)}
         labelColor={labelColorForEventType(item)}
+        labelBold={labelBoldForEventType(item)}
         log={log}
         isUpload={isUploadEvent(item)}
         onCopy={handleCopyEventLogs}

--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -21,6 +21,7 @@ import { DateTime } from 'luxon'
 import formatEvent, {
   displayNameForEventType,
   isUploadEvent,
+  labelColorForEventType,
 } from '../lib/formatEvent'
 import {
   applySelectedFilters,
@@ -447,6 +448,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
         time={time}
         timeAgo={timeAgo}
         label={displayNameForEventType(item)}
+        labelColor={labelColorForEventType(item)}
         log={log}
         isUpload={isUploadEvent(item)}
         onCopy={handleCopyEventLogs}

--- a/apps/lrauv-dash2/jest/LogsSection.test.tsx
+++ b/apps/lrauv-dash2/jest/LogsSection.test.tsx
@@ -181,6 +181,53 @@ test('notes with different event IDs are kept as separate rows', async () => {
   })
 })
 
+// ── Color / bold wiring tests (#640) ──────────────────────────────────────────
+
+test('renders Fault label in amber with bold styling', async () => {
+  const ts = Date.now() - 60 * 1000
+  renderLogs([
+    {
+      eventId: 6001,
+      vehicleName: 'triton',
+      eventType: 'logFault',
+      unixTime: ts,
+      isoTime: new Date(ts).toISOString(),
+      name: 'BuoyancyServo',
+      text: 'uart error',
+      user: null,
+      state: 0,
+    },
+  ])
+
+  await waitFor(() => {
+    const label = screen.getByText('Fault')
+    expect(label).toHaveStyle({ color: '#c78204' })
+    expect(label).toHaveClass('font-bold')
+  })
+})
+
+test('renders GPS Fix label in blue with bold styling', async () => {
+  const ts = Date.now() - 60 * 1000
+  renderLogs([
+    {
+      eventId: 6002,
+      vehicleName: 'triton',
+      eventType: 'gpsFix',
+      unixTime: ts,
+      isoTime: new Date(ts).toISOString(),
+      fix: { latitude: 36.8, longitude: -121.9 },
+      user: null,
+      state: 0,
+    },
+  ])
+
+  await waitFor(() => {
+    const label = screen.getByText('GPS Fix')
+    expect(label).toHaveStyle({ color: '#0000ff' })
+    expect(label).toHaveClass('font-bold')
+  })
+})
+
 test('timeout notes for same event ID outside the time window are NOT grouped', async () => {
   // Regression for Copilot review: grouping must be time-bounded so a timeout
   // note from a later incident (same event ID, far apart in time) doesn't get

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -165,6 +165,33 @@ describe('formatEvent', () => {
     })
   })
 
+  describe('gpsFix Google Maps link', () => {
+    const event: GetEventsResponse = {
+      ...baseEvent,
+      eventType: 'gpsFix',
+      fix: { latitude: 36.7974, longitude: -121.8498 },
+    } as GetEventsResponse
+
+    it('renders a Google Maps anchor with the correct href', () => {
+      const { container } = render(formatEvent(event, DASH_URL))
+      const link = container.querySelector('a') as HTMLAnchorElement
+      expect(link).toBeInTheDocument()
+      expect(link.href).toContain('google.com/maps?q=36.7974,-121.8498')
+    })
+
+    it('opens in a new tab with noopener noreferrer', () => {
+      const { container } = render(formatEvent(event, DASH_URL))
+      const link = container.querySelector('a') as HTMLAnchorElement
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+    })
+
+    it('displays the lat/lon as the link text', () => {
+      render(formatEvent(event, DASH_URL))
+      expect(screen.getByText('36.7974, -121.8498')).toBeInTheDocument()
+    })
+  })
+
   describe('logFault description color', () => {
     const event: GetEventsResponse = {
       ...baseEvent,

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -207,6 +207,58 @@ describe('formatEvent', () => {
     })
   })
 
+  describe('run (Mission Request) description color', () => {
+    const event: GetEventsResponse = {
+      ...baseEvent,
+      eventType: 'run',
+      user: 'testuser',
+      note: 'test mission',
+      data: 'speed=1.5;',
+    } as GetEventsResponse
+
+    it('wraps the run description in purple', () => {
+      const { container } = render(formatEvent(event, DASH_URL))
+      const wrapper = container.firstElementChild as HTMLElement
+      expect(wrapper).toHaveStyle({ color: 'purple' })
+    })
+  })
+
+  describe('logImportant startedMission / defaultMission text-base styling', () => {
+    it('renders startedMission text at text-base size', () => {
+      const event: GetEventsResponse = {
+        ...baseEvent,
+        eventType: 'logImportant',
+        text: 'Started mission Sci2000.xml',
+      } as GetEventsResponse
+      const { container } = render(formatEvent(event, DASH_URL))
+      const p = container.querySelector('p') as HTMLElement
+      expect(p).toHaveClass('text-base')
+    })
+
+    it('renders defaultMission text at text-base size', () => {
+      const event: GetEventsResponse = {
+        ...baseEvent,
+        eventType: 'logImportant',
+        text: 'Default mission has been running for 2 hours',
+      } as GetEventsResponse
+      const { container } = render(formatEvent(event, DASH_URL))
+      const p = container.querySelector('p') as HTMLElement
+      expect(p).toHaveClass('text-base')
+    })
+
+    it('does not apply text-base to a plain logImportant event', () => {
+      const event: GetEventsResponse = {
+        ...baseEvent,
+        eventType: 'logImportant',
+        name: 'GFScanner',
+        text: 'Some other important message',
+      } as GetEventsResponse
+      const { container } = render(formatEvent(event, DASH_URL))
+      const p = container.querySelector('p') as HTMLElement
+      expect(p).not.toHaveClass('text-base')
+    })
+  })
+
   describe('command event with newline in data', () => {
     const event: GetEventsResponse = {
       ...baseEvent,

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -131,9 +131,9 @@ describe('formatEvent', () => {
       expect(labelColorForEventType(event)).toBe('#0000ff')
     })
 
-    it('returns purple for run (Mission Request)', () => {
+    it('returns undefined for run (description is colored by formatEvent, not the label)', () => {
       const event = { ...baseEvent, eventType: 'run' } as GetEventsResponse
-      expect(labelColorForEventType(event)).toBe('purple')
+      expect(labelColorForEventType(event)).toBeUndefined()
     })
 
     it('returns undefined for uncolored event types', () => {

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -193,17 +193,30 @@ describe('formatEvent', () => {
   })
 
   describe('logFault description color', () => {
-    const event: GetEventsResponse = {
-      ...baseEvent,
-      eventType: 'logFault',
-      name: 'BuoyancyServo',
-      text: 'Buoyancy getPosition uart error',
-    } as GetEventsResponse
-
     it('wraps the fault description in amber #c78204', () => {
+      const event: GetEventsResponse = {
+        ...baseEvent,
+        eventType: 'logFault',
+        name: 'BuoyancyServo',
+        text: 'Buoyancy getPosition uart error',
+      } as GetEventsResponse
       const { container } = render(formatEvent(event, DASH_URL))
       const wrapper = container.firstElementChild as HTMLElement
       expect(wrapper).toHaveStyle({ color: '#c78204' })
+    })
+
+    it('scopes MTMSN= dark-red styling per-line, leaving other fault lines amber', () => {
+      const event: GetEventsResponse = {
+        ...baseEvent,
+        eventType: 'logFault',
+        name: 'BuoyancyServo',
+        text: 'Buoyancy uart error\nMTMSN=12345',
+      } as GetEventsResponse
+      const { container } = render(formatEvent(event, DASH_URL))
+      const faultLine = screen.getByText('Buoyancy uart error')
+      const mtmsnLine = screen.getByText('MTMSN=12345')
+      expect(faultLine).not.toHaveClass('text-red-800')
+      expect(mtmsnLine).toHaveClass('text-red-800')
     })
   })
 

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -1,7 +1,10 @@
 import '@testing-library/jest-dom'
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import formatEvent from '../lib/formatEvent'
+import formatEvent, {
+  labelBoldForEventType,
+  labelColorForEventType,
+} from '../lib/formatEvent'
 import { GetEventsResponse } from '@mbari/api-client'
 
 const DASH_URL = 'https://okeanids.mbari.org'
@@ -114,6 +117,66 @@ describe('formatEvent', () => {
       renderEvent(event)
       expect(screen.getByText('Critical line one')).toBeInTheDocument()
       expect(screen.getByText('Critical line two')).toBeInTheDocument()
+    })
+  })
+
+  describe('labelColorForEventType', () => {
+    it('returns #c78204 for logFault', () => {
+      const event = { ...baseEvent, eventType: 'logFault' } as GetEventsResponse
+      expect(labelColorForEventType(event)).toBe('#c78204')
+    })
+
+    it('returns #0000ff for gpsFix', () => {
+      const event = { ...baseEvent, eventType: 'gpsFix' } as GetEventsResponse
+      expect(labelColorForEventType(event)).toBe('#0000ff')
+    })
+
+    it('returns purple for run (Mission Request)', () => {
+      const event = { ...baseEvent, eventType: 'run' } as GetEventsResponse
+      expect(labelColorForEventType(event)).toBe('purple')
+    })
+
+    it('returns undefined for uncolored event types', () => {
+      const event = {
+        ...baseEvent,
+        eventType: 'logImportant',
+      } as GetEventsResponse
+      expect(labelColorForEventType(event)).toBeUndefined()
+    })
+  })
+
+  describe('labelBoldForEventType', () => {
+    it('returns true for logFault', () => {
+      const event = { ...baseEvent, eventType: 'logFault' } as GetEventsResponse
+      expect(labelBoldForEventType(event)).toBe(true)
+    })
+
+    it('returns true for gpsFix', () => {
+      const event = { ...baseEvent, eventType: 'gpsFix' } as GetEventsResponse
+      expect(labelBoldForEventType(event)).toBe(true)
+    })
+
+    it('returns false for other event types', () => {
+      const event = {
+        ...baseEvent,
+        eventType: 'logImportant',
+      } as GetEventsResponse
+      expect(labelBoldForEventType(event)).toBe(false)
+    })
+  })
+
+  describe('logFault description color', () => {
+    const event: GetEventsResponse = {
+      ...baseEvent,
+      eventType: 'logFault',
+      name: 'BuoyancyServo',
+      text: 'Buoyancy getPosition uart error',
+    } as GetEventsResponse
+
+    it('wraps the fault description in amber #c78204', () => {
+      const { container } = render(formatEvent(event, DASH_URL))
+      const wrapper = container.firstElementChild as HTMLElement
+      expect(wrapper).toHaveStyle({ color: '#c78204' })
     })
   })
 

--- a/apps/lrauv-dash2/lib/formatEvent.tsx
+++ b/apps/lrauv-dash2/lib/formatEvent.tsx
@@ -61,6 +61,25 @@ export const displayNameForEventType = (eventType: GetEventsResponse) =>
     return a
   }, '')
 
+/**
+ * Returns the Dash4-matching label color for a given event, or undefined for
+ * events that use the default text color.
+ */
+export const labelColorForEventType = (
+  event: GetEventsResponse
+): string | undefined => {
+  switch (event.eventType) {
+    case 'logFault':
+      return '#c78204'
+    case 'gpsFix':
+      return '#0000ff'
+    case 'run':
+      return 'purple'
+    default:
+      return undefined
+  }
+}
+
 export const isUploadEvent = (event: GetEventsResponse) =>
   (event.eventType === 'sbdSend' && event.state === 2) ||
   (event.eventType === 'sbdReceive' &&
@@ -148,22 +167,43 @@ const formatEvent = (
         </p>
       )
 
-    case 'gpsFix':
+    case 'gpsFix': {
+      const lat = event.fix?.latitude
+      const lon = event.fix?.longitude
+      const mapsUrl =
+        lat != null && lon != null
+          ? `https://www.google.com/maps?q=${lat},${lon}`
+          : undefined
       return (
         <p className="flex flex-col">
-          <span className="font-bold">Lat/Lon:</span>
-          <span className="font-mono">
-            {event.fix?.latitude}, {event.fix?.longitude}
+          <span className="font-bold" style={{ color: '#0000ff' }}>
+            Lat/Lon:
           </span>
+          {mapsUrl ? (
+            <a
+              href={mapsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono"
+              style={{ color: '#0000ff' }}
+            >
+              {lat}, {lon}
+            </a>
+          ) : (
+            <span className="font-mono" style={{ color: '#0000ff' }}>
+              {lat}, {lon}
+            </span>
+          )}
         </p>
       )
+    }
 
     case 'logCritical':
     case 'logFault':
     case 'logImportant':
       if (startedMission || defaultMission) {
         return (
-          <p className="font-bold text-purple-700">
+          <p className="text-base font-bold text-purple-700">
             <span>{text}</span>
           </p>
         )
@@ -237,7 +277,7 @@ const formatEvent = (
 
     case 'run':
       return (
-        <div className="flex flex-col">
+        <div className="flex flex-col" style={{ color: 'purple' }}>
           <p>
             <span className="font-bold">by {user ?? 'unknown'},</span> id:{' '}
             {event.eventId}, {note}

--- a/apps/lrauv-dash2/lib/formatEvent.tsx
+++ b/apps/lrauv-dash2/lib/formatEvent.tsx
@@ -82,7 +82,7 @@ export const labelColorForEventType = (
 
 /** Returns true for event types whose label should be rendered in bold. */
 export const labelBoldForEventType = (event: GetEventsResponse): boolean =>
-  event.eventType === 'logFault'
+  event.eventType === 'logFault' || event.eventType === 'gpsFix'
 
 export const isUploadEvent = (event: GetEventsResponse) =>
   (event.eventType === 'sbdSend' && event.state === 2) ||

--- a/apps/lrauv-dash2/lib/formatEvent.tsx
+++ b/apps/lrauv-dash2/lib/formatEvent.tsx
@@ -73,8 +73,6 @@ export const labelColorForEventType = (
       return '#c78204'
     case 'gpsFix':
       return '#0000ff'
-    case 'run':
-      return 'purple'
     default:
       return undefined
   }
@@ -206,12 +204,23 @@ const formatEvent = (
       return (
         <p className="flex flex-col" style={{ color: '#c78204' }}>
           <span className="block font-bold">[{name}]</span>
-          {Array.isArray(text) &&
+          {event.text?.match('MTMSN=') ? (
+            <span className={styles.mtmsn}>
+              {Array.isArray(text) &&
+                text.map((line, i) => (
+                  <span key={`${event.eventId}${i}`} className="block">
+                    {line}
+                  </span>
+                ))}
+            </span>
+          ) : (
+            Array.isArray(text) &&
             text.map((line, i) => (
               <span key={`${event.eventId}${i}`} className="block">
                 {line}
               </span>
-            ))}
+            ))
+          )}
         </p>
       )
 

--- a/apps/lrauv-dash2/lib/formatEvent.tsx
+++ b/apps/lrauv-dash2/lib/formatEvent.tsx
@@ -80,6 +80,10 @@ export const labelColorForEventType = (
   }
 }
 
+/** Returns true for event types whose label should be rendered in bold. */
+export const labelBoldForEventType = (event: GetEventsResponse): boolean =>
+  event.eventType === 'logFault'
+
 export const isUploadEvent = (event: GetEventsResponse) =>
   (event.eventType === 'sbdSend' && event.state === 2) ||
   (event.eventType === 'sbdReceive' &&
@@ -198,8 +202,20 @@ const formatEvent = (
       )
     }
 
-    case 'logCritical':
     case 'logFault':
+      return (
+        <p className="flex flex-col" style={{ color: '#c78204' }}>
+          <span className="block font-bold">[{name}]</span>
+          {Array.isArray(text) &&
+            text.map((line, i) => (
+              <span key={`${event.eventId}${i}`} className="block">
+                {line}
+              </span>
+            ))}
+        </p>
+      )
+
+    case 'logCritical':
     case 'logImportant':
       if (startedMission || defaultMission) {
         return (

--- a/apps/lrauv-dash2/lib/formatEvent.tsx
+++ b/apps/lrauv-dash2/lib/formatEvent.tsx
@@ -204,23 +204,21 @@ const formatEvent = (
       return (
         <p className="flex flex-col" style={{ color: '#c78204' }}>
           <span className="block font-bold">[{name}]</span>
-          {event.text?.match('MTMSN=') ? (
-            <span className={styles.mtmsn}>
-              {Array.isArray(text) &&
-                text.map((line, i) => (
-                  <span key={`${event.eventId}${i}`} className="block">
-                    {line}
-                  </span>
-                ))}
-            </span>
-          ) : (
-            Array.isArray(text) &&
-            text.map((line, i) => (
-              <span key={`${event.eventId}${i}`} className="block">
-                {line}
-              </span>
-            ))
-          )}
+          {Array.isArray(text) &&
+            text.map((line, i) =>
+              line.includes('MTMSN=') ? (
+                <span
+                  key={`${event.eventId}${i}`}
+                  className={`block ${styles.mtmsn}`}
+                >
+                  {line}
+                </span>
+              ) : (
+                <span key={`${event.eventId}${i}`} className="block">
+                  {line}
+                </span>
+              )
+            )}
         </p>
       )
 

--- a/packages/react-ui/src/Cells/LogCell.test.tsx
+++ b/packages/react-ui/src/Cells/LogCell.test.tsx
@@ -81,3 +81,13 @@ test('does not set inline color on label when labelColor is omitted', async () =
   const label = screen.getByText(props.label)
   expect(label).not.toHaveAttribute('style')
 })
+
+test('renders label in bold when labelBold is true', async () => {
+  render(<LogCell {...props} labelBold />)
+  expect(screen.getByText(props.label)).toHaveClass('font-bold')
+})
+
+test('does not render label in bold by default', async () => {
+  render(<LogCell {...props} />)
+  expect(screen.getByText(props.label)).not.toHaveClass('font-bold')
+})

--- a/packages/react-ui/src/Cells/LogCell.test.tsx
+++ b/packages/react-ui/src/Cells/LogCell.test.tsx
@@ -63,3 +63,21 @@ test('applies default padding and text size when compact is false', async () => 
   expect(grid).toHaveClass('text-sm')
   expect(grid).not.toHaveClass('px-2')
 })
+
+test('applies labelColor to the label element in comfortable mode', async () => {
+  render(<LogCell {...props} labelColor="#c78204" />)
+  const label = screen.getByText(props.label)
+  expect(label).toHaveStyle({ color: '#c78204' })
+})
+
+test('applies labelColor to the label element in compact mode', async () => {
+  render(<LogCell {...props} labelColor="#0000ff" compact />)
+  const label = screen.getByText(props.label)
+  expect(label).toHaveStyle({ color: '#0000ff' })
+})
+
+test('does not set inline color on label when labelColor is omitted', async () => {
+  render(<LogCell {...props} />)
+  const label = screen.getByText(props.label)
+  expect(label).not.toHaveAttribute('style')
+})

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -7,6 +7,8 @@ export interface LogCellProps {
   className?: string
   style?: React.CSSProperties
   label: string
+  /** Optional color applied to the event type label, e.g. '#c78204' for Fault. */
+  labelColor?: string
   time: string
   /** Compact relative time string, e.g. "3m ago". Rendered inline after the transmission icon. */
   timeAgo?: string
@@ -28,6 +30,7 @@ export const LogCell: React.FC<LogCellProps> = ({
   className,
   style,
   label,
+  labelColor,
   time,
   timeAgo,
   date,
@@ -72,7 +75,12 @@ export const LogCell: React.FC<LogCellProps> = ({
             >
               {isUpload ? <UploadIcon /> : <DownloadIcon />}
             </span>
-            <span className="truncate">{label}</span>
+            <span
+              className="truncate"
+              style={labelColor ? { color: labelColor } : undefined}
+            >
+              {label}
+            </span>
           </div>
 
           {/* Description — expands to fill remaining width; collapses to one row
@@ -102,7 +110,9 @@ export const LogCell: React.FC<LogCellProps> = ({
         onCopy={onCopy}
       >
         <ul className={styles.details}>
-          <li>{label}</li>
+          <li style={labelColor ? { color: labelColor } : undefined}>
+            {label}
+          </li>
           <li className="flex flex-row items-baseline gap-1">
             <span className="pr-1 opacity-60" aria-label="time">
               {time}

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -51,12 +51,27 @@ export const LogCell: React.FC<LogCellProps> = ({
         >
           {/* Time — fixed-width, always ≤2 rows: time on row 1, date+ago
               inline on row 2 so the column never grows taller than 2 lines */}
-          <div className="flex w-24 shrink-0 flex-col" aria-label="time">
+          {/* Time — no forced wrap; all three pieces flow on one line and
+              only wrap together when the overall row is narrow */}
+          <div
+            className="flex shrink-0 flex-row items-baseline gap-x-1.5"
+            aria-label="time"
+          >
             <span className="whitespace-nowrap opacity-60">{time}</span>
-            <span className="flex flex-row flex-wrap gap-x-1 opacity-40 text-[10px]">
-              <span aria-label="date">{date}</span>
-              {timeAgo && <span aria-label="time ago">{timeAgo}</span>}
+            <span
+              className="whitespace-nowrap opacity-40 text-[10px]"
+              aria-label="date"
+            >
+              {date}
             </span>
+            {timeAgo && (
+              <span
+                className="whitespace-nowrap opacity-40 text-[10px]"
+                aria-label="time ago"
+              >
+                {timeAgo}
+              </span>
+            )}
           </div>
 
           {/* Type — wide enough to show "Direct Comms" without truncation */}

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -53,7 +53,7 @@ export const LogCell: React.FC<LogCellProps> = ({
               inline on row 2 so the column never grows taller than 2 lines */}
           {/* Time — fixed at 34ch so the worst-case string fits on one line */}
           <div
-            className="flex w-[calc(34ch-15px)] shrink-0 flex-row items-baseline gap-x-1.5"
+            className="flex w-[calc(34ch-30px)] shrink-0 flex-row items-baseline gap-x-1.5"
             aria-label="time"
           >
             <span className="whitespace-nowrap opacity-60">{time}</span>

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -53,7 +53,7 @@ export const LogCell: React.FC<LogCellProps> = ({
               inline on row 2 so the column never grows taller than 2 lines */}
           {/* Time — fixed at 34ch so the worst-case string fits on one line */}
           <div
-            className="flex w-[calc(34ch-30px)] shrink-0 flex-row items-baseline gap-x-1.5"
+            className="flex w-[170px] shrink-0 flex-row items-baseline gap-x-1.5"
             aria-label="time"
           >
             <span className="whitespace-nowrap opacity-60">{time}</span>

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -49,29 +49,27 @@ export const LogCell: React.FC<LogCellProps> = ({
           className="flex w-full select-text items-start gap-2 px-2 py-0.5 text-xs"
           onCopy={onCopy}
         >
-          {/* Time — flows inline when the column is wide enough, wraps when narrow */}
-          <div className="flex flex-row flex-wrap items-baseline gap-x-1.5">
-            <div className="whitespace-nowrap opacity-60" aria-label="time">
-              {time}
-            </div>
-            <div
+          {/* Time — fixed-width column so every subsequent column lines up */}
+          <div className="flex w-24 shrink-0 flex-col" aria-label="time">
+            <span className="whitespace-nowrap opacity-60">{time}</span>
+            <span
               className="whitespace-nowrap opacity-40 text-[10px]"
               aria-label="date"
             >
               {date}
-            </div>
+            </span>
             {timeAgo && (
-              <div
+              <span
                 className="whitespace-nowrap opacity-40 text-[10px]"
                 aria-label="time ago"
               >
                 {timeAgo}
-              </div>
+              </span>
             )}
           </div>
 
-          {/* Type — fixed width, never wraps */}
-          <div className="flex w-24 shrink-0 items-start gap-1">
+          {/* Type — wide enough to show "Direct Comms" without truncation */}
+          <div className="flex w-28 shrink-0 items-start gap-1">
             <span
               className="mt-px shrink-0"
               aria-label="data transmission icon"

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -49,9 +49,8 @@ export const LogCell: React.FC<LogCellProps> = ({
           className="flex w-full select-text items-start gap-2 px-2 py-0.5 text-xs"
           onCopy={onCopy}
         >
-          {/* Time — fixed-width, always ≤2 rows: time on row 1, date+ago
-              inline on row 2 so the column never grows taller than 2 lines */}
-          {/* Time — fixed at 34ch so the worst-case string fits on one line */}
+          {/* Time — fixed 170px so all three pieces (time, date, ago) fit on
+              one line for typical entries; the column never compresses */}
           <div
             className="flex w-[170px] shrink-0 flex-row items-baseline gap-x-1.5"
             aria-label="time"

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -51,10 +51,9 @@ export const LogCell: React.FC<LogCellProps> = ({
         >
           {/* Time — fixed-width, always ≤2 rows: time on row 1, date+ago
               inline on row 2 so the column never grows taller than 2 lines */}
-          {/* Time — no forced wrap; all three pieces flow on one line and
-              only wrap together when the overall row is narrow */}
+          {/* Time — fixed at 34ch so the worst-case string fits on one line */}
           <div
-            className="flex shrink-0 flex-row items-baseline gap-x-1.5"
+            className="flex w-[34ch] shrink-0 flex-row items-baseline gap-x-1.5"
             aria-label="time"
           >
             <span className="whitespace-nowrap opacity-60">{time}</span>

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -49,8 +49,12 @@ export const LogCell: React.FC<LogCellProps> = ({
           className="flex w-full select-text items-start gap-2 px-2 py-0.5 text-xs"
           onCopy={onCopy}
         >
-          {/* Time — fixed-width column so every subsequent column lines up */}
-          <div className="flex w-24 shrink-0 flex-col" aria-label="time">
+          {/* Time — fixed-width column so subsequent columns always line up;
+              content flows on one row and wraps only if it must */}
+          <div
+            className="flex w-24 shrink-0 flex-row flex-wrap items-baseline gap-x-1"
+            aria-label="time"
+          >
             <span className="whitespace-nowrap opacity-60">{time}</span>
             <span
               className="whitespace-nowrap opacity-40 text-[10px]"

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -9,6 +9,8 @@ export interface LogCellProps {
   label: string
   /** Optional color applied to the event type label, e.g. '#c78204' for Fault. */
   labelColor?: string
+  /** When true, renders the label in bold. */
+  labelBold?: boolean
   time: string
   /** Compact relative time string, e.g. "3m ago". Rendered inline after the transmission icon. */
   timeAgo?: string
@@ -31,6 +33,7 @@ export const LogCell: React.FC<LogCellProps> = ({
   style,
   label,
   labelColor,
+  labelBold = false,
   time,
   timeAgo,
   date,
@@ -76,7 +79,7 @@ export const LogCell: React.FC<LogCellProps> = ({
               {isUpload ? <UploadIcon /> : <DownloadIcon />}
             </span>
             <span
-              className="truncate"
+              className={clsx('truncate', labelBold && 'font-bold')}
               style={labelColor ? { color: labelColor } : undefined}
             >
               {label}
@@ -110,7 +113,10 @@ export const LogCell: React.FC<LogCellProps> = ({
         onCopy={onCopy}
       >
         <ul className={styles.details}>
-          <li style={labelColor ? { color: labelColor } : undefined}>
+          <li
+            className={clsx(labelBold && 'font-bold')}
+            style={labelColor ? { color: labelColor } : undefined}
+          >
             {label}
           </li>
           <li className="flex flex-row items-baseline gap-1">

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -53,7 +53,7 @@ export const LogCell: React.FC<LogCellProps> = ({
               inline on row 2 so the column never grows taller than 2 lines */}
           {/* Time — fixed at 34ch so the worst-case string fits on one line */}
           <div
-            className="flex w-[34ch] shrink-0 flex-row items-baseline gap-x-1.5"
+            className="flex w-[calc(34ch-15px)] shrink-0 flex-row items-baseline gap-x-1.5"
             aria-label="time"
           >
             <span className="whitespace-nowrap opacity-60">{time}</span>

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -49,27 +49,14 @@ export const LogCell: React.FC<LogCellProps> = ({
           className="flex w-full select-text items-start gap-2 px-2 py-0.5 text-xs"
           onCopy={onCopy}
         >
-          {/* Time — fixed-width column so subsequent columns always line up;
-              content flows on one row and wraps only if it must */}
-          <div
-            className="flex w-24 shrink-0 flex-row flex-wrap items-baseline gap-x-1"
-            aria-label="time"
-          >
+          {/* Time — fixed-width, always ≤2 rows: time on row 1, date+ago
+              inline on row 2 so the column never grows taller than 2 lines */}
+          <div className="flex w-24 shrink-0 flex-col" aria-label="time">
             <span className="whitespace-nowrap opacity-60">{time}</span>
-            <span
-              className="whitespace-nowrap opacity-40 text-[10px]"
-              aria-label="date"
-            >
-              {date}
+            <span className="flex flex-row flex-wrap gap-x-1 opacity-40 text-[10px]">
+              <span aria-label="date">{date}</span>
+              {timeAgo && <span aria-label="time ago">{timeAgo}</span>}
             </span>
-            {timeAgo && (
-              <span
-                className="whitespace-nowrap opacity-40 text-[10px]"
-                aria-label="time ago"
-              >
-                {timeAgo}
-              </span>
-            )}
           </div>
 
           {/* Type — wide enough to show "Direct Comms" without truncation */}


### PR DESCRIPTION
## Summary

Closes #640, addresses the color syntax portion of #425.

Matches the Dash4 log color scheme so operators can scan logs at a glance:

- **Fault** label → amber/orange \`#c78204\`
- **GPS Fix** label → blue \`#0000ff\`; lat/lon rendered as a clickable Google Maps link
- **Mission Request** description → purple (matches Dash4 \`event-run: color: purple\`); the *label* keeps its default color — only the description text is purple
- **Started/Default mission** text bumped to \`text-base\` for Dash4 \`font-size: large\` parity (was already purple bold)
- **MTMSN** dark red — already matched, no change needed

## Changes

### \`LogCell.tsx\` (\`@mbari/react-ui\`)
- Added optional \`labelColor?: string\` and \`labelBold?: boolean\` props
- Applied as inline \`style={{ color }}\` and \`font-bold\` class on the label in both compact and comfortable layouts

### \`formatEvent.tsx\`
- Added \`labelColorForEventType()\` helper (exported) — returns \`#c78204\` for Fault, \`#0000ff\` for GPS Fix, \`undefined\` for everything else (including \`run\` — the run *label* stays default; only the *description* is purple)
- Added \`labelBoldForEventType()\` helper (exported) — returns \`true\` for Fault and GPS Fix
- GPS Fix \`case 'gpsFix'\`: lat/lon now rendered as a \`<a href="https://www.google.com/maps?q=lat,lon">\` link in blue
- \`case 'run'\`: wrapper \`<div>\` now has \`style={{ color: 'purple' }}\`
- \`startedMission\`/\`defaultMission\`: added \`text-base\` class for slightly larger font
- \`logFault\`: restored MTMSN= conditional so fault messages containing MTMSN values still show the MTMSN portion in dark-red

### \`LogsSection.tsx\`
- Imports \`labelColorForEventType\` and \`labelBoldForEventType\`, passes results as \`labelColor\`/\`labelBold\` to each \`<LogCell>\`

### Tests
- \`LogCell.test.tsx\`: 3 new tests for \`labelColor\` (comfortable, compact, omitted) + 2 for \`labelBold\`
- \`formatEvent.test.tsx\`: tests for \`labelColorForEventType\`, \`labelBoldForEventType\`, GPS Fix Maps link, logFault amber color, run description purple, startedMission/defaultMission \`text-base\`
- \`LogsSection.test.tsx\`: integration tests asserting Fault and GPS Fix labels render with correct color and bold wiring

## Test plan
- [ ] Open the Logs panel for a vehicle with recent activity
- [ ] Confirm **Fault** rows show the type label in amber/orange and bold
- [ ] Confirm **GPS Fix** rows show the type label in blue and bold; lat/lon text is blue and clicking opens Google Maps
- [ ] Confirm **Mission Request** rows show the description text in purple; the label stays default color
- [ ] Confirm **Started mission** \`logImportant\` text is bold purple and slightly larger than surrounding lines
- [ ] Confirm all other event types remain their default color (no regression)
- [ ] Toggle compact mode — colors should persist in both layouts