### PR TITLE
feat(#652): dim historical track and highlight future path during timeline scrubbing

### DIFF
--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -358,9 +358,8 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   return route?.length ? (
     <>
       <Polyline
-        pathOptions={lineStyle}
-        positions={route}
-        // positions={activeRoute ?? route}
+        pathOptions={activeRoute ? { ...lineStyle, opacity: 0.35 } : lineStyle}
+        positions={activeRoute ?? route}
         color={color}
         eventHandlers={{
           mouseover: () => {
@@ -471,11 +470,13 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           position={r}
           color={color}
           radius={10}
+          opacity={activeRoute ? 0.35 : 1}
+          fillOpacity={activeRoute ? 0.35 : 1}
         />
       ))}
       {inactiveRoute && (
         <Polyline
-          pathOptions={{ color, opacity: 0.35 }}
+          pathOptions={{ color, weight: 3, dashArray: '6, 8' }}
           positions={inactiveRoute}
         />
       )}
@@ -491,9 +492,9 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             }}
             fillColor={color}
             radius={10}
-            fillOpacity={0.25}
+            fillOpacity={1}
             color={color}
-            opacity={0.25}
+            opacity={1}
           />
         ))}
       {/* This handles the Scrub Timeline route */}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -236,51 +236,49 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     return deduped
   }, [route, futureRoute])
 
-  // DEPLOYMENT MAP
-  // activePoints - Deployment Map
-  const activePoints =
-    indicatorTime && indicatorTime > 0
-      ? vehiclePosition?.gpsFixes.filter(
-          (fix) => fix.unixTime <= (indicatorTime ?? 0)
-        )
-      : null
+  // DEPLOYMENT MAP — scrubbing-derived values
+  // Memoize on stable primitives (indicatorTime + gpsFixes reference) so
+  // derived arrays are only recomputed when the data or scrub position changes.
+  const gpsFixes = vehiclePosition?.gpsFixes ?? null
 
