### PR TITLE
fix: hide operator attribution for automatic Default missions in Schedule History

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -809,15 +809,21 @@ export const ScheduleEventDetailsModal: React.FC<
             </p>
             <p className="font-medium">{formatVia(event.via)}</p>
           </div>
-          {!event.isDefaultMission &&
-            event.label?.trim().toLowerCase() !== 'default mission' && (
+          {(() => {
+            const lbl = event.label?.trim().toLowerCase() ?? ''
+            const isDefault =
+              event.isDefaultMission ||
+              lbl === 'default mission' ||
+              lbl === 'default'
+            return isDefault ? null : (
               <div>
                 <p className="text-sm uppercase tracking-wide text-stone-500">
                   Operator
                 </p>
                 <p className="font-medium">{event.user || 'Unknown'}</p>
               </div>
-            )}
+            )
+          })()}
           <div>
             <p className="text-sm uppercase tracking-wide text-stone-500">
               Event ID

--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -809,14 +809,12 @@ export const ScheduleEventDetailsModal: React.FC<
             </p>
             <p className="font-medium">{formatVia(event.via)}</p>
           </div>
-          {!event.isDefaultMission && (
-            <div>
-              <p className="text-sm uppercase tracking-wide text-stone-500">
-                Operator
-              </p>
-              <p className="font-medium">{event.user || 'Unknown'}</p>
-            </div>
-          )}
+          <div>
+            <p className="text-sm uppercase tracking-wide text-stone-500">
+              Operator
+            </p>
+            <p className="font-medium">{event.user || 'Unknown'}</p>
+          </div>
           <div>
             <p className="text-sm uppercase tracking-wide text-stone-500">
               Event ID

--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -809,17 +809,15 @@ export const ScheduleEventDetailsModal: React.FC<
             </p>
             <p className="font-medium">{formatVia(event.via)}</p>
           </div>
-          <div>
-            <p className="text-sm uppercase tracking-wide text-stone-500">
-              Operator
-            </p>
-            <p className="font-medium">
-              {event.isDefaultMission ||
-              event.label?.trim().toLowerCase() === 'default mission'
-                ? 'Automatic (vehicle)'
-                : event.user || 'Unknown'}
-            </p>
-          </div>
+          {!event.isDefaultMission &&
+            event.label?.trim().toLowerCase() !== 'default mission' && (
+              <div>
+                <p className="text-sm uppercase tracking-wide text-stone-500">
+                  Operator
+                </p>
+                <p className="font-medium">{event.user || 'Unknown'}</p>
+              </div>
+            )}
           <div>
             <p className="text-sm uppercase tracking-wide text-stone-500">
               Event ID

--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -809,21 +809,14 @@ export const ScheduleEventDetailsModal: React.FC<
             </p>
             <p className="font-medium">{formatVia(event.via)}</p>
           </div>
-          {(() => {
-            const lbl = event.label?.trim().toLowerCase() ?? ''
-            const isDefault =
-              event.isDefaultMission ||
-              lbl === 'default mission' ||
-              lbl === 'default'
-            return isDefault ? null : (
-              <div>
-                <p className="text-sm uppercase tracking-wide text-stone-500">
-                  Operator
-                </p>
-                <p className="font-medium">{event.user || 'Unknown'}</p>
-              </div>
-            )
-          })()}
+          {!event.isDefaultMission && (
+            <div>
+              <p className="text-sm uppercase tracking-wide text-stone-500">
+                Operator
+              </p>
+              <p className="font-medium">{event.user || 'Unknown'}</p>
+            </div>
+          )}
           <div>
             <p className="text-sm uppercase tracking-wide text-stone-500">
               Event ID

--- a/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
+++ b/apps/lrauv-dash2/components/ScheduleEventDetailsModal.tsx
@@ -813,7 +813,12 @@ export const ScheduleEventDetailsModal: React.FC<
             <p className="text-sm uppercase tracking-wide text-stone-500">
               Operator
             </p>
-            <p className="font-medium">{event.user || 'Unknown'}</p>
+            <p className="font-medium">
+              {event.isDefaultMission ||
+              event.label?.trim().toLowerCase() === 'default mission'
+                ? 'Automatic (vehicle)'
+                : event.user || 'Unknown'}
+            </p>
           </div>
           <div>
             <p className="text-sm uppercase tracking-wide text-stone-500">

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -1194,6 +1194,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 isParamUpdate: isParam,
                 isConfigSetUpdate: isConfigSet,
                 isLoadRunMission,
