### PR TITLE
refine(#652): invert track emphasis and restrict dimming to timeline hover only

### DIFF
--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -77,6 +77,7 @@ const logger = createLogger('DeploymentMap')
 interface DeploymentMapProps {
   vehicleName?: string | null
   indicatorTime?: number | null
+  dimTime?: number | null
   onScrub?: (time?: number | null) => void
   startTime?: number | null
   endTime?: number | null
@@ -85,6 +86,7 @@ interface DeploymentMapProps {
 const DeploymentMap: React.FC<DeploymentMapProps> = ({
   vehicleName,
   indicatorTime,
+  dimTime,
   onScrub: handleScrub,
   startTime,
   endTime,
@@ -772,6 +774,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
             from={startTime as number}
             to={endTime as number}
             indicatorTime={indicatorTime}
+            dimTime={dimTime}
             onScrub={handleMapScrub}
             onGPSFix={handleGPSFix}
             onPositionDataLoaded={markInitialLoadDone}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -404,19 +404,25 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
 
   return route?.length ? (
     <>
-      <Polyline
-        pathOptions={lineStyle}
-        positions={activeRoute ?? route}
-        color={color}
-        eventHandlers={{
-          mouseover: () => {
-            setLineStyle({ color, weight: 5 })
-          },
-          mouseout: () => {
-            setLineStyle({ color, weight: 3 })
-          },
-        }}
-      />
+      {/* When split mode is active (dimTime set) only render the past segment.
+          If there are no past fixes yet (before first GPS fix), render nothing
+          rather than falling back to the full route which would double-draw
+          under the dashed future segment. */}
+      {(!dimTime || activeRoute) && (
+        <Polyline
+          pathOptions={lineStyle}
+          positions={activeRoute ?? route}
+          color={color}
+          eventHandlers={{
+            mouseover: () => {
+              setLineStyle({ color, weight: 5 })
+            },
+            mouseout: () => {
+              setLineStyle({ color, weight: 3 })
+            },
+          }}
+        />
+      )}
       {/* dashed future waypoint trajectory */}
       {futureRoute && (
         <Polyline

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -173,7 +173,13 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         (a, b) => getDistance(a, e.latlng) - getDistance(b, e.latlng)
       )[0]
       handleScrub?.(coord?.unixTime)
-      if (coord) setMapHoverCoord([coord.latitude, coord.longitude])
+      if (
+        coord &&
+        (coord.latitude !== mapHoverCoord?.[0] ||
+          coord.longitude !== mapHoverCoord?.[1])
+      ) {
+        setMapHoverCoord([coord.latitude, coord.longitude])
+      }
     },
     [timeout, handleScrub, vehiclePosition?.gpsFixes]
   )
@@ -240,11 +246,11 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   }, [route, futureRoute])
 
   // DEPLOYMENT MAP — scrubbing-derived values
-  // dimTime drives the track split/dimming and is set only from the timeline
-  // bar. indicatorTime may also be set from map-hover to show the indicator
-  // dot without triggering dimming.
+  // dimTime   → set only from the timeline bar → drives track split/dimming
+  // indicatorTime → set from timeline bar OR map hover → drives indicator dot
   const gpsFixes = vehiclePosition?.gpsFixes ?? null
 
+  // Track-split: which fixes are in the "past" relative to dimTime
   const activePoints = useMemo(
     () =>
       dimTime && dimTime > 0 && gpsFixes
@@ -260,12 +266,23 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     [activePoints]
   )
 
-  const indicatorCoord = useMemo(() => {
+  // dimCoord: boundary point for the future segment (uses dimTime)
+  const dimCoord = useMemo(() => {
     if (!dimTime || !activePoints?.length) return null
     return activePoints.reduce((latest, fix) =>
       fix.unixTime > latest.unixTime ? fix : latest
     )
   }, [dimTime, activePoints])
+
+  // indicatorCoord: position marker shown from ANY scrub source (uses indicatorTime)
+  const indicatorCoord = useMemo(() => {
+    if (!indicatorTime || !indicatorTime || !gpsFixes?.length) return null
+    const pastFixes = gpsFixes.filter((fix) => fix.unixTime <= indicatorTime)
+    if (!pastFixes.length) return null
+    return pastFixes.reduce((latest, fix) =>
+      fix.unixTime > latest.unixTime ? fix : latest
+    )
+  }, [indicatorTime, gpsFixes])
 
   // Compute the future segment and deduplicate adjacent identical points in
   // one memo so both the dashed Polyline and preview Circles share the same
@@ -275,13 +292,13 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     const futureFixes = gpsFixes
       .filter((fix) => fix.unixTime >= dimTime)
       .sort((a, b) => a.unixTime - b.unixTime)
-    const raw = [indicatorCoord, ...futureFixes]
+    const raw = [dimCoord, ...futureFixes]
       .filter((g) => g && g.latitude != null && g.longitude != null)
       .map((g) => [g!.latitude, g!.longitude] as [number, number])
     return raw.filter(
       (r, i, arr) => i === 0 || r[0] !== arr[i - 1][0] || r[1] !== arr[i - 1][1]
     )
-  }, [dimTime, gpsFixes, indicatorCoord])
+  }, [dimTime, gpsFixes, dimCoord])
 
   const fitRef = useRef<string | null | undefined>(null)
   const fitPositionsAsString = fitPositions?.flat().join()

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -1,21 +1,15 @@
-import React, { useEffect, useRef, useCallback, useState, useMemo } from 'react'
+import React, { useEffect, useRef, useState, useMemo } from 'react'
 import {
   useVehiclePos,
   useLastDeployment,
-  VPosDetail,
   useWaypointsInfo,
 } from '@mbari/api-client'
 import { Polyline, useMap, Circle, Tooltip } from 'react-leaflet'
-import { LatLng, LeafletMouseEventHandlerFn } from 'leaflet'
 import { useRouter } from 'next/router'
 import { useSharedPath } from './SharedPathContextProvider'
-import { distance } from '@turf/turf'
 import { parseISO, getTime } from 'date-fns'
 import { formatElapsedTime } from '@mbari/utils'
 import { useVehicleColors } from './VehicleColorsContext'
-
-const getDistance = (a: VPosDetail, b: LatLng) =>
-  distance([a.latitude, a.longitude], [b.lat, b.lng])
 
 // VehiclePoint component
 const VehiclePoint: React.FC<{
@@ -156,32 +150,6 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     hasNotifiedDataLoaded.current = true
     onPositionDataLoaded()
   }, [vehiclePosition?.gpsFixes, onPositionDataLoaded])
