### PR TITLE
chore: merge develop into main for v5.1.42 production release

### DIFF
--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -63,7 +63,8 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   }
 
   const onCommandError = (error: unknown) => {
-    toast.error(`Error sending command: ${error}`)
+    const message = error instanceof Error ? error.message : String(error)
+    toast.error(`Error sending command: ${message}`)
   }
 
   const sendCommand = (params: CreateCommandParams) => {

--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -61,21 +61,8 @@ const MissionModal: React.FC<MissionModalProps> = ({
   const { data: alternativeAddresses } = useSbdOutgoingAlternativeAddresses({})
   const { data: unitsData } = useUnits()
 
-  const {
-    mutate: createCommand,
-    isLoading: sendingCommand,
-    isSuccess: commandSent,
-    isError: commandError,
-  } = useCreateCommand()
-
-  useEffect(() => {
-    if (commandSent) {
-      toast.success('Command sent')
-      onClose()
-    } else if (commandError) {
-      toast.error(`Error sending command: ${commandError}`)
-    }
-  }, [commandSent, commandError, onClose])
+  const { mutate: createCommand, isLoading: sendingCommand } =
+    useCreateCommand()
 
   useEffect(() => {
     if (drawerOpen) {
@@ -292,17 +279,28 @@ const MissionModal: React.FC<MissionModalProps> = ({
     setPreviewText(previewSbd)
 
     if (!preview) {
-      createCommand({
-        vehicle: confirmedVehicle?.toLowerCase() ?? '',
-        path: missionPathForCommand,
-        commandNote: notes ?? '',
-        runCommand: 'y',
-        schedDate,
-        destinationAddress: alternateAddress ?? undefined,
-        commandText: formattedCommandText ?? '',
-        via: commType,
-        timeout,
-      })
+      createCommand(
+        {
+          vehicle: confirmedVehicle?.toLowerCase() ?? '',
+          path: missionPathForCommand,
+          commandNote: notes ?? '',
+          runCommand: 'y',
+          schedDate,
+          destinationAddress: alternateAddress ?? undefined,
+          commandText: formattedCommandText ?? '',
+          via: commType,
+          timeout,
+        },
+        {
+          onSuccess: () => {
+            toast.success('Command sent')
+            onClose()
+          },
+          onError: (error) => {
+            toast.error(`Error sending command: ${error}`)
+          },
+        }
+      )
     }
   }
 

--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -297,7 +297,9 @@ const MissionModal: React.FC<MissionModalProps> = ({
             onClose()
           },
           onError: (error) => {
-            toast.error(`Error sending command: ${error}`)
+            const message =
+              error instanceof Error ? error.message : String(error)
+            toast.error(`Error sending command: ${message}`)
           },
         }
       )


### PR DESCRIPTION
## Summary

Production release v5.1.42 — promotes the mission-send error toast fix from staging to production.

### Changes (since v5.1.41)

- **fix: stop continuous error toasts on mission send failure** (PR #666)
  - Extracts a readable message from error objects so the toast shows meaningful text
  - Stops the repeat-fire of error toasts when a mission send fails, preventing the UI from flooding the user with notifications

This fix has been running on `dash5-staging` for ~2 days with no issues reported.