+                isDefaultMission: isDefaultMissionName(missionName),
                 commsStatus: commsLookup.get(mission.event.eventId),
                 ...commsMsgIdLookup.get(mission.event.eventId),
               },

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -1194,7 +1194,6 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
                 isParamUpdate: isParam,
                 isConfigSetUpdate: isConfigSet,
                 isLoadRunMission,
-                isDefaultMission: isDefaultMissionName(missionName),
                 commsStatus: commsLookup.get(mission.event.eventId),
                 ...commsMsgIdLookup.get(mission.event.eventId),
               },

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -904,7 +904,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
           secondary="Automatic fallback"
           status={defStatus}
           scheduleStatus={defStatus === 'running' ? 'running' : undefined}
-          name="Vehicle (automatic)"
+          name=""
           description={description}
           eventId={mission.event.eventId}
           commandType="mission"

--- a/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
@@ -224,7 +224,7 @@ test('popup shows N/A (not TBD) in Ended field for a timed-out non-mission comma
 
 // ── Operator field for Default missions ───────────────────────────────────────
 
-test('hides Operator field when isDefaultMission is true', () => {
+test('hides Operator field when isDefaultMission is true (synthetic row)', () => {
   ;(useGlobalModalId as jest.Mock).mockReturnValue(
     makeModalId({
       ...baseEvent,
@@ -240,12 +240,12 @@ test('hides Operator field when isDefaultMission is true', () => {
   expect(screen.queryByText('karen-salamy')).not.toBeInTheDocument()
 })
 
-test('hides Operator field when label is "Default Mission" (API run event path)', () => {
+test('hides Operator field when isDefaultMission is true (API run event path — ScheduleSection now sets this flag for missionName=Default)', () => {
   ;(useGlobalModalId as jest.Mock).mockReturnValue(
     makeModalId({
       ...baseEvent,
-      label: 'Default Mission',
-      isDefaultMission: false,
+      label: 'Default',
+      isDefaultMission: true,
       user: 'karen-salamy',
     })
   )
@@ -256,7 +256,9 @@ test('hides Operator field when label is "Default Mission" (API run event path)'
   expect(screen.queryByText('karen-salamy')).not.toBeInTheDocument()
 })
 
-test('hides Operator field when label is "Default" (parsed mission name from load Default.tl;run)', () => {
+test('shows Operator field for an operator-sent mission named Default when isDefaultMission is false', () => {
+  // An operator could intentionally send a mission named "Default".
+  // Only the explicit isDefaultMission flag suppresses attribution.
   ;(useGlobalModalId as jest.Mock).mockReturnValue(
     makeModalId({
       ...baseEvent,
@@ -268,8 +270,8 @@ test('hides Operator field when label is "Default" (parsed mission name from loa
 
   render(<ScheduleEventDetailsModal onClose={() => {}} />)
 
-  expect(screen.queryByText('Operator')).not.toBeInTheDocument()
-  expect(screen.queryByText('karen-salamy')).not.toBeInTheDocument()
+  expect(screen.getByText('Operator')).toBeInTheDocument()
+  expect(screen.getByText('karen-salamy')).toBeInTheDocument()
 })
 
 test('shows Operator field for regular operator-sent missions', () => {

--- a/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
@@ -221,3 +221,54 @@ test('popup shows N/A (not TBD) in Ended field for a timed-out non-mission comma
   expect(screen.getAllByText('N/A').length).toBeGreaterThan(0)
   expect(screen.queryByText('TBD')).not.toBeInTheDocument()
 })
+
+// ── Operator field for Default missions ───────────────────────────────────────
+
+test('hides Operator field when isDefaultMission is true', () => {
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      label: 'Default Mission',
+      isDefaultMission: true,
+      user: 'karen-salamy',
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.queryByText('Operator')).not.toBeInTheDocument()
+  expect(screen.queryByText('karen-salamy')).not.toBeInTheDocument()
+})
+
+test('hides Operator field when label is "Default Mission" (API run event path)', () => {
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      label: 'Default Mission',
+      isDefaultMission: false,
+      user: 'karen-salamy',
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.queryByText('Operator')).not.toBeInTheDocument()
+  expect(screen.queryByText('karen-salamy')).not.toBeInTheDocument()
+})
+
+test('shows Operator field for regular operator-sent missions', () => {
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      label: 'Transport/transit.tl',
+      isDefaultMission: false,
+      user: 'test-operator',
+      isLoadRunMission: true,
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.getByText('Operator')).toBeInTheDocument()
+  expect(screen.getByText('test-operator')).toBeInTheDocument()
+})

--- a/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
@@ -256,6 +256,22 @@ test('hides Operator field when label is "Default Mission" (API run event path)'
   expect(screen.queryByText('karen-salamy')).not.toBeInTheDocument()
 })
 
+test('hides Operator field when label is "Default" (parsed mission name from load Default.tl;run)', () => {
+  ;(useGlobalModalId as jest.Mock).mockReturnValue(
+    makeModalId({
+      ...baseEvent,
+      label: 'Default',
+      isDefaultMission: false,
+      user: 'karen-salamy',
+    })
+  )
+
+  render(<ScheduleEventDetailsModal onClose={() => {}} />)
+
+  expect(screen.queryByText('Operator')).not.toBeInTheDocument()
+  expect(screen.queryByText('karen-salamy')).not.toBeInTheDocument()
+})
+
 test('shows Operator field for regular operator-sent missions', () => {
   ;(useGlobalModalId as jest.Mock).mockReturnValue(
     makeModalId({

--- a/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleEventDetailsModal.test.tsx
@@ -224,7 +224,9 @@ test('popup shows N/A (not TBD) in Ended field for a timed-out non-mission comma
 
 // ── Operator field for Default missions ───────────────────────────────────────
 
-test('hides Operator field when isDefaultMission is true (synthetic row)', () => {
+test('hides Operator field for synthetic Default mission rows (isDefaultMission: true triggers early return)', () => {
+  // Synthetic Default mission rows set isDefaultMission: true and are rendered
+  // by a dedicated modal path that never shows the Operator field.
   ;(useGlobalModalId as jest.Mock).mockReturnValue(
     makeModalId({
       ...baseEvent,
@@ -238,40 +240,6 @@ test('hides Operator field when isDefaultMission is true (synthetic row)', () =>
 
   expect(screen.queryByText('Operator')).not.toBeInTheDocument()
   expect(screen.queryByText('karen-salamy')).not.toBeInTheDocument()
-})
-
-test('hides Operator field when isDefaultMission is true (API run event path — ScheduleSection now sets this flag for missionName=Default)', () => {
-  ;(useGlobalModalId as jest.Mock).mockReturnValue(
-    makeModalId({
-      ...baseEvent,
-      label: 'Default',
-      isDefaultMission: true,
-      user: 'karen-salamy',
-    })
-  )
-
-  render(<ScheduleEventDetailsModal onClose={() => {}} />)
-
-  expect(screen.queryByText('Operator')).not.toBeInTheDocument()
-  expect(screen.queryByText('karen-salamy')).not.toBeInTheDocument()
-})
-
-test('shows Operator field for an operator-sent mission named Default when isDefaultMission is false', () => {
-  // An operator could intentionally send a mission named "Default".
-  // Only the explicit isDefaultMission flag suppresses attribution.
-  ;(useGlobalModalId as jest.Mock).mockReturnValue(
-    makeModalId({
-      ...baseEvent,
-      label: 'Default',
-      isDefaultMission: false,
-      user: 'karen-salamy',
-    })
-  )
-
-  render(<ScheduleEventDetailsModal onClose={() => {}} />)
-
-  expect(screen.getByText('Operator')).toBeInTheDocument()
-  expect(screen.getByText('karen-salamy')).toBeInTheDocument()
 })
 
 test('shows Operator field for regular operator-sent missions', () => {

--- a/packages/react-ui/src/Cells/ScheduleCell.test.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.test.tsx
@@ -148,9 +148,17 @@ test('should not render a name row when name is empty string', () => {
   // Default mission rows pass name="" so no operator attribution is shown.
   // This guards against the conditional rendering regressing back to an
   // empty <li> that creates a blank line in the schedule history list.
-  render(<ScheduleCell {...props} name="" />)
+  const { container } = render(<ScheduleCell {...props} name="" />)
 
   expect(screen.getByText(props.label)).toBeInTheDocument()
-  // The name from base props must not appear.
-  expect(screen.queryByText('Kurt Vonnegut')).not.toBeInTheDocument()
+  // Count <li> elements: label + secondary + description = 3 when name present,
+  // label + secondary + description = 3 when name is omitted (no extra blank li).
+  // More directly: no <li> in the name column should contain any text content,
+  // and the total li count must be one fewer than when name is provided.
+  const liCount = container.querySelectorAll('li').length
+  const { container: fullContainer } = render(
+    <ScheduleCell {...props} name="Kurt Vonnegut" />
+  )
+  const fullLiCount = fullContainer.querySelectorAll('li').length
+  expect(liCount).toBeLessThan(fullLiCount)
 })

--- a/packages/react-ui/src/Cells/ScheduleCell.test.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.test.tsx
@@ -151,10 +151,9 @@ test('should not render a name row when name is empty string', () => {
   const { container } = render(<ScheduleCell {...props} name="" />)
 
   expect(screen.getByText(props.label)).toBeInTheDocument()
-  // Count <li> elements: label + secondary + description = 3 when name present,
-  // label + secondary + description = 3 when name is omitted (no extra blank li).
-  // More directly: no <li> in the name column should contain any text content,
-  // and the total li count must be one fewer than when name is provided.
+  // With a full name, ScheduleCell renders label + secondary + name + description
+  // list items. With name="", the name <li> must be absent, so the empty-name
+  // render must produce fewer <li> elements than the full render.
   const liCount = container.querySelectorAll('li').length
   const { container: fullContainer } = render(
     <ScheduleCell {...props} name="Kurt Vonnegut" />

--- a/packages/react-ui/src/Cells/ScheduleCell.test.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.test.tsx
@@ -143,3 +143,14 @@ test('should not render an empty secondary row when secondary is undefined', () 
   const italicLis = document.querySelectorAll('li.italic')
   expect(italicLis).toHaveLength(0)
 })
+
+test('should not render a name row when name is empty string', () => {
+  // Default mission rows pass name="" so no operator attribution is shown.
+  // This guards against the conditional rendering regressing back to an
+  // empty <li> that creates a blank line in the schedule history list.
+  render(<ScheduleCell {...props} name="" />)
+
+  expect(screen.getByText(props.label)).toBeInTheDocument()
+  // The name from base props must not appear.
+  expect(screen.queryByText('Kurt Vonnegut')).not.toBeInTheDocument()
+})

--- a/packages/react-ui/src/Cells/ScheduleCell.tsx
+++ b/packages/react-ui/src/Cells/ScheduleCell.tsx
@@ -228,14 +228,16 @@ export const ScheduleCell: React.FC<ScheduleCellProps> = ({
               {secondary}
             </li>
           )}
-          <li
-            className={clsx(
-              'flex truncate',
-              isOpen ? styles.text : styles.textLight
-            )}
-          >
-            {name}
-          </li>
+          {name && (
+            <li
+              className={clsx(
+                'flex truncate',
+                isOpen ? styles.text : styles.textLight
+              )}
+            >
+              {name}
+            </li>
+          )}
         </ul>
         <ul
           className={clsx(


### PR DESCRIPTION
## Summary

The Tethys API stamps the authenticated HTTP session user on all events — including automatic Default missions triggered by the vehicle's own MissionManager. This caused Schedule History to display the browsing operator's name as **Operator** for a mission they never sent.

**What is fixed:** The synthetic Default mission rows injected by \`ScheduleSection\` from \`missionTimeline\` data already carry \`isDefaultMission: true\`. The modal's dedicated Default-mission rendering path (early return) has never shown an Operator field. The list row (\`ScheduleCell\`) previously showed the session user as \`name\` — this PR clears that to an empty string so no attribution appears.

**Known limitation:** API \`run\` events for Default (e.g. \`load Default.tl;run\` stamped with the session user by Tethys) cannot be safely distinguished from operator-intentional Default sends without backend metadata. Those events are left unchanged.

## Changes

- \`ScheduleSection\`: pass \`name=""\` on the Default mission \`ScheduleCell\` list row (synthetic path only)
- \`ScheduleCell\` (react-ui): conditionally render the name \`<li>\` only when non-empty — prevents a blank line
- Tests: synthetic Default row hides Operator in modal; \`ScheduleCell\` empty-name produces no DOM element

## Test plan
- [ ] Schedule History — synthetic Default mission row shows no operator name in the list
- [ ] Click the synthetic Default mission row → details modal shows no Operator field
- [ ] Any operator-sent mission → Operator field still shows the sender