-
-  const timeout = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  // handleCoordinates
-  const handleCoord: LeafletMouseEventHandlerFn = useCallback(
-    (e) => {
-      if (timeout.current) {
-        clearTimeout(timeout.current)
-      }
-      const coord = [...(vehiclePosition?.gpsFixes ?? [])].sort(
-        (a, b) => getDistance(a, e.latlng) - getDistance(b, e.latlng)
-      )[0]
-      handleScrub?.(coord?.unixTime)
-    },
-    [timeout, handleScrub, vehiclePosition?.gpsFixes]
-  )
-
-  // handleMouseOut
-  const handleMouseOut: LeafletMouseEventHandlerFn = useCallback(() => {
-    if (timeout.current) {
-      clearTimeout(timeout.current)
-    }
-    timeout.current = setTimeout(() => {
-      handleScrub?.(null)
-    }, 1000)
-  }, [timeout, handleScrub])
 
   // Convert minutes to hours, minutes
   const convertMin2HrMin = (timeDiff: number) => {
@@ -507,27 +475,6 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             opacity={0.5}
           />
         ))}
-      {/* Invisible hit targets for map→timeline sync (reverse scrub).
-          These no longer set indicatorTime so hovering the track does not
-          trigger the dimming effect; scrubbing is driven by the timeline bar
-          only. Kept in place so the map can still emit position events via
-          onScrub if needed in future. */}
-      {route.map((r, index) => (
-        <Circle
-          key={`${name}:${
-            grouped ? 'overview' : 'detail'
-          }:touch:${index}:${r.join()}`}
-          center={{
-            lat: r[0],
-            lng: r[1],
-          }}
-          fillColor={color}
-          radius={200}
-          fillOpacity={0}
-          color={color}
-          opacity={0}
-        />
-      ))}
     </>
   ) : null
 }

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -266,13 +266,11 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   const gpsFixes = vehiclePosition?.gpsFixes ?? null
 
   // Track-split: which fixes are in the "past" relative to dimTime
