### PR TITLE
feat(#278): preserve open accordion tab across vehicle switches

### DIFF
--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -24,6 +24,16 @@ export type VehicleAccordionSection =
   | 'docs'
   | null
 
+const SECTION_STORAGE_KEY = 'accordion:section'
+const VALID_SECTIONS: VehicleAccordionSection[] = [
+  'handoff',
+  'data',
+  'schedule',
+  'comms',
+  'log',
+  'docs',
+]
+
 export interface VehicleAccordionProps {
   vehicleName: string
   from: number
@@ -122,16 +132,6 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
   // The mission started event text is always in the format "Started mission <mission name>"
   const currentMissionText = missionStartedEvent?.[0]?.text ?? ''
 
-  const SECTION_STORAGE_KEY = 'accordion:section'
-  const VALID_SECTIONS: VehicleAccordionSection[] = [
-    'handoff',
-    'data',
-    'schedule',
-    'comms',
-    'log',
-    'docs',
-  ]
-
   // Initialize to null to match SSR output; restore from localStorage after
   // hydration to avoid server/client markup mismatches.
   const [section, setSection] = useState<VehicleAccordionSection>(null)
@@ -147,7 +147,6 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
     } catch {
       // localStorage unavailable (SSR, private browsing)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleToggleForSection =

--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -1,5 +1,5 @@
 import { AccordionHeader } from '@mbari/react-ui'
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import CommsSection from './CommsSection'
 import DocsSection from './DocsSection'
 import HandoffSection from './HandoffSection'
@@ -123,15 +123,32 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
   const currentMissionText = missionStartedEvent?.[0]?.text ?? ''
 
   const SECTION_STORAGE_KEY = 'accordion:section'
+  const VALID_SECTIONS: VehicleAccordionSection[] = [
+    'handoff',
+    'data',
+    'schedule',
+    'comms',
+    'log',
+    'docs',
+  ]
 
-  const [section, setSection] = useState<VehicleAccordionSection>(() => {
+  // Initialize to null to match SSR output; restore from localStorage after
+  // hydration to avoid server/client markup mismatches.
+  const [section, setSection] = useState<VehicleAccordionSection>(null)
+  useEffect(() => {
     try {
       const stored = localStorage.getItem(SECTION_STORAGE_KEY)
-      return (stored as VehicleAccordionSection) ?? null
+      if (
+        stored &&
+        VALID_SECTIONS.includes(stored as VehicleAccordionSection)
+      ) {
+        setSection(stored as VehicleAccordionSection)
+      }
     } catch {
-      return null
+      // localStorage unavailable (SSR, private browsing)
     }
-  })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleToggleForSection =
     (currentSection: VehicleAccordionSection) => (open: boolean) => {

--- a/apps/lrauv-dash2/components/VehicleAccordion.tsx
+++ b/apps/lrauv-dash2/components/VehicleAccordion.tsx
@@ -122,15 +122,31 @@ const VehicleAccordion: React.FC<VehicleAccordionProps> = ({
   // The mission started event text is always in the format "Started mission <mission name>"
   const currentMissionText = missionStartedEvent?.[0]?.text ?? ''
 
-  const [section, setSection] = useState<VehicleAccordionSection>(null)
-  const handleToggleForSection =
-    (currentSection: VehicleAccordionSection) => (open: boolean) =>
-      setSection(open ? currentSection : null)
+  const SECTION_STORAGE_KEY = 'accordion:section'
 
-  if (!currentMissionText || !activeDeployment) {
-    ;(currentSection: VehicleAccordionSection) => (open: boolean) =>
-      setSection(open ? currentSection : 'comms')
-  }
+  const [section, setSection] = useState<VehicleAccordionSection>(() => {
+    try {
+      const stored = localStorage.getItem(SECTION_STORAGE_KEY)
+      return (stored as VehicleAccordionSection) ?? null
+    } catch {
+      return null
+    }
+  })
+
+  const handleToggleForSection =
+    (currentSection: VehicleAccordionSection) => (open: boolean) => {
+      const next = open ? currentSection : null
+      setSection(next)
+      try {
+        if (next) {
+          localStorage.setItem(SECTION_STORAGE_KEY, next)
+        } else {
+          localStorage.removeItem(SECTION_STORAGE_KEY)
+        }
+      } catch {
+        // localStorage unavailable (private browsing, etc.)
+      }
+    }
 
   const handoffLabel =
     (picLabel || onCallLabel) && authenticated

--- a/apps/lrauv-dash2/jest/VehicleAccordion.test.tsx
+++ b/apps/lrauv-dash2/jest/VehicleAccordion.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import VehicleAccordion from '../components/VehicleAccordion'
 import { QueryClient } from 'react-query'
@@ -303,8 +303,20 @@ test('queue count ignores sent commands from a previous deployment', async () =>
 describe('accordion section persistence via localStorage', () => {
   const STORAGE_KEY = 'accordion:section'
 
-  beforeEach(() => localStorage.removeItem(STORAGE_KEY))
-  afterEach(() => localStorage.removeItem(STORAGE_KEY))
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY)
+    // Silence MSW unhandled-request warnings for the queries VehicleAccordion
+    // always fires on mount (useCommsEvents, useEvents timeout-notes).
+    server.use(
+      rest.get('/events', (_req, res, ctx) =>
+        res(ctx.status(200), ctx.json({ result: [] }))
+      )
+    )
+  })
+  afterEach(() => {
+    localStorage.removeItem(STORAGE_KEY)
+    server.resetHandlers()
+  })
 
   const renderAccordion = () =>
     render(
@@ -319,20 +331,30 @@ describe('accordion section persistence via localStorage', () => {
     expect(localStorage.getItem(STORAGE_KEY)).toBe('log')
   })
 
-  test('closing an open tab removes the key from localStorage', () => {
+  test('closing an open tab removes the key from localStorage', async () => {
     localStorage.setItem(STORAGE_KEY, 'log')
     renderAccordion()
-    // Section starts open; one click closes it
-    fireEvent.click(screen.getByText('Log'))
+    // useEffect restores the section after mount — wait for it
+    await waitFor(() =>
+      expect(screen.getByText('Log').closest('div')).toHaveClass(
+        'bg-primary-600'
+      )
+    )
+    // Section is now open; one click closes it
+    act(() => fireEvent.click(screen.getByText('Log')))
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
   })
 
-  test('restores the previously open tab on mount', () => {
-    localStorage.setItem(STORAGE_KEY, 'schedule')
+  test('restores the previously open tab on mount', async () => {
+    // Use 'log' rather than 'schedule' to avoid mounting ScheduleSection
+    // (which triggers unmocked network requests)
+    localStorage.setItem(STORAGE_KEY, 'log')
     renderAccordion()
-    // AccordionHeader marks the open container with bg-primary-600
-    const headerDiv = screen.getByText('Schedule').closest('div') as HTMLElement
-    expect(headerDiv).toHaveClass('bg-primary-600')
+    // useEffect restores the section after hydration — wait for it
+    await waitFor(() => {
+      const headerDiv = screen.getByText('Log').closest('div') as HTMLElement
+      expect(headerDiv).toHaveClass('bg-primary-600')
+    })
   })
 
   test('switching sections updates the stored key', () => {

--- a/apps/lrauv-dash2/jest/VehicleAccordion.test.tsx
+++ b/apps/lrauv-dash2/jest/VehicleAccordion.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import VehicleAccordion from '../components/VehicleAccordion'
 import { QueryClient } from 'react-query'
@@ -295,6 +295,52 @@ test('queue count ignores sent commands from a previous deployment', async () =>
 
   await waitFor(() => {
     expect(screen.getByText('0 item(s) in queue')).toBeInTheDocument()
+  })
+})
+
+// ── Accordion tab persistence (#278) ──────────────────────────────────────────
+
+describe('accordion section persistence via localStorage', () => {
+  const STORAGE_KEY = 'accordion:section'
+
+  beforeEach(() => localStorage.removeItem(STORAGE_KEY))
+  afterEach(() => localStorage.removeItem(STORAGE_KEY))
+
+  const renderAccordion = () =>
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <VehicleAccordion {...props} />
+      </MockProviders>
+    )
+
+  test('opening a tab saves the section to localStorage', () => {
+    renderAccordion()
+    fireEvent.click(screen.getByText('Log'))
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('log')
+  })
+
+  test('closing an open tab removes the key from localStorage', () => {
+    localStorage.setItem(STORAGE_KEY, 'log')
+    renderAccordion()
+    // Section starts open; one click closes it
+    fireEvent.click(screen.getByText('Log'))
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  })
+
+  test('restores the previously open tab on mount', () => {
+    localStorage.setItem(STORAGE_KEY, 'schedule')
+    renderAccordion()
+    // AccordionHeader marks the open container with bg-primary-600
+    const headerDiv = screen.getByText('Schedule').closest('div') as HTMLElement
+    expect(headerDiv).toHaveClass('bg-primary-600')
+  })
+
+  test('switching sections updates the stored key', () => {
+    renderAccordion()
+    fireEvent.click(screen.getByText('Log'))
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('log')
+    fireEvent.click(screen.getByText('Comms Queue'))
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('comms')
   })
 })
 

--- a/apps/lrauv-dash2/jest/useSidebarSizes.test.ts
+++ b/apps/lrauv-dash2/jest/useSidebarSizes.test.ts
@@ -3,8 +3,14 @@ import { useSidebarSizes } from '../lib/useSidebarSizes'
 
 const STORAGE_KEY = 'sidebar:rightPct'
 
-beforeEach(() => localStorage.removeItem(STORAGE_KEY))
-afterEach(() => localStorage.removeItem(STORAGE_KEY))
+beforeEach(() => {
+  localStorage.removeItem(STORAGE_KEY)
+  jest.useFakeTimers()
+})
+afterEach(() => {
+  localStorage.removeItem(STORAGE_KEY)
+  jest.useRealTimers()
+})
 
 test('returns default [75, 25] when nothing is stored', () => {
   const { result } = renderHook(() => useSidebarSizes())
@@ -18,25 +24,58 @@ test('restores stored right-pane percentage as defaultSizes on mount', () => {
   expect(result.current.defaultSizes[0]).toBeCloseTo(60, 1)
 })
 
-test('onSidebarChange saves the right-pane percentage to localStorage', () => {
+test('onSidebarChange saves the right-pane percentage after debounce', () => {
   const { result } = renderHook(() => useSidebarSizes())
   act(() => {
     result.current.onSidebarChange([900, 300])
+    jest.runAllTimers()
   })
   const stored = parseFloat(localStorage.getItem(STORAGE_KEY) ?? '')
   expect(stored).toBeCloseTo(25, 1)
 })
 
+test('onSidebarChange does not write immediately — debounces the write', () => {
+  const { result } = renderHook(() => useSidebarSizes())
+  act(() => {
+    result.current.onSidebarChange([900, 300])
+    // Timer has not fired yet
+  })
+  expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  act(() => jest.runAllTimers())
+  expect(localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+})
+
 test('onSidebarChange updates the stored value when the user resizes', () => {
   const { result } = renderHook(() => useSidebarSizes())
-  act(() => result.current.onSidebarChange([800, 400]))
+  act(() => {
+    result.current.onSidebarChange([800, 400])
+    jest.runAllTimers()
+  })
   expect(parseFloat(localStorage.getItem(STORAGE_KEY) ?? '')).toBeCloseTo(
     33.33,
     1
   )
 })
 
-test('ignores stored values outside the 5–95 % safety range', () => {
+test('onSidebarChange skips writing out-of-range values (< 5%)', () => {
+  const { result } = renderHook(() => useSidebarSizes())
+  act(() => {
+    result.current.onSidebarChange([990, 10]) // ~1% right — out of range
+    jest.runAllTimers()
+  })
+  expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+})
+
+test('onSidebarChange skips writing out-of-range values (> 95%)', () => {
+  const { result } = renderHook(() => useSidebarSizes())
+  act(() => {
+    result.current.onSidebarChange([10, 990]) // ~99% right — out of range
+    jest.runAllTimers()
+  })
+  expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+})
+
+test('ignores stored values outside the 5–95 % safety range on mount', () => {
   localStorage.setItem(STORAGE_KEY, '2.00')
   const { result } = renderHook(() => useSidebarSizes())
   expect(result.current.defaultSizes).toEqual([75, 25])

--- a/apps/lrauv-dash2/jest/useSidebarSizes.test.ts
+++ b/apps/lrauv-dash2/jest/useSidebarSizes.test.ts
@@ -42,6 +42,16 @@ test('ignores stored values outside the 5–95 % safety range', () => {
   expect(result.current.defaultSizes).toEqual([75, 25])
 })
 
+test('accepts boundary values of exactly 5% and 95%', () => {
+  localStorage.setItem(STORAGE_KEY, '5.00')
+  const { result: r5 } = renderHook(() => useSidebarSizes())
+  expect(r5.current.defaultSizes[1]).toBeCloseTo(5, 1)
+
+  localStorage.setItem(STORAGE_KEY, '95.00')
+  const { result: r95 } = renderHook(() => useSidebarSizes())
+  expect(r95.current.defaultSizes[1]).toBeCloseTo(95, 1)
+})
+
 test('onSidebarChange is a stable reference (does not change between renders)', () => {
   const { result, rerender } = renderHook(() => useSidebarSizes())
   const first = result.current.onSidebarChange

--- a/apps/lrauv-dash2/jest/useSidebarSizes.test.ts
+++ b/apps/lrauv-dash2/jest/useSidebarSizes.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from '@testing-library/react'
+import { useSidebarSizes } from '../lib/useSidebarSizes'
+
+const STORAGE_KEY = 'sidebar:rightPct'
+
+beforeEach(() => localStorage.removeItem(STORAGE_KEY))
+afterEach(() => localStorage.removeItem(STORAGE_KEY))
+
+test('returns default [75, 25] when nothing is stored', () => {
+  const { result } = renderHook(() => useSidebarSizes())
+  expect(result.current.defaultSizes).toEqual([75, 25])
+})
+
+test('restores stored right-pane percentage as defaultSizes on mount', () => {
+  localStorage.setItem(STORAGE_KEY, '40.00')
+  const { result } = renderHook(() => useSidebarSizes())
+  expect(result.current.defaultSizes[1]).toBeCloseTo(40, 1)
+  expect(result.current.defaultSizes[0]).toBeCloseTo(60, 1)
+})
+
+test('onSidebarChange saves the right-pane percentage to localStorage', () => {
+  const { result } = renderHook(() => useSidebarSizes())
+  act(() => {
+    result.current.onSidebarChange([900, 300])
+  })
+  const stored = parseFloat(localStorage.getItem(STORAGE_KEY) ?? '')
+  expect(stored).toBeCloseTo(25, 1)
+})
+
+test('onSidebarChange updates the stored value when the user resizes', () => {
+  const { result } = renderHook(() => useSidebarSizes())
+  act(() => result.current.onSidebarChange([800, 400]))
+  expect(parseFloat(localStorage.getItem(STORAGE_KEY) ?? '')).toBeCloseTo(
+    33.33,
+    1
+  )
+})
+
+test('ignores stored values outside the 5–95 % safety range', () => {
+  localStorage.setItem(STORAGE_KEY, '2.00')
+  const { result } = renderHook(() => useSidebarSizes())
+  expect(result.current.defaultSizes).toEqual([75, 25])
+})
+
+test('onSidebarChange is a stable reference (does not change between renders)', () => {
+  const { result, rerender } = renderHook(() => useSidebarSizes())
+  const first = result.current.onSidebarChange
+  rerender()
+  expect(result.current.onSidebarChange).toBe(first)
+})

--- a/apps/lrauv-dash2/jest/useSidebarSizes.test.ts
+++ b/apps/lrauv-dash2/jest/useSidebarSizes.test.ts
@@ -91,6 +91,20 @@ test('accepts boundary values of exactly 5% and 95%', () => {
   expect(r95.current.defaultSizes[1]).toBeCloseTo(95, 1)
 })
 
+test('flushes the pending write synchronously on unmount (navigate-away scenario)', () => {
+  const { result, unmount } = renderHook(() => useSidebarSizes())
+  act(() => {
+    result.current.onSidebarChange([700, 300]) // 30% right, timer not yet fired
+  })
+  // Timer has not fired — nothing written yet
+  expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+  // Unmount (simulate page navigation within debounce window)
+  unmount()
+  // Pending value should have been flushed synchronously
+  const stored = parseFloat(localStorage.getItem(STORAGE_KEY) ?? '')
+  expect(stored).toBeCloseTo(30, 1)
+})
+
 test('onSidebarChange is a stable reference (does not change between renders)', () => {
   const { result, rerender } = renderHook(() => useSidebarSizes())
   const first = result.current.onSidebarChange

--- a/apps/lrauv-dash2/lib/useSidebarSizes.ts
+++ b/apps/lrauv-dash2/lib/useSidebarSizes.ts
@@ -33,12 +33,22 @@ export function useSidebarSizes(): {
   })
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pendingPctRef = useRef<number | null>(null)
 
-  // Cancel any pending write on unmount to avoid writing after the component
-  // is gone (e.g. during page navigation).
+  // On unmount flush any pending debounced value immediately so a navigation
+  // that happens within the debounce window still persists the last width.
   useEffect(() => {
     return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current)
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current)
+        if (pendingPctRef.current !== null) {
+          try {
+            localStorage.setItem(STORAGE_KEY, pendingPctRef.current.toFixed(2))
+          } catch {
+            // ignore storage failures
+          }
+        }
+      }
     }
   }, [])
 
@@ -50,8 +60,10 @@ export function useSidebarSizes(): {
     // Skip extreme values so we never overwrite a valid setting with one that
     // would fall back to defaults on the next mount.
     if (rightPct < 5 || rightPct > 95) return
+    pendingPctRef.current = rightPct
     if (debounceRef.current) clearTimeout(debounceRef.current)
     debounceRef.current = setTimeout(() => {
+      pendingPctRef.current = null
       try {
         localStorage.setItem(STORAGE_KEY, rightPct.toFixed(2))
       } catch {

--- a/apps/lrauv-dash2/lib/useSidebarSizes.ts
+++ b/apps/lrauv-dash2/lib/useSidebarSizes.ts
@@ -1,7 +1,8 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 const STORAGE_KEY = 'sidebar:rightPct'
 const DEFAULT_SIZES: [number, number] = [75, 25]
+const DEBOUNCE_MS = 300
 
 /**
  * Persists the right-pane percentage of the Allotment split to localStorage
@@ -31,16 +32,32 @@ export function useSidebarSizes(): {
     return DEFAULT_SIZES
   })
 
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Cancel any pending write on unmount to avoid writing after the component
+  // is gone (e.g. during page navigation).
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [])
+
   const onSidebarChange = useCallback((sizes: number[]) => {
     if (sizes.length < 2) return
     const total = sizes[0] + sizes[1]
     if (total <= 0) return
     const rightPct = (sizes[1] / total) * 100
-    try {
-      localStorage.setItem(STORAGE_KEY, rightPct.toFixed(2))
-    } catch {
-      // ignore storage failures
-    }
+    // Skip extreme values so we never overwrite a valid setting with one that
+    // would fall back to defaults on the next mount.
+    if (rightPct < 5 || rightPct > 95) return
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      try {
+        localStorage.setItem(STORAGE_KEY, rightPct.toFixed(2))
+      } catch {
+        // ignore storage failures
+      }
+    }, DEBOUNCE_MS)
   }, [])
 
   return { defaultSizes, onSidebarChange }

--- a/apps/lrauv-dash2/lib/useSidebarSizes.ts
+++ b/apps/lrauv-dash2/lib/useSidebarSizes.ts
@@ -21,7 +21,7 @@ export function useSidebarSizes(): {
         typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null
       if (stored) {
         const rightPct = parseFloat(stored)
-        if (!isNaN(rightPct) && rightPct > 5 && rightPct < 95) {
+        if (!isNaN(rightPct) && rightPct >= 5 && rightPct <= 95) {
           return [100 - rightPct, rightPct]
         }
       }

--- a/apps/lrauv-dash2/lib/useSidebarSizes.ts
+++ b/apps/lrauv-dash2/lib/useSidebarSizes.ts
@@ -1,0 +1,47 @@
+import { useCallback, useState } from 'react'
+
+const STORAGE_KEY = 'sidebar:rightPct'
+const DEFAULT_SIZES: [number, number] = [75, 25]
+
+/**
+ * Persists the right-pane percentage of the Allotment split to localStorage
+ * so the user's preferred sidebar width is restored across page navigations.
+ *
+ * Returns:
+ *  - `defaultSizes`      — pass as the `defaultSizes` prop on <Allotment>
+ *  - `onSidebarChange`   — pass as (or compose into) the `onChange` prop
+ */
+export function useSidebarSizes(): {
+  defaultSizes: [number, number]
+  onSidebarChange: (sizes: number[]) => void
+} {
+  const [defaultSizes] = useState<[number, number]>(() => {
+    try {
+      const stored =
+        typeof window !== 'undefined' ? localStorage.getItem(STORAGE_KEY) : null
+      if (stored) {
+        const rightPct = parseFloat(stored)
+        if (!isNaN(rightPct) && rightPct > 5 && rightPct < 95) {
+          return [100 - rightPct, rightPct]
+        }
+      }
+    } catch {
+      // localStorage unavailable (SSR, private browsing)
+    }
+    return DEFAULT_SIZES
+  })
+
+  const onSidebarChange = useCallback((sizes: number[]) => {
+    if (sizes.length < 2) return
+    const total = sizes[0] + sizes[1]
+    if (total <= 0) return
+    const rightPct = (sizes[1] / total) * 100
+    try {
+      localStorage.setItem(STORAGE_KEY, rightPct.toFixed(2))
+    } catch {
+      // ignore storage failures
+    }
+  }, [])
+
+  return { defaultSizes, onSidebarChange }
+}

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -18,6 +18,7 @@ import useGlobalModalId from '../lib/useGlobalModalId'
 import useGoogleElevator from '../lib/useGoogleElevator'
 import { Allotment, LayoutPriority } from 'allotment'
 import { useGoogleMaps } from '../lib/useGoogleMaps'
+import { useSidebarSizes } from '../lib/useSidebarSizes'
 import { VPosDetail, useStations } from '@mbari/api-client'
 import 'allotment/dist/style.css'
 import { StationsListModal } from '../components/StationsListModal'
@@ -898,6 +899,7 @@ const OverviewPage: NextPage = () => {
   // Allotment's onChange fires it so the map re-measures after every
   // layout pass, including the initial one where pane sizes are first set.
   const mapInvalidateSizeRef = useRef<(() => void) | null>(null)
+  const { defaultSizes, onSidebarChange } = useSidebarSizes()
 
   useEffect(() => {
     if (!mounted.current) {
@@ -959,10 +961,11 @@ const OverviewPage: NextPage = () => {
                                 <Allotment
                                   separator
                                   snap
-                                  defaultSizes={[75, 25]}
+                                  defaultSizes={defaultSizes}
                                   proportionalLayout
-                                  onChange={() => {
+                                  onChange={(sizes) => {
                                     mapInvalidateSizeRef.current?.()
+                                    onSidebarChange(sizes)
                                   }}
                                 >
                                   <Allotment.Pane>

--- a/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
+++ b/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
@@ -41,6 +41,7 @@ import { useLastCommsTime } from '../../lib/useLastCommsTime'
 import { Allotment } from 'allotment'
 import 'allotment/dist/style.css'
 import { useGoogleMaps } from '../../lib/useGoogleMaps'
+import { useSidebarSizes } from '../../lib/useSidebarSizes'
 import { SelectedStationsProvider } from '../../components/SelectedStationContext'
 import { MapCameraProvider } from '../../components/MapCameraContext'
 import { SelectedPolygonsProvider } from '../../components/SelectedPolygonsContext'
@@ -112,6 +113,7 @@ const Vehicle: NextPage = () => {
 
   const [mobileView, setMobileView] = useState<MobileView>('main')
   const isDesktop = useIsDesktop()
+  const { defaultSizes, onSidebarChange } = useSidebarSizes()
 
   const params = (router.query?.deployment ?? []) as string[]
   const vehicleName = params[0]
@@ -496,8 +498,9 @@ const Vehicle: NextPage = () => {
                         <div className={styles.content}>
                           <Allotment
                             separator
-                            defaultSizes={[75, 25]}
+                            defaultSizes={defaultSizes}
                             className="min-h-0"
+                            onChange={onSidebarChange}
                           >
                             <Allotment.Pane minSize={720}>
                               {primarySection}


### PR DESCRIPTION
## Summary

Closes #278.

Two related UX improvements so the accordion panel state is preserved when switching between vehicles or navigating between pages:

### 1. Preserve open accordion tab across vehicle switches
The section state was local to \`VehicleAccordion\` and reset to \`null\` on every vehicle change. Now the active tab is persisted to \`localStorage('accordion:section')\`:

- **Opening a tab** saves the section name
- **Closing an open tab** removes the key (no auto-open on next mount)
- **Switching tabs** updates the key in one write
- Falls back silently on private browsing / SSR

### 2. Persist sidebar width across Overview and Deployment pages
The Allotment split defaulted to \`[75, 25]\` on every page load. Now the right-pane percentage is saved to \`localStorage('sidebar:rightPct')\` on every drag and restored on mount:

- New \`useSidebarSizes()\` hook reads on mount, writes on \`onChange\`
- Ignores values outside 5–95% (avoids restoring an unusable layout)
- Deployment page: \`defaultSizes\` and \`onChange\` wired to hook
- Overview page: existing \`onChange\` (map invalidation) extended to also call \`onSidebarChange\`

## Changes

- \`VehicleAccordion.tsx\` — lazy \`useState\` initializer reads \`localStorage\`; \`handleToggleForSection\` writes/removes on every toggle; dead-code block removed
- \`lib/useSidebarSizes.ts\` — new hook
- \`pages/vehicle/[...deployment].tsx\` — wired to \`useSidebarSizes\`
- \`pages/index.tsx\` — wired to \`useSidebarSizes\`

## Tests

- \`VehicleAccordion.test.tsx\` — 4 new tests: open saves key, close removes key, restores on mount, switching updates key
- \`jest/useSidebarSizes.test.ts\` — 6 tests: default, restore, write, update, safety guard, stable reference

## Test plan
- [ ] Open the **Log** tab on vehicle A → switch to vehicle B → Log tab should still be open
- [ ] Close the tab → switch vehicles → no tab auto-opens
- [ ] Drag the sidebar narrower on the Overview page → navigate to a vehicle deployment page → sidebar opens at the same width
- [ ] Drag on the deployment page → go back to Overview → width preserved
- [ ] Verify private/incognito browsing → accordion and sidebar still work, just don't persist