### PR TITLE
fix: address Copilot review comments on PR #662 (round 3)

### DIFF
--- a/apps/lrauv-dash2/components/MapLayersTreeItem.tsx
+++ b/apps/lrauv-dash2/components/MapLayersTreeItem.tsx
@@ -212,7 +212,7 @@ export const TreeItem: React.FC<TreeItemProps> = ({
               </button>
             </Tippy>
           )}
-          {legendContent !== undefined && (
+          {legendContent != null && (
             <Tippy
               content={legendContent}
               placement="right"

--- a/apps/lrauv-dash2/components/TileLayersSection.tsx
+++ b/apps/lrauv-dash2/components/TileLayersSection.tsx
@@ -11,7 +11,8 @@ interface TileLayerItem {
 }
 
 const getLegendUrl = (tile: TileLayerItem): string | undefined => {
-  if (tile.legendurl) return tile.legendurl
+  const trimmedLegendUrl = tile.legendurl?.trim()
+  if (trimmedLegendUrl) return trimmedLegendUrl
   const urlTemplate = tile.urlTemplate?.trim()
   if (tile.wms && urlTemplate) {
     const base = urlTemplate.replace(/\?$/, '')

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -536,6 +536,24 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           </Tooltip>
         </Circle>
       )}
+      {/* Scrub indicator dot — shown for any scrub source (depth chart, timeline)
+          unless the map-hover highlight is already visible at that position */}
+      {indicatorCoord && !mapHoverFix && (
+        <Circle
+          center={{
+            lat: indicatorCoord.latitude,
+            lng: indicatorCoord.longitude,
+          }}
+          interactive={false}
+          pathOptions={{
+            color,
+            fillColor: color,
+            fillOpacity: 0.85,
+            weight: 2,
+          }}
+          radius={40}
+        />
+      )}
       {/* Crumb trail dots — only shown while the timeline bar is being hovered */}
       {activeRoute &&
         activeRoute.map((r, i) => (

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -538,7 +538,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
       )}
       {/* Scrub indicator dot — shown for any scrub source (depth chart, timeline)
           unless the map-hover highlight is already visible at that position */}
-      {indicatorCoord && !mapHoverFix && (
+      {indicatorCoord && mapHoverFix?.unixTime !== indicatorCoord.unixTime && (
         <Circle
           center={{
             lat: indicatorCoord.latitude,


### PR DESCRIPTION
## Summary

Three fixes in response to the latest Copilot review on PR #662 (v5.1.41 production release):

- **`VehiclePath.tsx`**: Restore the scrub indicator dot. `indicatorCoord` was correctly computed from `indicatorTime` but was never rendered, so depth-chart hover and generic scrubbing no longer showed a position marker on the map. Added a small filled circle at `indicatorCoord` that is suppressed when the larger map-hover highlight (`mapHoverFix`) is already visible to avoid overlap.
- **`TileLayersSection.tsx`**: Trim `tile.legendurl` in `getLegendUrl()`. Without trimming, a whitespace-only value from the backend would still pass the truthiness check, rendering a legend info button whose tooltip content would be empty.
- **`MapLayersTreeItem.tsx`**: Tighten the `legendContent` guard from `!== undefined` to `!= null`. `React.ReactNode` includes `null`, so the previous check rendered a focusable legend button with no content when `legendContent` was explicitly `null`.

Closes these Copilot comments on #662.