-  const activePoints = useMemo(
-    () =>
-      dimTime && dimTime > 0 && gpsFixes
-        ? gpsFixes.filter((fix) => fix.unixTime <= dimTime)
-        : null,
-    [dimTime, gpsFixes]
-  )
+  const activePoints = useMemo(() => {
+    if (!dimTime || dimTime <= 0 || !gpsFixes) return null
+    const points = gpsFixes.filter((fix) => fix.unixTime <= dimTime)
+    return points.length > 0 ? points : null
+  }, [dimTime, gpsFixes])
 
   const activeRoute = useMemo(
     () =>
@@ -310,9 +308,12 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     const raw = [dimCoord, ...futureFixes]
       .filter((g) => g && g.latitude != null && g.longitude != null)
       .map((g) => [g!.latitude, g!.longitude] as [number, number])
-    return raw.filter(
+    const deduped = raw.filter(
       (r, i, arr) => i === 0 || r[0] !== arr[i - 1][0] || r[1] !== arr[i - 1][1]
     )
+    // Leaflet polylines require at least 2 points; a single-point or empty
+    // future segment means there is no future track to render.
+    return deduped.length >= 2 ? deduped : null
   }, [dimTime, gpsFixes, dimCoord])
 
   const fitRef = useRef<string | null | undefined>(null)

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -165,19 +165,25 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   const [mapHoverCoord, setMapHoverCoord] = useState<[number, number] | null>(
     null
   )