-  // activeRoute
-  const activeRoute = activePoints?.map(
-    (g) => [g.latitude, g.longitude] as [number, number]
-  )
-
-  // indicatorCoord - Deployment Map
-  const indicatorCoord = indicatorTime
-    ? activePoints?.sort((a, b) => b.unixTime - a.unixTime)[0]
-    : null
-
-  // inactiveRoute - Deployment Map
-  const inactiveRoute =
-    indicatorTime &&
-    [
-      indicatorCoord,
-      ...(
-        vehiclePosition?.gpsFixes.filter(
-          (fix) => fix.unixTime >= (indicatorTime ?? 0)
-        ) ?? []
-      ).sort((a, b) => a.unixTime - b.unixTime),
-    ]
-      ?.filter((g) => g && g.latitude != null && g.longitude != null)
-      .map((g) => [g?.latitude ?? 0, g?.longitude ?? 0] as [number, number])
-
-  // Deduplicate adjacent identical points once so both the Polyline and
-  // Circle renders share the same filtered array without recomputing it.
-  const dedupedInactiveRoute = useMemo(
+  const activePoints = useMemo(
     () =>
-      inactiveRoute
-        ? inactiveRoute.filter(
-            (r, i, arr) =>
-              i === 0 || r[0] !== arr[i - 1][0] || r[1] !== arr[i - 1][1]
-          )
+      indicatorTime && indicatorTime > 0 && gpsFixes
+        ? gpsFixes.filter((fix) => fix.unixTime <= indicatorTime)
         : null,
-    [inactiveRoute]
+    [indicatorTime, gpsFixes]
   )
+
+  const activeRoute = useMemo(
+    () =>
+      activePoints?.map((g) => [g.latitude, g.longitude] as [number, number]) ??
+      null,
+    [activePoints]
+  )
+
+  const indicatorCoord = useMemo(
+    () =>
+      indicatorTime && activePoints
+        ? [...activePoints].sort((a, b) => b.unixTime - a.unixTime)[0] ?? null
+        : null,
+    [indicatorTime, activePoints]
+  )
+
+  // Compute the future segment and deduplicate adjacent identical points in
+  // one memo so both the dashed Polyline and preview Circles share the same
+  // stable array reference without redundant work.
+  const dedupedInactiveRoute = useMemo(() => {
+    if (!indicatorTime || !gpsFixes) return null
+    const futureFixes = gpsFixes
+      .filter((fix) => fix.unixTime >= indicatorTime)
+      .sort((a, b) => a.unixTime - b.unixTime)
+    const raw = [indicatorCoord, ...futureFixes]
+      .filter((g) => g && g.latitude != null && g.longitude != null)
+      .map((g) => [g!.latitude, g!.longitude] as [number, number])
+    return raw.filter(
+      (r, i, arr) => i === 0 || r[0] !== arr[i - 1][0] || r[1] !== arr[i - 1][1]
+    )
+  }, [indicatorTime, gpsFixes, indicatorCoord])
 
   const fitRef = useRef<string | null | undefined>(null)
   const fitPositionsAsString = fitPositions?.flat().join()

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -481,22 +481,29 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         />
       )}
       {inactiveRoute &&
-        inactiveRoute?.map((r, i) => (
-          <Circle
-            key={`${name}:${
-              grouped ? 'overview' : 'detail'
-            }:inactivePreview:${i}:${r.join()}`}
-            center={{
-              lat: r[0],
-              lng: r[1],
-            }}
-            fillColor={color}
-            radius={10}
-            fillOpacity={1}
-            color={color}
-            opacity={1}
-          />
-        ))}
+        inactiveRoute
+          .filter(
+            (r, i) =>
+              i === 0 ||
+              r[0] !== inactiveRoute[i - 1][0] ||
+              r[1] !== inactiveRoute[i - 1][1]
+          )
+          .map((r, i) => (
+            <Circle
+              key={`${name}:${
+                grouped ? 'overview' : 'detail'
+              }:inactivePreview:${i}:${r.join()}`}
+              center={{
+                lat: r[0],
+                lng: r[1],
+              }}
+              fillColor={color}
+              radius={10}
+              fillOpacity={1}
+              color={color}
+              opacity={1}
+            />
+          ))}
       {/* This handles the Scrub Timeline route */}
       {route.map((r, index) => (
         <Circle

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -269,6 +269,19 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
       ?.filter((g) => g && g.latitude != null && g.longitude != null)
       .map((g) => [g?.latitude ?? 0, g?.longitude ?? 0] as [number, number])
 
+  // Deduplicate adjacent identical points once so both the Polyline and
+  // Circle renders share the same filtered array without recomputing it.
+  const dedupedInactiveRoute = useMemo(
+    () =>
+      inactiveRoute
+        ? inactiveRoute.filter(
+            (r, i, arr) =>
+              i === 0 || r[0] !== arr[i - 1][0] || r[1] !== arr[i - 1][1]
+          )
+        : null,
+    [inactiveRoute]
+  )
+
   const fitRef = useRef<string | null | undefined>(null)
   const fitPositionsAsString = fitPositions?.flat().join()
 
@@ -474,37 +487,29 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           fillOpacity={activeRoute ? 0.35 : 1}
         />
       ))}
