### PR TITLE
feat(#652): add hover tooltip and stable highlight dot on vehicle track

### DIFF
--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -270,7 +270,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     () =>
       vehiclePosition?.gpsFixes?.map(
         (g) => [g.latitude, g.longitude] as [number, number]
-      ),
+      ) ?? [],
     [vehiclePosition?.gpsFixes]
   )
 
@@ -573,16 +573,16 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
       {mapHoverFix && (
         <Circle
           center={{ lat: mapHoverFix.latitude, lng: mapHoverFix.longitude }}
+          interactive={false}
           pathOptions={{
             color,
             fillColor: color,
             fillOpacity: 0.85,
             weight: 2,
-            interactive: false,
           }}
           radius={60}
         >
-          <Tooltip direction="right" offset={[10, 0]} opacity={0.95}>
+          <Tooltip permanent direction="right" offset={[10, 0]} opacity={0.95}>
             <div className="text-xs leading-snug">
               <div className="flex items-center gap-1 font-bold text-black">
                 <span

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -47,6 +47,45 @@ const VehiclePoint: React.FC<{
   </Circle>
 )
 
+// Memoized hit-circle layer so it never re-renders when VehiclePath state
+// (mapHoverFix, indicatorTime, etc.) changes — prevents React-Leaflet from
+// re-mounting the circles and emitting spurious mouseout/mouseover events.
+const HitCircles = React.memo(
+  ({
+    name,
+    grouped,
+    route,
+    color,
+    onCoord,
+    onMouseOut,
+  }: {
+    name: string
+    grouped?: boolean
+    route: [number, number][]
+    color: string
+    onCoord: LeafletMouseEventHandlerFn
+    onMouseOut: LeafletMouseEventHandlerFn
+  }) => (
+    <>
+      {route.map((r, index) => (
+        <Circle
+          key={`${name}:${
+            grouped ? 'overview' : 'detail'
+          }:touch:${index}:${r.join()}`}
+          center={{ lat: r[0], lng: r[1] }}
+          fillColor={color}
+          radius={200}
+          fillOpacity={0}
+          color={color}
+          opacity={0}
+          eventHandlers={{ mouseover: onCoord, mouseout: onMouseOut }}
+        />
+      ))}
+    </>
+  )
+)
+HitCircles.displayName = 'HitCircles'
+
 // VehiclePathProps interface
 interface VehiclePathProps {
   name: string
@@ -162,11 +201,9 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   }, [vehiclePosition?.gpsFixes, onPositionDataLoaded])
 
   const timeout = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [mapHoverCoord, setMapHoverCoord] = useState<[number, number] | null>(
-    null
-  )
+  const [mapHoverFix, setMapHoverFix] = useState<VPosDetail | null>(null)
   // Track the last hovered fix by unixTime to avoid stale-closure comparisons
-  // and skip setMapHoverCoord when the nearest fix hasn't changed.
+  // and skip setState when the nearest fix hasn't changed.
   const lastHoveredFixTimeRef = useRef<number | null>(null)
 
   const handleCoord: LeafletMouseEventHandlerFn = useCallback(
@@ -181,10 +218,10 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             : nearest,
         null
       )
-      handleScrub?.(coord?.unixTime)
       if (coord && coord.unixTime !== lastHoveredFixTimeRef.current) {
         lastHoveredFixTimeRef.current = coord.unixTime
-        setMapHoverCoord([coord.latitude, coord.longitude])
+        handleScrub?.(coord.unixTime)
+        setMapHoverFix(coord)
       }
     },
     [timeout, handleScrub, vehiclePosition?.gpsFixes]
@@ -194,7 +231,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     if (timeout.current) clearTimeout(timeout.current)
     timeout.current = setTimeout(() => {
       handleScrub?.(null)
-      setMapHoverCoord(null)
+      setMapHoverFix(null)
       // Reset so hovering the same fix again after mouseout re-shows the dot
       lastHoveredFixTimeRef.current = null
     }, 1000)
@@ -530,17 +567,45 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           />
         ))}
       {/* Hover highlight — grows at the nearest fix when hovering the map track */}
