### PR TITLE
feat(#570): add colorbar legend hover to TILE layer rows in Layers panel

### DIFF
--- a/apps/lrauv-dash2/components/MapLayersTreeItem.tsx
+++ b/apps/lrauv-dash2/components/MapLayersTreeItem.tsx
@@ -8,6 +8,7 @@ import {
   faStar,
   faArrowsToCircle,
   faCircle,
+  faCircleInfo,
 } from '@fortawesome/free-solid-svg-icons'
 
 export interface TreeItemProps {
@@ -27,6 +28,7 @@ export interface TreeItemProps {
   onMouseLeaveStar?: () => void
   onCenterClick?: () => void
   centerLabel?: string
+  legendContent?: React.ReactNode
 }
 
 const CustomCircleIcon = () => (
@@ -60,6 +62,7 @@ export const TreeItem: React.FC<TreeItemProps> = ({
   onMouseLeaveStar,
   onCenterClick,
   centerLabel = 'Center map on this item',
+  legendContent,
 }) => {
   const hasChildren = React.Children.count(children) > 0
 
@@ -205,6 +208,45 @@ export const TreeItem: React.FC<TreeItemProps> = ({
                 <FontAwesomeIcon
                   icon={faArrowsToCircle}
                   style={{ color: '#6b7280', fontSize: '14.5px' }}
+                />
+              </button>
+            </Tippy>
+          )}
+          {legendContent !== undefined && (
+            <Tippy
+              content={legendContent}
+              placement="right"
+              appendTo={() => document.body}
+              interactive
+              trigger="mouseenter focus"
+              delay={[200, 0]}
+            >
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                }}
+                className="ml-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+                aria-label="Show layer legend"
+                style={{
+                  width: '20px',
+                  height: '20px',
+                  flexShrink: 0,
+                  borderRadius: '50%',
+                  background: '#fff',
+                  border: 0,
+                  padding: 0,
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.35)',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'default',
+                }}
+              >
+                <FontAwesomeIcon
+                  icon={faCircleInfo}
+                  style={{ color: '#0ea5e9', fontSize: '13px' }}
                 />
               </button>
             </Tippy>

--- a/apps/lrauv-dash2/components/TileLayersSection.tsx
+++ b/apps/lrauv-dash2/components/TileLayersSection.tsx
@@ -6,7 +6,45 @@ interface TileLayerItem {
   name: string
   urlTemplate?: string
   wms?: boolean
+  legendurl?: string
   options?: Record<string, unknown>
+}
+
+const getLegendUrl = (tile: TileLayerItem): string | undefined => {
+  if (tile.legendurl) return tile.legendurl
+  const urlTemplate = tile.urlTemplate?.trim()
+  if (tile.wms && urlTemplate) {
+    const base = urlTemplate.replace(/\?$/, '')
+    const layers = String(tile.options?.layers ?? '')
+    if (!layers.trim()) return undefined
+    const version = String(tile.options?.version ?? '1.1.1')
+    return (
+      `${base}?SERVICE=WMS&REQUEST=GetLegendGraphic` +
+      `&VERSION=${encodeURIComponent(version)}` +
+      `&FORMAT=image%2Fpng` +
+      `&LAYER=${encodeURIComponent(layers)}`
+    )
+  }
+  return undefined
+}
+
+const TileLegendPopup: React.FC<{ tile: TileLayerItem }> = ({ tile }) => {
+  const url = getLegendUrl(tile)
+  if (!url) return null
+  return (
+    <div className="max-w-xs rounded bg-white p-2 shadow-lg">
+      <p className="mb-1 text-xs font-semibold text-gray-700">{tile.name}</p>
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={url}
+        alt={`${tile.name} legend`}
+        className="max-w-full"
+        onError={(e) => {
+          ;(e.currentTarget as HTMLImageElement).style.display = 'none'
+        }}
+      />
+    </div>
+  )
 }
 
 interface TileLayersSectionProps {
@@ -75,6 +113,7 @@ export const TileLayersSection: React.FC<TileLayersSectionProps> = ({
           : tile.wms && !String(tile.options?.layers ?? '').trim()
           ? 'WMS layer has no layers configured'
           : undefined
+        const legendUrl = getLegendUrl(tile)
         return (
           <TreeItem
             key={`tile-${tile.name}`}
@@ -93,6 +132,11 @@ export const TileLayersSection: React.FC<TileLayersSectionProps> = ({
             }
             disabled={!hasValidUrl}
             disabledTitle={disabledTitle}
+            legendContent={
+              legendUrl !== undefined ? (
+                <TileLegendPopup tile={tile} />
+              ) : undefined
+            }
           />
         )
       })}

--- a/apps/lrauv-dash2/components/TileLayersSection.tsx
+++ b/apps/lrauv-dash2/components/TileLayersSection.tsx
@@ -18,8 +18,9 @@ const getLegendUrl = (tile: TileLayerItem): string | undefined => {
     const layers = String(tile.options?.layers ?? '')
     if (!layers.trim()) return undefined
     const version = String(tile.options?.version ?? '1.1.1')
+    const sep = base.includes('?') ? '&' : '?'
     return (
-      `${base}?SERVICE=WMS&REQUEST=GetLegendGraphic` +
+      `${base}${sep}SERVICE=WMS&REQUEST=GetLegendGraphic` +
       `&VERSION=${encodeURIComponent(version)}` +
       `&FORMAT=image%2Fpng` +
       `&LAYER=${encodeURIComponent(layers)}`


### PR DESCRIPTION
## Summary

Phase 1 of [#570](https://github.com/mbari-org/dash5/issues/570) — surfaces WMS layer colorbars in the Layers panel so operators can immediately see the color scale and product metadata for any active satellite/tile layer.

- Each WMS TILE layer row in `MapLayersListModal` now shows a blue ℹ button that displays a legend popup on hover
- The legend image is sourced from `legendurl` (if configured in TethysDash) or dynamically constructed as a WMS `GetLegendGraphic` URL fallback
- `getLegendUrl()` guards against whitespace-only `urlTemplate` values
- The popup shows the layer name + colorbar image; gracefully hides the image on 404
- No backend changes required — `legendurl` is already typed in `GetTileLayersResponse`

## Files changed

- **`MapLayersTreeItem.tsx`** — added optional `legendContent?: React.ReactNode` prop; renders a Tippy-powered ℹ button after the label when content is provided
- **`TileLayersSection.tsx`** — added `getLegendUrl()` helper and `TileLegendPopup` component wired to each layer row

## What's not yet included (Phase 2)

Product date display requires a new `productDate` field from the TethysDash backend. A follow-up issue will be filed separately.

## Test plan

- [ ] Open the Layers panel and expand TILE Layers
- [ ] Confirm a blue ℹ button appears next to each WMS tile layer row
- [ ] Hover the ℹ button — verify the colorbar popup appears with the layer name and legend image
- [ ] Non-WMS tile layers or those without a `legendurl`/valid URL should show no ℹ button
- [ ] Confirm existing checkbox / select-all / collapse behavior is unchanged

Replaces #577 (conflict-free rebase from develop).