-      {inactiveRoute && (
+      {dedupedInactiveRoute && (
         <Polyline
           pathOptions={{ color, weight: 3, dashArray: '6, 8' }}
-          positions={inactiveRoute.filter(
-            (r, i, arr) =>
-              i === 0 || r[0] !== arr[i - 1][0] || r[1] !== arr[i - 1][1]
-          )}
+          positions={dedupedInactiveRoute}
         />
       )}
-      {inactiveRoute &&
-        inactiveRoute
-          .filter(
-            (r, i, arr) =>
-              i === 0 || r[0] !== arr[i - 1][0] || r[1] !== arr[i - 1][1]
-          )
-          .map((r, i) => (
-            <Circle
-              key={`${name}:${
-                grouped ? 'overview' : 'detail'
-              }:inactivePreview:${i}:${r.join()}`}
-              center={{
-                lat: r[0],
-                lng: r[1],
-              }}
-              fillColor={color}
-              radius={10}
-              fillOpacity={1}
-              color={color}
-              opacity={1}
-            />
-          ))}
+      {dedupedInactiveRoute &&
+        dedupedInactiveRoute.map((r, i) => (
+          <Circle
+            key={`${name}:${
+              grouped ? 'overview' : 'detail'
+            }:inactivePreview:${i}:${r.join()}`}
+            center={{
+              lat: r[0],
+              lng: r[1],
+            }}
+            fillColor={color}
+            radius={10}
+            fillOpacity={1}
+            color={color}
+            opacity={1}
+          />
+        ))}
       {/* This handles the Scrub Timeline route */}
       {route.map((r, index) => (
         <Circle

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -477,16 +477,17 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
       {inactiveRoute && (
         <Polyline
           pathOptions={{ color, weight: 3, dashArray: '6, 8' }}
-          positions={inactiveRoute}
+          positions={inactiveRoute.filter(
+            (r, i, arr) =>
+              i === 0 || r[0] !== arr[i - 1][0] || r[1] !== arr[i - 1][1]
+          )}
         />
       )}
       {inactiveRoute &&
         inactiveRoute
           .filter(
-            (r, i) =>
-              i === 0 ||
-              r[0] !== inactiveRoute[i - 1][0] ||
-              r[1] !== inactiveRoute[i - 1][1]
+            (r, i, arr) =>
+              i === 0 || r[0] !== arr[i - 1][0] || r[1] !== arr[i - 1][1]
           )
           .map((r, i) => (
             <Circle

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -256,13 +256,12 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     [activePoints]
   )
 
-  const indicatorCoord = useMemo(
-    () =>
-      indicatorTime && activePoints
-        ? [...activePoints].sort((a, b) => b.unixTime - a.unixTime)[0] ?? null
-        : null,
-    [indicatorTime, activePoints]
-  )
+  const indicatorCoord = useMemo(() => {
+    if (!indicatorTime || !activePoints?.length) return null
+    return activePoints.reduce((latest, fix) =>
+      fix.unixTime > latest.unixTime ? fix : latest
+    )
+  }, [indicatorTime, activePoints])
 
   // Compute the future segment and deduplicate adjacent identical points in
   // one memo so both the dashed Polyline and preview Circles share the same

--- a/packages/react-ui/src/Map/MapDepthDisplay.tsx
+++ b/packages/react-ui/src/Map/MapDepthDisplay.tsx
@@ -49,9 +49,9 @@ const MapDepthDisplay: React.FC<MapDepthDisplayProps> = ({
 
   const onRequestDepth = useCallback(
     (lat: number, lng: number) =>
-      handleDepthRequestWithFeedback(lat, lng)
-        .then((r: { depth: number | null }) => r.depth)
-        .catch(() => null),
+      handleDepthRequestWithFeedback(lat, lng).then(
+        (r: { depth: number | null }) => r.depth
+      ),
     [handleDepthRequestWithFeedback]
   )
 

--- a/packages/react-ui/src/Map/MapDepthDisplay.tsx
+++ b/packages/react-ui/src/Map/MapDepthDisplay.tsx
@@ -49,9 +49,9 @@ const MapDepthDisplay: React.FC<MapDepthDisplayProps> = ({
 
   const onRequestDepth = useCallback(
     (lat: number, lng: number) =>
-      handleDepthRequestWithFeedback(lat, lng).then(
-        (r: { depth: number | null }) => r.depth
-      ),
+      handleDepthRequestWithFeedback(lat, lng)
+        .then((r: { depth: number | null }) => r.depth)
+        .catch(() => null),
     [handleDepthRequestWithFeedback]
   )
 

--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -33,6 +33,7 @@ const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
   const [depth, setDepth] = useState(
     null as null | { depth: number | null; coordinate: string }
   )
+  const requestIdRef = useRef(0)
 
   const formattedCoordinates =
     mousePoint === null
@@ -51,13 +52,20 @@ const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
     //   return
     // }
     if (mousePoint != null && onRequestDepth) {
+      const id = ++requestIdRef.current
       onRequestDepth(mousePoint.lat, mousePoint.lng)
-        .then((depth) => setDepth({ depth, coordinate: formattedCoordinates }))
+        .then((depth) => {
+          if (id === requestIdRef.current) {
+            setDepth({ depth, coordinate: formattedCoordinates })
+          }
+        })
         .catch(() => {
           // Elevation API errors (e.g. MapsServerError UNKNOWN_ERROR) are
-          // handled upstream; clear stale depth so we don't show the previous
-          // coordinate's value for the new position.
-          setDepth(null)
+          // handled upstream; clear stale depth so the previous coordinate's
+          // value is not shown for the new position.
+          if (id === requestIdRef.current) {
+            setDepth(null)
+          }
         })
     }
   }, [mousePoint, onRequestDepth, formattedCoordinates])

--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -51,9 +51,12 @@ const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
     //   return
     // }
     if (mousePoint?.lat && mousePoint.lng) {
-      onRequestDepth?.(mousePoint?.lat, mousePoint?.lng).then((depth) =>
-        setDepth({ depth, coordinate: formattedCoordinates })
-      )
+      onRequestDepth?.(mousePoint?.lat, mousePoint?.lng)
+        .then((depth) => setDepth({ depth, coordinate: formattedCoordinates }))
+        .catch(() => {
+          // Elevation API errors (e.g. MapsServerError UNKNOWN_ERROR) are
+          // handled upstream; swallow here to prevent unhandled rejection.
+        })
     }
   }, [mousePoint, onRequestDepth, formattedCoordinates])
 

--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -35,6 +35,13 @@ const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
   )
   const requestIdRef = useRef(0)
 
+  // Clear stale depth immediately when the cursor moves to a new position so
+  // the old value is never shown alongside the new coordinate.
+  useEffect(() => {
+    requestIdRef.current++
+    setDepth(null)
+  }, [mousePoint])
+
   const formattedCoordinates =
     mousePoint === null
       ? ''

--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -50,12 +50,14 @@ const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
     //   setDepth({ depth: Math.random() * 100, coordinate: formattedCoordinates })
     //   return
     // }
-    if (mousePoint?.lat && mousePoint.lng) {
-      onRequestDepth?.(mousePoint?.lat, mousePoint?.lng)
+    if (mousePoint != null && onRequestDepth) {
+      onRequestDepth(mousePoint.lat, mousePoint.lng)
         .then((depth) => setDepth({ depth, coordinate: formattedCoordinates }))
         .catch(() => {
           // Elevation API errors (e.g. MapsServerError UNKNOWN_ERROR) are
-          // handled upstream; swallow here to prevent unhandled rejection.
+          // handled upstream; clear stale depth so we don't show the previous
+          // coordinate's value for the new position.
+          setDepth(null)
         })
     }
   }, [mousePoint, onRequestDepth, formattedCoordinates])

--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -1,5 +1,11 @@
 // jshint esversion:6
-import React, { useState, useEffect, useCallback, useRef } from 'react'
+import React, {
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useRef,
+} from 'react'
 import { useMapEvents } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 import { useDebouncedEffect } from '@mbari/utils'
@@ -35,12 +41,12 @@ const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
   )
   const requestIdRef = useRef(0)
 
-  // Clear stale depth immediately when the cursor moves to a new position so
-  // the old value is never shown alongside the new coordinate. The cleanup
-  // bumps the counter on unmount (and before each re-run) so any in-flight
-  // onRequestDepth promise becomes stale and cannot call setDepth after the
-  // component unmounts.
-  useEffect(() => {
+  // useLayoutEffect runs synchronously after DOM mutations but before paint,
+  // preventing the one-frame flicker where new coordinates appear alongside
+  // the previous depth value. The cleanup bumps the counter on unmount (and
+  // before each re-run) so any in-flight onRequestDepth promise becomes stale
+  // and cannot call setDepth after the component unmounts.
+  useLayoutEffect(() => {
     requestIdRef.current++
     setDepth(null)
     return () => {

--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -1,5 +1,5 @@
 // jshint esversion:6
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { useMapEvents } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 import { useDebouncedEffect } from '@mbari/utils'

--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -36,10 +36,16 @@ const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
   const requestIdRef = useRef(0)
 
   // Clear stale depth immediately when the cursor moves to a new position so
-  // the old value is never shown alongside the new coordinate.
+  // the old value is never shown alongside the new coordinate. The cleanup
+  // bumps the counter on unmount (and before each re-run) so any in-flight
+  // onRequestDepth promise becomes stale and cannot call setDepth after the
+  // component unmounts.
   useEffect(() => {
     requestIdRef.current++
     setDepth(null)
+    return () => {
+      requestIdRef.current++
+    }
   }, [mousePoint])
 
   const formattedCoordinates =


### PR DESCRIPTION
## Summary

Closes #652

- When scrubbing the mission progress timeline, the vehicle GPS track now splits at the scrub position:
  - **Past segment** (already traveled): solid line at 35% opacity — de-emphasized to show history
  - **Future segment** (still to navigate): bright dashed line — highlighted to show what lies ahead
- Also fixes an unhandled `MapsServerError` from the Google Elevation API (`ELEVATION_LOCATIONS: UNKNOWN_ERROR`) that was crashing the Next.js dev overlay; added `.catch()` guards in `MouseCoordinates` and `MapDepthDisplay` so transient Google Maps errors are silently absorbed upstream where they are already logged/handled.

## Test plan

- [ ] Open a vehicle deployment page with an active GPS track
- [ ] Hover the mission progress bar at the bottom — track should split: solid/dim past, dashed/bright future
- [ ] Move to left end of timeline — most of track should be dashed/bright (future)
- [ ] Move to right end — most of track should be solid/dim (past)
- [ ] Move mouse off timeline — full solid track restores after ~1 second
- [ ] Hover the deployment map — confirm no `MapsServerError` runtime error overlay appears