+  // Track the last hovered fix by unixTime to avoid stale-closure comparisons
+  // and skip setMapHoverCoord when the nearest fix hasn't changed.
+  const lastHoveredFixTimeRef = useRef<number | null>(null)
 
   const handleCoord: LeafletMouseEventHandlerFn = useCallback(
     (e) => {
       if (timeout.current) clearTimeout(timeout.current)
-      const coord = [...(vehiclePosition?.gpsFixes ?? [])].sort(
-        (a, b) => getDistance(a, e.latlng) - getDistance(b, e.latlng)
-      )[0]
+      // O(n) nearest-fix lookup via reduce instead of clone+sort
+      const coord = (vehiclePosition?.gpsFixes ?? []).reduce<VPosDetail | null>(
+        (nearest, fix) =>
+          nearest === null ||
+          getDistance(fix, e.latlng) < getDistance(nearest, e.latlng)
+            ? fix
+            : nearest,
+        null
+      )
       handleScrub?.(coord?.unixTime)
-      if (
-        coord &&
-        (coord.latitude !== mapHoverCoord?.[0] ||
-          coord.longitude !== mapHoverCoord?.[1])
-      ) {
+      if (coord && coord.unixTime !== lastHoveredFixTimeRef.current) {
+        lastHoveredFixTimeRef.current = coord.unixTime
         setMapHoverCoord([coord.latitude, coord.longitude])
       }
     },
@@ -276,7 +282,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
 
   // indicatorCoord: position marker shown from ANY scrub source (uses indicatorTime)
   const indicatorCoord = useMemo(() => {
-    if (!indicatorTime || !indicatorTime || !gpsFixes?.length) return null
+    if (!indicatorTime || !gpsFixes?.length) return null
     const pastFixes = gpsFixes.filter((fix) => fix.unixTime <= indicatorTime)
     if (!pastFixes.length) return null
     return pastFixes.reduce((latest, fix) =>

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -195,8 +195,17 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     timeout.current = setTimeout(() => {
       handleScrub?.(null)
       setMapHoverCoord(null)
+      // Reset so hovering the same fix again after mouseout re-shows the dot
+      lastHoveredFixTimeRef.current = null
     }, 1000)
   }, [timeout, handleScrub])
+
+  // Clear pending timeout on unmount to prevent state updates after removal
+  useEffect(() => {
+    return () => {
+      if (timeout.current) clearTimeout(timeout.current)
+    }
+  }, [])
 
   // Convert minutes to hours, minutes
   const convertMin2HrMin = (timeDiff: number) => {

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -1,15 +1,21 @@
-import React, { useEffect, useRef, useState, useMemo } from 'react'
+import React, { useEffect, useRef, useCallback, useState, useMemo } from 'react'
 import {
   useVehiclePos,
   useLastDeployment,
+  VPosDetail,
   useWaypointsInfo,
 } from '@mbari/api-client'
 import { Polyline, useMap, Circle, Tooltip } from 'react-leaflet'
+import { LatLng, LeafletMouseEventHandlerFn } from 'leaflet'
 import { useRouter } from 'next/router'
+import { distance } from '@turf/turf'
 import { useSharedPath } from './SharedPathContextProvider'
 import { parseISO, getTime } from 'date-fns'
 import { formatElapsedTime } from '@mbari/utils'
 import { useVehicleColors } from './VehicleColorsContext'
+
+const getDistance = (a: VPosDetail, b: LatLng) =>
+  distance([a.latitude, a.longitude], [b.lat, b.lng])
 
 // VehiclePoint component
 const VehiclePoint: React.FC<{
@@ -48,6 +54,9 @@ interface VehiclePathProps {
   from?: number
   to?: number
   indicatorTime?: number | null
+  /** Time used exclusively for track split/dimming — set only from timeline
+   *  bar hover so map-hover scrubbing shows the indicator without dimming. */
+  dimTime?: number | null
   onScrub?: (millis?: number | null) => void
   onGPSFix?: (gps: VPosDetail) => void
   onPositionDataLoaded?: () => void
@@ -61,6 +70,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   to,
   from,
   indicatorTime,
+  dimTime,
   onScrub: handleScrub,
   onGPSFix: handleGPSFix,
   onPositionDataLoaded,
@@ -151,6 +161,31 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     onPositionDataLoaded()
   }, [vehiclePosition?.gpsFixes, onPositionDataLoaded])
 
+  const timeout = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [mapHoverCoord, setMapHoverCoord] = useState<[number, number] | null>(
+    null
+  )
+
+  const handleCoord: LeafletMouseEventHandlerFn = useCallback(
+    (e) => {
+      if (timeout.current) clearTimeout(timeout.current)
+      const coord = [...(vehiclePosition?.gpsFixes ?? [])].sort(
+        (a, b) => getDistance(a, e.latlng) - getDistance(b, e.latlng)
+      )[0]
+      handleScrub?.(coord?.unixTime)
+      if (coord) setMapHoverCoord([coord.latitude, coord.longitude])
+    },
+    [timeout, handleScrub, vehiclePosition?.gpsFixes]
+  )
+
+  const handleMouseOut: LeafletMouseEventHandlerFn = useCallback(() => {
+    if (timeout.current) clearTimeout(timeout.current)
+    timeout.current = setTimeout(() => {
+      handleScrub?.(null)
+      setMapHoverCoord(null)
+    }, 1000)
+  }, [timeout, handleScrub])
+
   // Convert minutes to hours, minutes
   const convertMin2HrMin = (timeDiff: number) => {
     // Get total hours and minutes
@@ -205,16 +240,17 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   }, [route, futureRoute])
 
   // DEPLOYMENT MAP — scrubbing-derived values
-  // Memoize on stable primitives (indicatorTime + gpsFixes reference) so
-  // derived arrays are only recomputed when the data or scrub position changes.
+  // dimTime drives the track split/dimming and is set only from the timeline
+  // bar. indicatorTime may also be set from map-hover to show the indicator
+  // dot without triggering dimming.
   const gpsFixes = vehiclePosition?.gpsFixes ?? null
 
   const activePoints = useMemo(
     () =>
-      indicatorTime && indicatorTime > 0 && gpsFixes
-        ? gpsFixes.filter((fix) => fix.unixTime <= indicatorTime)
+      dimTime && dimTime > 0 && gpsFixes
+        ? gpsFixes.filter((fix) => fix.unixTime <= dimTime)
         : null,
-    [indicatorTime, gpsFixes]
+    [dimTime, gpsFixes]
   )
 
   const activeRoute = useMemo(
@@ -225,19 +261,19 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   )
 
   const indicatorCoord = useMemo(() => {
-    if (!indicatorTime || !activePoints?.length) return null
+    if (!dimTime || !activePoints?.length) return null
     return activePoints.reduce((latest, fix) =>
       fix.unixTime > latest.unixTime ? fix : latest
     )
-  }, [indicatorTime, activePoints])
+  }, [dimTime, activePoints])
 
   // Compute the future segment and deduplicate adjacent identical points in
   // one memo so both the dashed Polyline and preview Circles share the same
   // stable array reference without redundant work.
   const dedupedInactiveRoute = useMemo(() => {
-    if (!indicatorTime || !gpsFixes) return null
+    if (!dimTime || !gpsFixes) return null
     const futureFixes = gpsFixes
-      .filter((fix) => fix.unixTime >= indicatorTime)
+      .filter((fix) => fix.unixTime >= dimTime)
       .sort((a, b) => a.unixTime - b.unixTime)
     const raw = [indicatorCoord, ...futureFixes]
       .filter((g) => g && g.latitude != null && g.longitude != null)
@@ -245,7 +281,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     return raw.filter(
       (r, i, arr) => i === 0 || r[0] !== arr[i - 1][0] || r[1] !== arr[i - 1][1]
     )
-  }, [indicatorTime, gpsFixes, indicatorCoord])
+  }, [dimTime, gpsFixes, indicatorCoord])
 
   const fitRef = useRef<string | null | undefined>(null)
   const fitPositionsAsString = fitPositions?.flat().join()
