### PR TITLE
feat(#270): show last comms elapsed time in the vehicle log toolbar

### DIFF
--- a/apps/lrauv-dash2/components/LogsSection.tsx
+++ b/apps/lrauv-dash2/components/LogsSection.tsx
@@ -39,6 +39,7 @@ import {
   useDebounce,
   useResizeObserver,
 } from '@mbari/utils'
+import { useLastCommsTime } from '../lib/useLastCommsTime'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import {
   faChevronDown,
@@ -229,6 +230,21 @@ const LogsSection: React.FC<LogsSectionProps> = ({
           }
         )
       : undefined
+
+  // Last comms — show elapsed time since the most recent sat or cell contact.
+  const { lastSatCommsTime, lastCellCommsTime } = useLastCommsTime(
+    vehicleName,
+    from
+  )
+  const lastCommsTimeMs =
+    lastSatCommsTime !== null || lastCellCommsTime !== null
+      ? Math.max(lastSatCommsTime ?? 0, lastCellCommsTime ?? 0)
+      : null
+  const lastCommsDuration = lastCommsTimeMs
+    ? formatCompactDuration(DateTime.fromMillis(lastCommsTimeMs), nowDT, {
+        maxDays: 7,
+      })
+    : undefined
 
   const flatData = useMemo(() => {
     if (!hasSelection) return []
@@ -507,6 +523,7 @@ const LogsSection: React.FC<LogsSectionProps> = ({
           disabled={isLoading || isFetching}
           handleRefresh={handleRefresh}
           lastUpdatedDuration={lastUpdatedDuration}
+          lastCommsDuration={lastCommsDuration}
           compact={compact}
           onToggleCompact={handleToggleCompact}
           className="min-w-0 shrink pl-2"

--- a/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.test.tsx
@@ -60,6 +60,19 @@ describe('LogsToolbar', () => {
     expect(screen.queryByText(/updated/i)).not.toBeInTheDocument()
   })
 
+  test('renders lastCommsDuration when provided', () => {
+    render(<LogsToolbar {...defaultProps} lastCommsDuration="1h 4m" />)
+    expect(screen.getByTestId('last-comms-duration')).toBeInTheDocument()
+    expect(screen.getByText('Last comms')).toBeInTheDocument()
+    expect(screen.getByText('1h 4m')).toBeInTheDocument()
+  })
+
+  test('does not render last-comms indicator when lastCommsDuration is omitted', () => {
+    render(<LogsToolbar {...defaultProps} />)
+    expect(screen.queryByTestId('last-comms-duration')).not.toBeInTheDocument()
+    expect(screen.queryByText('Last comms')).not.toBeInTheDocument()
+  })
+
   test('renders compact toggle button when onToggleCompact is provided', () => {
     const onToggleCompact = jest.fn()
     render(<LogsToolbar {...defaultProps} onToggleCompact={onToggleCompact} />)

--- a/packages/react-ui/src/Toolbars/LogsToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/LogsToolbar.tsx
@@ -16,6 +16,8 @@ export interface LogsToolbarProps {
   handleRefresh: () => void
   /** Duration since the last successful fetch, e.g. "2m". The component renders this as "Updated 2m ago". */
   lastUpdatedDuration?: string
+  /** Duration since the most-recent comms event (sat or cell), e.g. "1h 4m". Renders as "Last comms X ago". */
+  lastCommsDuration?: string
   /** When true, the log list is rendered in compact/dense mode. */
   compact?: boolean
   /** Called when the user toggles compact mode. */
@@ -29,6 +31,7 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
   disabled,
   handleRefresh,
   lastUpdatedDuration,
+  lastCommsDuration,
   compact = false,
   onToggleCompact,
   className,
@@ -72,6 +75,18 @@ export const LogsToolbar: React.FC<LogsToolbarProps> = ({
       >
         <span>Updated</span>
         <span>{lastUpdatedDuration}</span>
+        <span>ago</span>
+      </div>
+    )}
+
+    {lastCommsDuration && (
+      <div
+        className="flex flex-col items-center text-[9px] leading-tight text-stone-400"
+        aria-label="last comms time"
+        data-testid="last-comms-duration"
+      >
+        <span>Last comms</span>
+        <span>{lastCommsDuration}</span>
         <span>ago</span>
       </div>
     )}


### PR DESCRIPTION
## Summary

Closes #270.

Operators need to know at a glance how long it's been since the vehicle last communicated. This PR adds a **"Last comms X ago"** indicator directly in the Log section toolbar — visible without opening the log or hovering over anything.

- **`LogsToolbar`** (`packages/react-ui`): new optional `lastCommsDuration` prop renders a stacked _"Last comms / X / ago"_ label using the same `text-[9px]` style as the existing "Updated" counter.
- **`LogsSection`** (`apps/lrauv-dash2`): calls `useLastCommsTime(vehicleName, from)`, picks the most-recent of sat and cell comms times, formats it with `formatCompactDuration` (using the same 30 s `nowDT` tick already in the component), and passes it to `LogsToolbar` as `lastCommsDuration`.
- **`LogsToolbar.test.tsx`**: two new tests — renders the indicator when the prop is provided; does not render it when the prop is omitted.

## Test plan

- [ ] Open the Log accordion in the vehicle sidebar — "Last comms X ago" should appear in the toolbar next to "Updated X ago"
- [ ] If no comms events exist in history, the indicator should be absent
- [ ] `yarn workspace @mbari/react-ui test src/Toolbars/LogsToolbar.test.tsx` passes (12/12)