### PR TITLE
fix(#557): prevent React state-after-unmount warnings in async useEffects

### DIFF
--- a/apps/lrauv-dash2/components/MarkerContext.tsx
+++ b/apps/lrauv-dash2/components/MarkerContext.tsx
@@ -16,7 +16,6 @@ import React, {
 // } from '@mbari/api-client'
 import toast from 'react-hot-toast'
 import { createLogger } from '@mbari/utils'
-import { set } from 'msw/lib/types/context'
 
 const logger = createLogger('MarkerContext')
 
@@ -103,23 +102,32 @@ export const MarkerProvider: React.FC<{ children: React.ReactNode }> = ({
 
   // Fetch markers on mount
   useEffect(() => {
+    let cancelled = false
     const fetchMarkers = async () => {
+      if (cancelled) return
       setLoading(true)
       try {
         const response = await getMarkers()
-        setMarkers(response)
-        setError(null)
+        if (!cancelled) {
+          setMarkers(response)
+          setError(null)
+        }
       } catch (err) {
-        logger.error('Failed to fetch markers:', err)
-        setError(
-          err instanceof Error ? err : new Error('Failed to fetch markers')
-        )
+        if (!cancelled) {
+          logger.error('Failed to fetch markers:', err)
+          setError(
+            err instanceof Error ? err : new Error('Failed to fetch markers')
+          )
+        }
       } finally {
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       }
     }
 
     fetchMarkers()
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   // Load markers from localStorage on initial mount

--- a/apps/lrauv-dash2/lib/useGoogleElevator.test.ts
+++ b/apps/lrauv-dash2/lib/useGoogleElevator.test.ts
@@ -92,20 +92,22 @@ test('does not update state after unmount (cancelled flag)', async () => {
 
   const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
 
-  await act(async () => {
-    elevationService.__resolveAll({})
-  })
+  try {
+    await act(async () => {
+      elevationService.__resolveAll({})
+    })
 
-  // React logs "Can't perform a React state update on an unmounted component"
-  // (or similar) via console.error. Check every argument across all calls.
-  const allArgs = consoleError.mock.calls.flat()
-  const hasStateWarning = allArgs.some(
-    (arg) => typeof arg === 'string' && /state update/i.test(arg)
-  )
-  expect(hasStateWarning).toBe(false)
+    // React logs "Can't perform a React state update on an unmounted component"
+    // (or similar) via console.error. Check every argument across all calls.
+    const allArgs = consoleError.mock.calls.flat()
+    const hasStateWarning = allArgs.some(
+      (arg) => typeof arg === 'string' && /state update/i.test(arg)
+    )
+    expect(hasStateWarning).toBe(false)
 
-  consoleError.mockRestore()
-
-  // The rendered state should remain null since setState was never called.
-  expect(result.current.elevationAvailable).toBeNull()
+    // The rendered state should remain null since setState was never called.
+    expect(result.current.elevationAvailable).toBeNull()
+  } finally {
+    consoleError.mockRestore()
+  }
 })

--- a/apps/lrauv-dash2/lib/useGoogleElevator.test.ts
+++ b/apps/lrauv-dash2/lib/useGoogleElevator.test.ts
@@ -3,7 +3,8 @@ import '@testing-library/jest-dom'
 import { useElevator } from './useGoogleElevator'
 
 // The global `google.maps` mock is set up in jest/setup.js.
-// Reset the module-level singleton between tests so each test starts fresh.
+// elevationService is mocked below so tests can control when the Promise
+// resolves/rejects without touching the real singleton.
 jest.mock('./elevationService', () => {
   let resolvers: Array<(svc: unknown) => void> = []
   let rejecters: Array<(err: unknown) => void> = []
@@ -15,6 +16,12 @@ jest.mock('./elevationService', () => {
   }
   const __rejectAll = (err = new Error('unavailable')) => {
     rejecters.forEach((r) => r(err))
+    resolvers = []
+    rejecters = []
+  }
+  // Drop any pending (unresolved/unrejected) promises from a previous test so
+  // they can't bleed across test boundaries.
+  const __reset = () => {
     resolvers = []
     rejecters = []
   }
@@ -30,6 +37,7 @@ jest.mock('./elevationService', () => {
     getCachedElevation: jest.fn().mockResolvedValue(null),
     __resolveAll,
     __rejectAll,
+    __reset,
   }
 })
 
@@ -37,10 +45,17 @@ const elevationService = jest.requireMock('./elevationService') as {
   getElevationService: jest.Mock
   __resolveAll: (svc?: unknown) => void
   __rejectAll: (err?: unknown) => void
+  __reset: () => void
 }
 
 beforeEach(() => {
   elevationService.getElevationService.mockClear()
+  elevationService.__reset()
+})
+
+afterEach(() => {
+  // Drain any outstanding promises so they don't leak into later tests.
+  elevationService.__reset()
 })
 
 test('starts with elevationAvailable null', () => {
@@ -71,7 +86,8 @@ test('sets elevationAvailable false when service rejects', async () => {
 test('does not update state after unmount (cancelled flag)', async () => {
   const { result, unmount } = renderHook(() => useElevator())
 
-  // Unmount before the service resolves
+  // Unmount before the service resolves — the cancelled flag should prevent
+  // any setState call from firing.
   unmount()
 
   const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
@@ -80,13 +96,16 @@ test('does not update state after unmount (cancelled flag)', async () => {
     elevationService.__resolveAll({})
   })
 
-  // React should NOT log a "Can't perform state update on unmounted component"
-  // warning because the cancelled flag prevents the setState call.
-  expect(consoleError).not.toHaveBeenCalledWith(
-    expect.stringMatching(/state update/i)
+  // React logs "Can't perform a React state update on an unmounted component"
+  // (or similar) via console.error. Check every argument across all calls.
+  const allArgs = consoleError.mock.calls.flat()
+  const hasStateWarning = allArgs.some(
+    (arg) => typeof arg === 'string' && /state update/i.test(arg)
   )
+  expect(hasStateWarning).toBe(false)
+
   consoleError.mockRestore()
 
-  // The state should not have changed (result is from before unmount)
+  // The rendered state should remain null since setState was never called.
   expect(result.current.elevationAvailable).toBeNull()
 })

--- a/apps/lrauv-dash2/lib/useGoogleElevator.test.ts
+++ b/apps/lrauv-dash2/lib/useGoogleElevator.test.ts
@@ -1,0 +1,92 @@
+import { renderHook, act } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { useElevator } from './useGoogleElevator'
+
+// The global `google.maps` mock is set up in jest/setup.js.
+// Reset the module-level singleton between tests so each test starts fresh.
+jest.mock('./elevationService', () => {
+  let resolvers: Array<(svc: unknown) => void> = []
+  let rejecters: Array<(err: unknown) => void> = []
+
+  const __resolveAll = (svc = {}) => {
+    resolvers.forEach((r) => r(svc))
+    resolvers = []
+    rejecters = []
+  }
+  const __rejectAll = (err = new Error('unavailable')) => {
+    rejecters.forEach((r) => r(err))
+    resolvers = []
+    rejecters = []
+  }
+
+  return {
+    getElevationService: jest.fn(
+      () =>
+        new Promise((resolve, reject) => {
+          resolvers.push(resolve)
+          rejecters.push(reject)
+        })
+    ),
+    getCachedElevation: jest.fn().mockResolvedValue(null),
+    __resolveAll,
+    __rejectAll,
+  }
+})
+
+const elevationService = jest.requireMock('./elevationService') as {
+  getElevationService: jest.Mock
+  __resolveAll: (svc?: unknown) => void
+  __rejectAll: (err?: unknown) => void
+}
+
+beforeEach(() => {
+  elevationService.getElevationService.mockClear()
+})
+
+test('starts with elevationAvailable null', () => {
+  const { result } = renderHook(() => useElevator())
+  expect(result.current.elevationAvailable).toBeNull()
+})
+
+test('sets elevationAvailable true when service resolves', async () => {
+  const { result } = renderHook(() => useElevator())
+
+  await act(async () => {
+    elevationService.__resolveAll({})
+  })
+
+  expect(result.current.elevationAvailable).toBe(true)
+})
+
+test('sets elevationAvailable false when service rejects', async () => {
+  const { result } = renderHook(() => useElevator())
+
+  await act(async () => {
+    elevationService.__rejectAll(new Error('no maps'))
+  })
+
+  expect(result.current.elevationAvailable).toBe(false)
+})
+
+test('does not update state after unmount (cancelled flag)', async () => {
+  const { result, unmount } = renderHook(() => useElevator())
+
+  // Unmount before the service resolves
+  unmount()
+
+  const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+  await act(async () => {
+    elevationService.__resolveAll({})
+  })
+
+  // React should NOT log a "Can't perform state update on unmounted component"
+  // warning because the cancelled flag prevents the setState call.
+  expect(consoleError).not.toHaveBeenCalledWith(
+    expect.stringMatching(/state update/i)
+  )
+  consoleError.mockRestore()
+
+  // The state should not have changed (result is from before unmount)
+  expect(result.current.elevationAvailable).toBeNull()
+})

--- a/apps/lrauv-dash2/lib/useGoogleElevator.ts
+++ b/apps/lrauv-dash2/lib/useGoogleElevator.ts
@@ -19,17 +19,27 @@ export function useElevator() {
     null
   )
 
-  // Initialize elevation service on mount
+  // Initialize elevation service on mount. The cancelled flag prevents calling
+  // setState after the component unmounts (avoids "state update on unmounted
+  // component" console warnings when the deployment page is left quickly).
   useEffect(() => {
+    let cancelled = false
     getElevationService()
       .then(() => {
-        setElevationAvailable(true)
-        logger.info('👍 Elevation service ready')
+        if (!cancelled) {
+          setElevationAvailable(true)
+          logger.info('👍 Elevation service ready')
+        }
       })
       .catch(() => {
-        setElevationAvailable(false)
-        logger.warn('⚠️ Elevation service unavailable')
+        if (!cancelled) {
+          setElevationAvailable(false)
+          logger.warn('⚠️ Elevation service unavailable')
+        }
       })
+    return () => {
+      cancelled = true
+    }
   }, [])
 
   const handleDepthRequest = useCallback(


### PR DESCRIPTION
## Summary

Closes #557

The browser console on the deployment page showed:

```
Warning: Can't perform a React state update on a component that hasn't mounted yet.
This indicates that you have a side-effect in your render function that asynchronously
later calls tries to update the component. Move this work to useEffect instead.

  at DeploymentMap (DeploymentMap.tsx:86:3)
```

The root cause was `useGoogleElevator.ts` using the `useState` lazy initializer to start an async `getElevationService()` call — meaning state could be set before the component had mounted. That initializer was replaced with a `useEffect` in a previous commit. This PR adds the remaining safeguards so the warning cannot recur:

- **`useGoogleElevator.ts`** — add a `cancelled` cleanup flag to the `useEffect` so a slow-resolving `getElevationService()` Promise never calls `setState` on an unmounted component.
- **`MarkerContext.tsx`** — apply the same `cancelled`-flag pattern to `fetchMarkers` for consistency; also remove the stale unused `import { set } from 'msw/lib/types/context'`.
- **`lib/useGoogleElevator.test.ts`** (new) — four Jest tests covering: initial `null` state, resolved service sets `true`, rejected service sets `false`, and no `setState` after unmount.

## Test plan

- [x] `yarn test:ci` in `apps/lrauv-dash2` — 244 tests pass (1 pre-existing flaky `LogsSection` timing test, documented in prior PRs)
- [x] New `useGoogleElevator.test.ts` — all 4 tests green
- [ ] Navigate to a vehicle deployment page in the dev browser and confirm the React warning no longer appears in the console