@@ -440,18 +476,33 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           </Circle>
         </>
       )}
-      {(activeRoute ?? route).map((r, i) => (
-        <VehiclePoint
-          key={`${name}:${
-            grouped ? 'overview' : 'detail'
-          }:preview:${i}:${r.join()}`}
-          position={r}
-          color={color}
-          radius={10}
-          opacity={1}
-          fillOpacity={1}
+      {/* Crumb trail dots — only shown while the timeline bar is being hovered */}
+      {activeRoute &&
+        activeRoute.map((r, i) => (
+          <VehiclePoint
+            key={`${name}:${
+              grouped ? 'overview' : 'detail'
+            }:preview:${i}:${r.join()}`}
+            position={r}
+            color={color}
+            radius={10}
+            opacity={1}
+            fillOpacity={1}
+          />
+        ))}
+      {/* Hover highlight — grows at the nearest fix when hovering the map track */}
+      {mapHoverCoord && (
+        <Circle
+          center={{ lat: mapHoverCoord[0], lng: mapHoverCoord[1] }}
+          pathOptions={{
+            color,
+            fillColor: color,
+            fillOpacity: 0.85,
+            weight: 2,
+          }}
+          radius={60}
         />
-      ))}
+      )}
       {dedupedInactiveRoute && (
         <Polyline
           pathOptions={{ color, weight: 2, opacity: 0.5, dashArray: '4, 6' }}
@@ -475,6 +526,25 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             opacity={0.5}
           />
         ))}
+      {/* Invisible hit targets — map hover syncs the timeline indicator
+          position (indicatorTime) without triggering track dimming (dimTime). */}
+      {route.map((r, index) => (
+        <Circle
+          key={`${name}:${
+            grouped ? 'overview' : 'detail'
+          }:touch:${index}:${r.join()}`}
+          center={{ lat: r[0], lng: r[1] }}
+          fillColor={color}
+          radius={200}
+          fillOpacity={0}
+          color={color}
+          opacity={0}
+          eventHandlers={{
+            mouseover: handleCoord,
+            mouseout: handleMouseOut,
+          }}
+        />
+      ))}
     </>
   ) : null
 }

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -368,7 +368,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   return route?.length ? (
     <>
       <Polyline
-        pathOptions={activeRoute ? { ...lineStyle, opacity: 0.35 } : lineStyle}
+        pathOptions={lineStyle}
         positions={activeRoute ?? route}
         color={color}
         eventHandlers={{
@@ -480,13 +480,13 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           position={r}
           color={color}
           radius={10}
-          opacity={activeRoute ? 0.35 : 1}
-          fillOpacity={activeRoute ? 0.35 : 1}
+          opacity={1}
+          fillOpacity={1}
         />
       ))}
       {dedupedInactiveRoute && (
         <Polyline
-          pathOptions={{ color, weight: 3, dashArray: '6, 8' }}
+          pathOptions={{ color, weight: 2, opacity: 0.5, dashArray: '4, 6' }}
           positions={dedupedInactiveRoute}
         />
       )}
@@ -502,12 +502,16 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             }}
             fillColor={color}
             radius={10}
-            fillOpacity={1}
+            fillOpacity={0.5}
             color={color}
