### PR TITLE
feat: show app version in primary toolbar nav bar

### DIFF
--- a/apps/lrauv-dash2/components/Layout.tsx
+++ b/apps/lrauv-dash2/components/Layout.tsx
@@ -93,6 +93,12 @@ const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
     authenticated ? modalJsx : <UserLogin onClose={setModal(null)} />
 
   const vehicleName = router.query.deployment?.[0] ?? ''
+  const appVersion = process.env.NEXT_PUBLIC_APP_VERSION
+  const versionLabel = appVersion
+    ? appVersion === 'dev'
+      ? 'Dash5 dev'
+      : `Dash5 v${appVersion}`
+    : undefined
   return (
     <div className="flex h-screen min-h-screen w-screen flex-col">
       <Head>
@@ -151,14 +157,7 @@ const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
           }
           onLoginClick={setModal({ id: 'login' })}
           signedIn={authenticated}
-          versionLabel={
-            process.env.NEXT_PUBLIC_APP_VERSION &&
-            process.env.NEXT_PUBLIC_APP_VERSION !== 'dev'
-              ? `Dash5 v${process.env.NEXT_PUBLIC_APP_VERSION}`
-              : process.env.NEXT_PUBLIC_APP_VERSION === 'dev'
-              ? 'Dash5 dev'
-              : undefined
-          }
+          versionLabel={versionLabel}
         />
       )}
       {children}

--- a/apps/lrauv-dash2/components/Layout.tsx
+++ b/apps/lrauv-dash2/components/Layout.tsx
@@ -152,8 +152,11 @@ const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
           onLoginClick={setModal({ id: 'login' })}
           signedIn={authenticated}
           versionLabel={
-            process.env.NEXT_PUBLIC_APP_VERSION
+            process.env.NEXT_PUBLIC_APP_VERSION &&
+            process.env.NEXT_PUBLIC_APP_VERSION !== 'dev'
               ? `Dash5 v${process.env.NEXT_PUBLIC_APP_VERSION}`
+              : process.env.NEXT_PUBLIC_APP_VERSION === 'dev'
+              ? 'Dash5 dev'
               : undefined
           }
         />

--- a/apps/lrauv-dash2/components/Layout.tsx
+++ b/apps/lrauv-dash2/components/Layout.tsx
@@ -151,6 +151,11 @@ const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
           }
           onLoginClick={setModal({ id: 'login' })}
           signedIn={authenticated}
+          versionLabel={
+            process.env.NEXT_PUBLIC_APP_VERSION
+              ? `Dash5 v${process.env.NEXT_PUBLIC_APP_VERSION}`
+              : undefined
+          }
         />
       )}
       {children}

--- a/apps/lrauv-dash2/next.config.js
+++ b/apps/lrauv-dash2/next.config.js
@@ -8,6 +8,8 @@ let appVersion = 'dev'
 try {
   const raw = execSync('git describe --tags --abbrev=0', {
     encoding: 'utf8',
+    cwd: __dirname,
+    stdio: ['pipe', 'pipe', 'pipe'],
   }).trim()
   appVersion = raw.replace(/^v/, '')
 } catch {

--- a/apps/lrauv-dash2/next.config.js
+++ b/apps/lrauv-dash2/next.config.js
@@ -1,9 +1,22 @@
 // This is a workaround for Next.js 15 to handle TypeScript files in workspace packages
-const pkg = require('./package.json')
+const { execSync } = require('child_process')
+
+// Derive version from the most recent git tag (e.g. v5.1.37 → "5.1.37").
+// Falls back to "dev" when git is unavailable (e.g. fresh Docker build without
+// the .git directory).
+let appVersion = 'dev'
+try {
+  const raw = execSync('git describe --tags --abbrev=0', {
+    encoding: 'utf8',
+  }).trim()
+  appVersion = raw.replace(/^v/, '')
+} catch {
+  // git unavailable or no tags yet
+}
 
 const nextConfig = {
   env: {
-    NEXT_PUBLIC_APP_VERSION: pkg.version,
+    NEXT_PUBLIC_APP_VERSION: appVersion,
   },
   output: 'export',
   reactStrictMode: true,

--- a/packages/react-ui/src/Toolbars/PrimaryToolbar.test.tsx
+++ b/packages/react-ui/src/Toolbars/PrimaryToolbar.test.tsx
@@ -57,3 +57,13 @@ test('should not render a generic profile button if there are profile credential
   render(<PrimaryToolbar options={options} signedIn avatarName="Dynamo Test" />)
   expect(screen.queryByLabelText(/profile/i)).not.toBeInTheDocument()
 })
+
+test('should render the version label when versionLabel is provided', async () => {
+  render(<PrimaryToolbar options={options} versionLabel="Dash5 v5.1.37" />)
+  expect(screen.getByText('Dash5 v5.1.37')).toBeInTheDocument()
+})
+
+test('should not render a version label when versionLabel is omitted', async () => {
+  render(<PrimaryToolbar options={options} />)
+  expect(screen.queryByText(/Dash5 v/i)).not.toBeInTheDocument()
+})

--- a/packages/react-ui/src/Toolbars/PrimaryToolbar.tsx
+++ b/packages/react-ui/src/Toolbars/PrimaryToolbar.tsx
@@ -32,6 +32,7 @@ export interface PrimaryToolbarProps {
   secondaryDropdown?: JSX.Element | null
   addItemDropdown?: JSX.Element | null
   logo?: JSX.Element
+  versionLabel?: string
 }
 
 const PrimaryToolbarOption: React.FC<{
@@ -101,6 +102,7 @@ export const PrimaryToolbar: React.FC<PrimaryToolbarProps> = ({
   addItemDropdown,
   canRemoveOption = () => true,
   logo,
+  versionLabel,
 }) => {
   const handleOptionClick = (option: string) => (e: React.MouseEvent) => {
     e.preventDefault()
@@ -140,7 +142,19 @@ export const PrimaryToolbar: React.FC<PrimaryToolbarProps> = ({
             {addItemDropdown}
           </li>
         )}
-        <li className="relative my-auto ml-auto flex-shrink-0">
+        {versionLabel && (
+          <li className="my-auto ml-auto flex-shrink-0 pr-4">
+            <span className="text-xs font-medium text-primary-600">
+              {versionLabel}
+            </span>
+          </li>
+        )}
+        <li
+          className={clsx(
+            'relative my-auto flex-shrink-0',
+            !versionLabel && 'ml-auto'
+          )}
+        >
           {!signedIn && (
             <IconButton
               icon={faSignIn}


### PR DESCRIPTION
## Summary

Adds the app version to the top navigation bar, matching Dash4's "Dash v4.99.21" display.

- **`PrimaryToolbar`** — new optional `versionLabel` prop; renders in `primary-600` blue between the vehicle tabs and the avatar
- **`Layout.tsx`** — passes `"Dash5 vX.Y.Z"` using `NEXT_PUBLIC_APP_VERSION`
- **`next.config.js`** — derives version from the latest git tag (`git describe --tags --abbrev=0`) instead of the stale `"0.1.0"` in `package.json`; falls back to `"dev"` when git is unavailable

## Test plan

- [ ] Version label "Dash5 vX.Y.Z" appears in the top-right nav bar in primary-600 blue
- [ ] Version matches the latest git tag
- [ ] Shows "dev" when no git tag is available (e.g. fresh Docker build)