### PR TITLE
chore: remove unused toast import from MouseCoordinates

### DIFF
--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -9,8 +9,6 @@ import React, {
 import { useMapEvents } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 import { useDebouncedEffect } from '@mbari/utils'
-import { toast } from 'react-hot-toast'
-
 const divStyle = {
   color: 'darkblue',
   fontFamily: 'monospace, serif',


### PR DESCRIPTION
Removes the `toast` import that was only referenced in commented-out debug code, flagged as a low-confidence suppressed comment in the Copilot review of PR #662.