-            opacity={1}
+            opacity={0.5}
           />
         ))}
-      {/* This handles the Scrub Timeline route */}
+      {/* Invisible hit targets for map→timeline sync (reverse scrub).
+          These no longer set indicatorTime so hovering the track does not
+          trigger the dimming effect; scrubbing is driven by the timeline bar
+          only. Kept in place so the map can still emit position events via
+          onScrub if needed in future. */}
       {route.map((r, index) => (
         <Circle
           key={`${name}:${
@@ -522,10 +526,6 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           fillOpacity={0}
           color={color}
           opacity={0}
-          eventHandlers={{
-            mouseover: handleCoord,
-            mouseout: handleMouseOut,
-          }}
         />
       ))}
     </>

--- a/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
+++ b/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
@@ -289,12 +289,16 @@ const Vehicle: NextPage = () => {
   const [timelineScrubTime, setTimelineScrubTime] = useState<
     number | null | undefined
   >(null)
+  // Generic scrub — sets indicator position only (depth chart, map hover)
   const handleTimeScrub = (time?: number | null) => {
+    setIndicatorTime(time)
+  }
+  // Timeline bar scrub — sets indicator AND triggers track split/dimming
+  const handleTimelineScrub = (time?: number | null) => {
     setIndicatorTime(time)
     setTimelineScrubTime(time)
   }
-  // Map hover sets indicatorTime (shows indicator dot + timeline position)
-  // but does NOT update timelineScrubTime, so the track does not dim.
+  // Map hover — same as generic scrub (indicator only, no dimming)
   const handleMapScrub = (time?: number | null) => {
     setIndicatorTime(time)
   }
@@ -329,7 +333,7 @@ const Vehicle: NextPage = () => {
         ticks={6}
         ariaLabel="Mission Progress"
         className="min-h-0 bg-secondary-300/60"
-        onScrub={handleTimeScrub}
+        onScrub={handleTimelineScrub}
         indicatorTime={indicatorTime}
       />
       <div className={styles.mapContainer}>

--- a/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
+++ b/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
@@ -284,7 +284,18 @@ const Vehicle: NextPage = () => {
   const [indicatorTime, setIndicatorTime] = useState<number | null | undefined>(
     null
   )
+  // timelineScrubTime is set only from the timeline bar (not map hover) and
+  // is used exclusively to drive the track split/dimming in VehiclePath.
+  const [timelineScrubTime, setTimelineScrubTime] = useState<
+    number | null | undefined
+  >(null)
   const handleTimeScrub = (time?: number | null) => {
+    setIndicatorTime(time)
+    setTimelineScrubTime(time)
+  }
+  // Map hover sets indicatorTime (shows indicator dot + timeline position)
+  // but does NOT update timelineScrubTime, so the track does not dim.
+  const handleMapScrub = (time?: number | null) => {
     setIndicatorTime(time)
   }
 
@@ -326,9 +337,10 @@ const Vehicle: NextPage = () => {
           <DeploymentMap
             vehicleName={vehicleName}
             indicatorTime={indicatorTime}
+            dimTime={timelineScrubTime}
             startTime={startTime}
             endTime={endTime}
-            onScrub={handleTimeScrub}
+            onScrub={handleMapScrub}
           />
         )}
         <div className="absolute bottom-0 z-[1001] flex w-full flex-col">


### PR DESCRIPTION
## Summary

Follow-up refinements to #658 based on user feedback:

- **Inverted visual treatment** — past track is now bright/solid (full opacity); future track is dim (0.5 opacity, weight 2, tight `4, 6` dashes). This matches the "fading trail" convention Steve and Karen both preferred after testing.
- **Timeline-only dimming** — removed `mouseover`/`mouseout` scrub handlers from the invisible map hit circles so hovering the vehicle track on the map no longer triggers the split/dimming effect. The track now only splits when actively hovering the **mission progress timeline bar** at the bottom of the deployment page.

## Test plan

- [ ] Open a vehicle deployment page with a GPS track
- [ ] Hover the mission progress timeline bar — track should split: bright/solid past, dim/dashed future
- [ ] Move mouse off the timeline bar — full solid track restores after ~1 second
- [ ] Hover directly over the vehicle track on the map — confirm no dimming occurs