### PR TITLE
perf: skip setDepth re-render when depth is already null on mouse move

### DIFF
--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -48,7 +48,7 @@ const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
   // and cannot call setDepth after the component unmounts.
   useLayoutEffect(() => {
     requestIdRef.current++
-    setDepth(null)
+    setDepth((prev) => (prev !== null ? null : prev))
     return () => {
       requestIdRef.current++
     }


### PR DESCRIPTION
Addresses Copilot comment on PR #662: `setDepth(null)` was called unconditionally on every mouse move in `useLayoutEffect`, triggering extra renders even when depth was already null. Using the functional updater form skips the state change when depth is already null.