-      {mapHoverCoord && (
+      {mapHoverFix && (
         <Circle
-          center={{ lat: mapHoverCoord[0], lng: mapHoverCoord[1] }}
+          center={{ lat: mapHoverFix.latitude, lng: mapHoverFix.longitude }}
           pathOptions={{
             color,
             fillColor: color,
             fillOpacity: 0.85,
             weight: 2,
+            interactive: false,
           }}
           radius={60}
-        />
+        >
+          <Tooltip direction="right" offset={[10, 0]} opacity={0.95}>
+            <div className="text-xs leading-snug">
+              <div className="flex items-center gap-1 font-bold text-black">
+                <span
+                  style={{
+                    background: color,
+                    borderRadius: '50%',
+                    width: 8,
+                    height: 8,
+                    display: 'inline-block',
+                    flexShrink: 0,
+                  }}
+                />
+                {name}
+              </div>
+              <div className="text-gray-700 mt-0.5">
+                {mapHoverFix.latitude.toFixed(5)},{' '}
+                {mapHoverFix.longitude.toFixed(5)}
+              </div>
+              <div className="text-gray-600">
+                {mapHoverFix.isoTime
+                  ? mapHoverFix.isoTime.replace('T', ' ').replace('Z', ' UTC')
+                  : new Date(mapHoverFix.unixTime).toUTCString()}
+              </div>
+            </div>
+          </Tooltip>
+        </Circle>
       )}
       {dedupedInactiveRoute && (
         <Polyline
@@ -565,25 +630,16 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             opacity={0.5}
           />
         ))}
-      {/* Invisible hit targets — map hover syncs the timeline indicator
-          position (indicatorTime) without triggering track dimming (dimTime). */}
-      {route.map((r, index) => (
-        <Circle
-          key={`${name}:${
-            grouped ? 'overview' : 'detail'
-          }:touch:${index}:${r.join()}`}
-          center={{ lat: r[0], lng: r[1] }}
-          fillColor={color}
-          radius={200}
-          fillOpacity={0}
-          color={color}
-          opacity={0}
-          eventHandlers={{
-            mouseover: handleCoord,
-            mouseout: handleMouseOut,
-          }}
-        />
-      ))}
+      {/* Memoized hit targets — isolated from VehiclePath re-renders to
+          prevent spurious mouseout/mouseover events causing tooltip flicker. */}
+      <HitCircles
+        name={name}
+        grouped={grouped}
+        route={route}
+        color={color}
+        onCoord={handleCoord}
+        onMouseOut={handleMouseOut}
+      />
     </>
   ) : null
 }

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -212,14 +212,15 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
 
   const handleCoord: LeafletMouseEventHandlerFn = useCallback((e) => {
     if (timeout.current) clearTimeout(timeout.current)
-    const coord = (gpsFixesRef.current ?? []).reduce<VPosDetail | null>(
-      (nearest, fix) =>
-        nearest === null ||
-        getDistance(fix, e.latlng) < getDistance(nearest, e.latlng)
-          ? fix
-          : nearest,
-      null
-    )
+    let coord: VPosDetail | null = null
+    let bestDist = Infinity
+    for (const fix of gpsFixesRef.current ?? []) {
+      const d = getDistance(fix, e.latlng)
+      if (d < bestDist) {
+        bestDist = d
+        coord = fix
+      }
+    }
     if (coord && coord.unixTime !== lastHoveredFixTimeRef.current) {
       lastHoveredFixTimeRef.current = coord.unixTime
       handleScrubRef.current?.(coord.unixTime)
@@ -581,9 +582,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 {mapHoverFix.longitude.toFixed(5)}
               </div>
               <div className="text-gray-600">
-                {mapHoverFix.isoTime
-                  ? mapHoverFix.isoTime.replace('T', ' ').replace('Z', ' UTC')
-                  : new Date(mapHoverFix.unixTime).toUTCString()}
+                {mapHoverFix.isoTime.replace('T', ' ').replace('Z', ' UTC')}
               </div>
             </div>
           </Tooltip>

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -15,7 +15,7 @@ import { formatElapsedTime } from '@mbari/utils'
 import { useVehicleColors } from './VehicleColorsContext'
 
 const getDistance = (a: VPosDetail, b: LatLng) =>
-  distance([a.latitude, a.longitude], [b.lat, b.lng])
+  distance([a.longitude, a.latitude], [b.lng, b.lat])
 
 // VehiclePoint component
 const VehiclePoint: React.FC<{
@@ -519,19 +519,20 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           radius={60}
         >
           <Tooltip direction="right" offset={[10, 0]} opacity={0.9}>
-            <span>
-              <div className="text-purple text-bold">
-                {name} <br />
+            <div>
+              <div className="text-purple text-bold">{name}</div>
+              <div>
+                Latest position: {latest.latitude.toFixed(5)},{' '}
+                {latest.longitude.toFixed(5)}
               </div>
-              Latest position: {latest.latitude.toFixed(5)},{' '}
-              {latest.longitude.toFixed(5)}
-              <br />
-              {latest.isoTime.split('T')[0] +
-                ' ' +
-                latest.isoTime.split('T')[1].split('Z')[0]}
-              {' - '}
-              {timeSinceFixDisplay}
-            </span>
+              <div>
+                {latest.isoTime.split('T')[0] +
+                  ' ' +
+                  latest.isoTime.split('T')[1].split('Z')[0]}
+                {' - '}
+                {timeSinceFixDisplay}
+              </div>
+            </div>
           </Tooltip>
         </Circle>
       )}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -267,8 +267,12 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   }
 
   // route
-  const route = vehiclePosition?.gpsFixes?.map(
-    (g) => [g.latitude, g.longitude] as [number, number]
+  const route = useMemo(
+    () =>
+      vehiclePosition?.gpsFixes?.map(
+        (g) => [g.latitude, g.longitude] as [number, number]
+      ),
+    [vehiclePosition?.gpsFixes]
   )
 
   const futureRoute = useMemo(() => {

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -257,14 +257,6 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     return { hours, minutes, timeSinceFix }
   }
 
-  const [tooltipVisible, setTooltipVisible] = useState(false)
-  const handleTTVisible = () => {
-    setTooltipVisible(true)
-  }
-  const handleTTHidden = () => {
-    setTooltipVisible(false)
-  }
-
   // route
   const route = useMemo(
     () =>
@@ -515,45 +507,32 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           </Circle>
         </>
       )}
-      {/* DEPLOYMENT MAP VEHICLE VIEW */}
-      {indicatorCoord && (
-        <>
-          {/* This Circle is the actual point per GPS fix */}
-          <Circle
-            pathOptions={{ color }}
-            center={{
-              lat: indicatorCoord.latitude,
-              lng: indicatorCoord.longitude,
-            }}
-            fillColor={color}
-            fillOpacity={1}
-            color={color}
-            // Sets the center dot radius of latest fix on hover
-            radius={60}
-            eventHandlers={{
-              mouseover: handleTTVisible,
-              mouseout: handleTTHidden,
-            }}
-          >
-            {tooltipVisible && (
-              <Tooltip direction="right" offset={[10, 0]} opacity={0.9}>
-                <span>
-                  <div className="text-purple text-bold">
-                    {name} <br />
-                  </div>
-                  Latest position: {indicatorCoord.latitude.toFixed(5)},{' '}
-                  {indicatorCoord.longitude.toFixed(5)}
-                  <br />
-                  {indicatorCoord.isoTime.split('T')[0] +
-                    ' ' +
-                    indicatorCoord.isoTime.split('T')[1].split('Z')[0]}
-                  {' - '}
-                  {timeSinceFixDisplay}
-                </span>
-              </Tooltip>
-            )}
-          </Circle>
-        </>
+      {/* Solid dot at the latest GPS fix — always visible, tooltip on hover only */}
+      {latest && (
+        <Circle
+          pathOptions={{ color }}
+          center={{ lat: latest.latitude, lng: latest.longitude }}
+          fillColor={color}
+          fillOpacity={1}
+          color={color}
+          radius={60}
+        >
+          <Tooltip direction="right" offset={[10, 0]} opacity={0.9}>
+            <span>
+              <div className="text-purple text-bold">
+                {name} <br />
+              </div>
+              Latest position: {latest.latitude.toFixed(5)},{' '}
+              {latest.longitude.toFixed(5)}
+              <br />
+              {latest.isoTime.split('T')[0] +
+                ' ' +
+                latest.isoTime.split('T')[1].split('Z')[0]}
+              {' - '}
+              {timeSinceFixDisplay}
+            </span>
+          </Tooltip>
+        </Circle>
       )}
       {/* Crumb trail dots — only shown while the timeline bar is being hovered */}
       {activeRoute &&

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -202,40 +202,39 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
 
   const timeout = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [mapHoverFix, setMapHoverFix] = useState<VPosDetail | null>(null)
-  // Track the last hovered fix by unixTime to avoid stale-closure comparisons
-  // and skip setState when the nearest fix hasn't changed.
   const lastHoveredFixTimeRef = useRef<number | null>(null)
+  // Refs keep handleCoord/handleMouseOut deps-free so they never change
+  // reference — preventing HitCircles from re-rendering on every poll/render.
+  const gpsFixesRef = useRef(vehiclePosition?.gpsFixes)
+  const handleScrubRef = useRef(handleScrub)
+  gpsFixesRef.current = vehiclePosition?.gpsFixes
+  handleScrubRef.current = handleScrub
 
-  const handleCoord: LeafletMouseEventHandlerFn = useCallback(
-    (e) => {
-      if (timeout.current) clearTimeout(timeout.current)
-      // O(n) nearest-fix lookup via reduce instead of clone+sort
-      const coord = (vehiclePosition?.gpsFixes ?? []).reduce<VPosDetail | null>(
-        (nearest, fix) =>
-          nearest === null ||
-          getDistance(fix, e.latlng) < getDistance(nearest, e.latlng)
-            ? fix
-            : nearest,
-        null
-      )
-      if (coord && coord.unixTime !== lastHoveredFixTimeRef.current) {
-        lastHoveredFixTimeRef.current = coord.unixTime
-        handleScrub?.(coord.unixTime)
-        setMapHoverFix(coord)
-      }
-    },
-    [timeout, handleScrub, vehiclePosition?.gpsFixes]
-  )
+  const handleCoord: LeafletMouseEventHandlerFn = useCallback((e) => {
+    if (timeout.current) clearTimeout(timeout.current)
+    const coord = (gpsFixesRef.current ?? []).reduce<VPosDetail | null>(
+      (nearest, fix) =>
+        nearest === null ||
+        getDistance(fix, e.latlng) < getDistance(nearest, e.latlng)
+          ? fix
+          : nearest,
+      null
+    )
+    if (coord && coord.unixTime !== lastHoveredFixTimeRef.current) {
+      lastHoveredFixTimeRef.current = coord.unixTime
+      handleScrubRef.current?.(coord.unixTime)
+      setMapHoverFix(coord)
+    }
+  }, []) // stable forever — reads live values via refs
 
   const handleMouseOut: LeafletMouseEventHandlerFn = useCallback(() => {
     if (timeout.current) clearTimeout(timeout.current)
     timeout.current = setTimeout(() => {
-      handleScrub?.(null)
+      handleScrubRef.current?.(null)
       setMapHoverFix(null)
-      // Reset so hovering the same fix again after mouseout re-shows the dot
       lastHoveredFixTimeRef.current = null
     }, 1000)
-  }, [timeout, handleScrub])
+  }, []) // stable forever — reads live values via refs
 
   // Clear pending timeout on unmount to prevent state updates after removal
   useEffect(() => {


### PR DESCRIPTION
## Summary

Adds a tooltip and highlight dot when hovering the vehicle GPS track on the deployment map.

- **Hover highlight dot** — a solid circle (radius 60m) grows at the nearest GPS fix when hovering the track
- **Tooltip** — shows vehicle name (bold + colored dot), lat/lon (5 decimal places), and UTC timestamp
- **Stable updates** — `handleScrub` and `setMapHoverFix` only fire when the nearest fix actually changes, avoiding unnecessary parent re-renders while traversing the track
- **Memoized hit circles** (`HitCircles`) — isolated from VehiclePath re-renders to reduce spurious Leaflet events
- **`interactive: false`** on highlight circle so it doesn't intercept mouse events from underlying hit circles

## Known issue

The tooltip still flashes periodically (tracked in #660). The root cause appears to be react-leaflet re-rendering the Leaflet layers on parent state changes. Shipping as-is since the tooltip is still useful; #660 will address the flicker in a follow-up.

## Test plan

- [ ] Hover vehicle track on deployment map — highlight dot appears at nearest GPS fix
- [ ] Tooltip shows: colored dot + bold vehicle name, lat/lon, UTC timestamp
- [ ] Moving to a different fix updates the tooltip
- [ ] Moving off the track clears the dot + tooltip after ~1s