### PR TITLE
fix: wrap compact log label to 2 rows instead of truncating

### DIFF
--- a/packages/react-ui/src/Cells/LogCell.test.tsx
+++ b/packages/react-ui/src/Cells/LogCell.test.tsx
@@ -91,3 +91,10 @@ test('does not render label in bold by default', async () => {
   render(<LogCell {...props} />)
   expect(screen.getByText(props.label)).not.toHaveClass('font-bold')
 })
+
+test('compact label uses line-clamp-2 so two-word labels wrap to two rows', async () => {
+  render(<LogCell {...props} label="Command Request" compact />)
+  const label = screen.getByText('Command Request')
+  expect(label).toHaveClass('line-clamp-2')
+  expect(label).not.toHaveClass('truncate')
+})

--- a/packages/react-ui/src/Cells/LogCell.tsx
+++ b/packages/react-ui/src/Cells/LogCell.tsx
@@ -81,7 +81,10 @@ export const LogCell: React.FC<LogCellProps> = ({
               {isUpload ? <UploadIcon /> : <DownloadIcon />}
             </span>
             <span
-              className={clsx('truncate', labelBold && 'font-bold')}
+              className={clsx(
+                'line-clamp-2 leading-tight',
+                labelBold && 'font-bold'
+              )}
               style={labelColor ? { color: labelColor } : undefined}
             >
               {label}


### PR DESCRIPTION
## Summary

Follow-up to #646. In compact mode the event-type label span used `truncate`, which collapsed multi-word labels like "Command Request" and "Mission Request" to a single elided line. This replaces it with `line-clamp-2 leading-tight` so the text wraps naturally — first word on row 1, second word on row 2 — while still capping at 2 lines with `…` for any label with 3+ words.

Adds a `LogCell` test asserting `line-clamp-2` is applied (and `truncate` is absent) in compact mode.

## Test plan
- [ ] Open the log in compact mode — "Command Request", "Mission Request", "Direct Comms" etc. should now show on two rows
- [ ] `yarn workspace @mbari/react-ui test src/Cells/LogCell.test.tsx` passes (14/14)