### PR TITLE
fix: normalize toWatchDuration to prevent PT1H60M overflow

### DIFF
--- a/apps/lrauv-dash2/components/Reassignment.tsx
+++ b/apps/lrauv-dash2/components/Reassignment.tsx
@@ -29,9 +29,13 @@ const toWatchDuration = (hours: string): string | undefined => {
   if (hours.trim() === '') return undefined
   const h = Number(hours)
   if (!Number.isFinite(h) || h < 0) return undefined
-  const wholeHours = Math.floor(h)
-  const minutes = Math.round((h - wholeHours) * 60)
-  return `PT${wholeHours}H${minutes}M`
+  let hours = Math.floor(h)
+  let minutes = Math.round((h - hours) * 60)
+  if (minutes === 60) {
+    hours += 1
+    minutes = 0
+  }
+  return `PT${hours}H${minutes}M`
 }
 
 const Reassignment: React.FC<{ vehicleNames: string[] }> = ({

--- a/apps/lrauv-dash2/components/Reassignment.tsx
+++ b/apps/lrauv-dash2/components/Reassignment.tsx
@@ -29,13 +29,13 @@ const toWatchDuration = (hours: string): string | undefined => {
   if (hours.trim() === '') return undefined
   const h = Number(hours)
   if (!Number.isFinite(h) || h < 0) return undefined
-  let hours = Math.floor(h)
-  let minutes = Math.round((h - hours) * 60)
+  let wholeHours = Math.floor(h)
+  let minutes = Math.round((h - wholeHours) * 60)
   if (minutes === 60) {
-    hours += 1
+    wholeHours += 1
     minutes = 0
   }
-  return `PT${hours}H${minutes}M`
+  return `PT${wholeHours}H${minutes}M`
 }
 
 const Reassignment: React.FC<{ vehicleNames: string[] }> = ({

--- a/apps/lrauv-dash2/components/Reassignment.tsx
+++ b/apps/lrauv-dash2/components/Reassignment.tsx
@@ -25,7 +25,7 @@ interface PendingSignOff {
  *  Returns PT0H0M for an explicit 0 so the backend records a zero-duration shift.
  *  Returns undefined for empty/invalid input as a safety fallback (the UI
  *  prevents submission while the field is blank). */
-const toWatchDuration = (hours: string): string | undefined => {
+export const toWatchDuration = (hours: string): string | undefined => {
   if (hours.trim() === '') return undefined
   const h = Number(hours)
   if (!Number.isFinite(h) || h < 0) return undefined

--- a/apps/lrauv-dash2/jest/Reassignment.test.tsx
+++ b/apps/lrauv-dash2/jest/Reassignment.test.tsx
@@ -1,0 +1,39 @@
+import { toWatchDuration } from '../components/Reassignment'
+
+describe('toWatchDuration', () => {
+  it('converts whole hours', () => {
+    expect(toWatchDuration('8')).toBe('PT8H0M')
+  })
+
+  it('converts decimal hours to hours and minutes', () => {
+    expect(toWatchDuration('1.5')).toBe('PT1H30M')
+  })
+
+  it('normalizes minutes overflow: 1.999 → PT2H0M (not PT1H60M)', () => {
+    expect(toWatchDuration('1.999')).toBe('PT2H0M')
+  })
+
+  it('normalizes minutes overflow: 0.999 → PT1H0M', () => {
+    expect(toWatchDuration('0.999')).toBe('PT1H0M')
+  })
+
+  it('allows explicit zero hours', () => {
+    expect(toWatchDuration('0')).toBe('PT0H0M')
+  })
+
+  it('returns undefined for empty string', () => {
+    expect(toWatchDuration('')).toBeUndefined()
+  })
+
+  it('returns undefined for whitespace-only string', () => {
+    expect(toWatchDuration('   ')).toBeUndefined()
+  })
+
+  it('returns undefined for non-numeric input', () => {
+    expect(toWatchDuration('abc')).toBeUndefined()
+  })
+
+  it('returns undefined for negative hours', () => {
+    expect(toWatchDuration('-1')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes a Copilot-flagged edge case from PR #649 review.

`toWatchDuration()` used `Math.round()` on the fractional minutes, which can produce `minutes === 60` for inputs like `1.999`. This results in an invalid ISO-8601 duration string (`PT1H60M`) that strict backend parsers may reject.

**Fix:** carry the overflow into the hours field so the output is always normalized (e.g. `PT2H0M` instead of `PT1H60M`).

## Test plan
- [ ] Enter `1.999` hours in the PIC sign-off dialog — API receives `PT2H0M`
- [ ] Enter `0.999` hours — API receives `PT1H0M`
- [ ] Enter `1.5` hours — API receives `PT1H30M` (unchanged)