### PR TITLE
fix: battery threshold text always renders in neutral color

### DIFF
--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.test.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.test.tsx
@@ -221,17 +221,9 @@ test('should hide Argos fill when no color from server (st18)', async () => {
 })
 
 test('should display volt threshold text in neutral color when not docked', async () => {
-  render(
-    <FullWidthVehicleDiagram
-      {...props}
-      textVoltThresh="13.5"
-      colorVoltThresh="st31"
-    />
-  )
-  // colorVoltThresh is intentionally ignored — threshold labels always render
-  // in neutral gray (st12) regardless of alarm state, matching Dash4 behavior.
+  render(<FullWidthVehicleDiagram {...props} textVoltThresh="13.5" />)
+  // Threshold labels always render in neutral gray (st12), matching Dash4 behavior.
   expect(screen.getByLabelText('text_voltthresh')).toHaveClass('st12')
-  expect(screen.getByLabelText('text_voltthresh')).not.toHaveClass('st31')
   expect(screen.getByLabelText('text_voltthresh')).toHaveTextContent('13.5')
 })
 
@@ -241,7 +233,6 @@ test('should hide volt threshold text when docked', async () => {
       {...props}
       status="pluggedIn"
       textVoltThresh="13.5"
-      colorVoltThresh="st31"
     />
   )
   expect(screen.getByLabelText('text_voltthresh')).toHaveClass('st18')

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.test.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.test.tsx
@@ -221,16 +221,30 @@ test('should hide Argos fill when no color from server (st18)', async () => {
 })
 
 test('should display volt threshold text in neutral color when not docked', async () => {
-  render(<FullWidthVehicleDiagram {...props} textVoltThresh="13.5" />)
-  // Threshold labels always render in neutral gray (st12), matching Dash4 behavior.
+  // Pass the alarm color (st31) to prove the component ignores it and stays neutral.
+  render(
+    <FullWidthVehicleDiagram
+      {...props}
+      textVoltThresh="13.5"
+      colorVoltThresh="st31"
+    />
+  )
   expect(screen.getByLabelText('text_voltthresh')).toHaveClass('st12')
+  expect(screen.getByLabelText('text_voltthresh')).not.toHaveClass('st31')
   expect(screen.getByLabelText('text_voltthresh')).toHaveTextContent('13.5')
 })
 
 test('should display amp threshold text in neutral color when not docked', async () => {
-  render(<FullWidthVehicleDiagram {...props} textAmpThresh="50" />)
-  // Threshold labels always render in neutral gray (st12), matching Dash4 behavior.
+  // Pass the alarm color (st31) to prove the component ignores it and stays neutral.
+  render(
+    <FullWidthVehicleDiagram
+      {...props}
+      textAmpThresh="50"
+      colorAmpThresh="st31"
+    />
+  )
   expect(screen.getByLabelText('text_ampthresh')).toHaveClass('st12')
+  expect(screen.getByLabelText('text_ampthresh')).not.toHaveClass('st31')
   expect(screen.getByLabelText('text_ampthresh')).toHaveTextContent('50')
 })
 

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.test.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.test.tsx
@@ -220,7 +220,7 @@ test('should hide Argos fill when no color from server (st18)', async () => {
   expect(screen.getByTestId('argos-battery fill')).toHaveClass('st18')
 })
 
-test('should display volt threshold text with colorVoltThresh class when not docked', async () => {
+test('should display volt threshold text in neutral color when not docked', async () => {
   render(
     <FullWidthVehicleDiagram
       {...props}
@@ -228,7 +228,10 @@ test('should display volt threshold text with colorVoltThresh class when not doc
       colorVoltThresh="st31"
     />
   )
-  expect(screen.getByLabelText('text_voltthresh')).toHaveClass('st31')
+  // colorVoltThresh is intentionally ignored — threshold labels always render
+  // in neutral gray (st12) regardless of alarm state, matching Dash4 behavior.
+  expect(screen.getByLabelText('text_voltthresh')).toHaveClass('st12')
+  expect(screen.getByLabelText('text_voltthresh')).not.toHaveClass('st31')
   expect(screen.getByLabelText('text_voltthresh')).toHaveTextContent('13.5')
 })
 

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.test.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.test.tsx
@@ -227,6 +227,13 @@ test('should display volt threshold text in neutral color when not docked', asyn
   expect(screen.getByLabelText('text_voltthresh')).toHaveTextContent('13.5')
 })
 
+test('should display amp threshold text in neutral color when not docked', async () => {
+  render(<FullWidthVehicleDiagram {...props} textAmpThresh="50" />)
+  // Threshold labels always render in neutral gray (st12), matching Dash4 behavior.
+  expect(screen.getByLabelText('text_ampthresh')).toHaveClass('st12')
+  expect(screen.getByLabelText('text_ampthresh')).toHaveTextContent('50')
+})
+
 test('should hide volt threshold text when docked', async () => {
   render(
     <FullWidthVehicleDiagram

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
@@ -124,9 +124,7 @@ export const FullWidthVehicleDiagram: React.FC<
   colorCameraLens,
   colorCam1,
   colorCam2,
-  colorVoltThresh,
   textVoltThresh,
-  colorAmpThresh,
   textAmpThresh,
   textBatteryDuration,
   textBatteryUnits,
@@ -291,9 +289,7 @@ export const FullWidthVehicleDiagram: React.FC<
             textAmpAgo={textAmpAgo}
             colorVolts={colorVolts}
             colorAmps={colorAmps}
-            colorVoltThresh={colorVoltThresh}
             textVoltThresh={textVoltThresh}
-            colorAmpThresh={colorAmpThresh}
             textAmpThresh={textAmpThresh}
             textBatteryDuration={textBatteryDuration}
             textBatteryUnits={textBatteryUnits}

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
@@ -29,10 +29,6 @@ import { Leak } from './VehicleAssets/Leak'
 export interface FullWidthVehicleDiagramProps extends VehicleProps {
   onBatteryClick?: BatteryProps['onClick']
   sparklineContent?: React.ReactNode
-  /** @deprecated Accepted for backwards compatibility but ignored — threshold text always renders in neutral gray. */
-  colorVoltThresh?: string
-  /** @deprecated Accepted for backwards compatibility but ignored — threshold text always renders in neutral gray. */
-  colorAmpThresh?: string
 }
 
 export const FullWidthVehicleDiagram: React.FC<

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
@@ -29,6 +29,10 @@ import { Leak } from './VehicleAssets/Leak'
 export interface FullWidthVehicleDiagramProps extends VehicleProps {
   onBatteryClick?: BatteryProps['onClick']
   sparklineContent?: React.ReactNode
+  /** @deprecated Accepted for backwards compatibility but ignored — threshold text always renders in neutral gray. */
+  colorVoltThresh?: string
+  /** @deprecated Accepted for backwards compatibility but ignored — threshold text always renders in neutral gray. */
+  colorAmpThresh?: string
 }
 
 export const FullWidthVehicleDiagram: React.FC<

--- a/packages/react-ui/src/Diagrams/Vehicle.test.tsx
+++ b/packages/react-ui/src/Diagrams/Vehicle.test.tsx
@@ -190,27 +190,22 @@ test('should hide Argos fill when no color from server (st18)', async () => {
   expect(screen.getByTestId('argos-battery fill')).toHaveClass('st18')
 })
 
-test('should display volt threshold text with colorVoltThresh class when not docked', async () => {
-  render(<Vehicle {...props} textVoltThresh="13.5" colorVoltThresh="st31" />)
-  expect(screen.getByLabelText('text_voltthresh')).toHaveClass('st31')
+test('should display volt threshold text in neutral color when not docked', async () => {
+  render(<Vehicle {...props} textVoltThresh="13.5" />)
+  // Threshold labels always render in neutral gray (st12) matching Dash4 behavior.
+  expect(screen.getByLabelText('text_voltthresh')).toHaveClass('st12')
   expect(screen.getByLabelText('text_voltthresh')).toHaveTextContent('13.5')
 })
 
 test('should hide volt threshold text when docked', async () => {
-  render(
-    <Vehicle
-      {...props}
-      status="pluggedIn"
-      textVoltThresh="13.5"
-      colorVoltThresh="st31"
-    />
-  )
+  render(<Vehicle {...props} status="pluggedIn" textVoltThresh="13.5" />)
   expect(screen.getByLabelText('text_voltthresh')).toHaveClass('st18')
 })
 
-test('should display amp threshold text with colorAmpThresh class when not docked', async () => {
-  render(<Vehicle {...props} textAmpThresh="50" colorAmpThresh="st31" />)
-  expect(screen.getByLabelText('text_ampthresh')).toHaveClass('st31')
+test('should display amp threshold text in neutral color when not docked', async () => {
+  render(<Vehicle {...props} textAmpThresh="50" />)
+  // Threshold labels always render in neutral gray (st12) matching Dash4 behavior.
+  expect(screen.getByLabelText('text_ampthresh')).toHaveClass('st12')
   expect(screen.getByLabelText('text_ampthresh')).toHaveTextContent('50')
 })
 

--- a/packages/react-ui/src/Diagrams/Vehicle.test.tsx
+++ b/packages/react-ui/src/Diagrams/Vehicle.test.tsx
@@ -191,9 +191,10 @@ test('should hide Argos fill when no color from server (st18)', async () => {
 })
 
 test('should display volt threshold text in neutral color when not docked', async () => {
-  render(<Vehicle {...props} textVoltThresh="13.5" />)
-  // Threshold labels always render in neutral gray (st12) matching Dash4 behavior.
+  // Pass the alarm color (st31) to prove the component ignores it and stays neutral.
+  render(<Vehicle {...props} textVoltThresh="13.5" colorVoltThresh="st31" />)
   expect(screen.getByLabelText('text_voltthresh')).toHaveClass('st12')
+  expect(screen.getByLabelText('text_voltthresh')).not.toHaveClass('st31')
   expect(screen.getByLabelText('text_voltthresh')).toHaveTextContent('13.5')
 })
 
@@ -203,9 +204,10 @@ test('should hide volt threshold text when docked', async () => {
 })
 
 test('should display amp threshold text in neutral color when not docked', async () => {
-  render(<Vehicle {...props} textAmpThresh="50" />)
-  // Threshold labels always render in neutral gray (st12) matching Dash4 behavior.
+  // Pass the alarm color (st31) to prove the component ignores it and stays neutral.
+  render(<Vehicle {...props} textAmpThresh="50" colorAmpThresh="st31" />)
   expect(screen.getByLabelText('text_ampthresh')).toHaveClass('st12')
+  expect(screen.getByLabelText('text_ampthresh')).not.toHaveClass('st31')
   expect(screen.getByLabelText('text_ampthresh')).toHaveTextContent('50')
 })
 

--- a/packages/react-ui/src/Diagrams/Vehicle.tsx
+++ b/packages/react-ui/src/Diagrams/Vehicle.tsx
@@ -110,9 +110,7 @@ export interface VehicleProps {
   colorCam2?: string
   textCameraAgo?: string
   textCtdStatus?: string
-  colorVoltThresh?: string
   textVoltThresh?: string
-  colorAmpThresh?: string
   textAmpThresh?: string
   textBatteryDuration?: number | string
   textBatteryUnits?: string
@@ -215,9 +213,7 @@ export const Vehicle: React.FC<VehicleProps> = ({
   colorCameraLens,
   colorCam1,
   colorCam2,
-  colorVoltThresh,
   textVoltThresh,
-  colorAmpThresh,
   textAmpThresh,
   textBatteryDuration,
   textBatteryUnits,
@@ -329,9 +325,7 @@ export const Vehicle: React.FC<VehicleProps> = ({
           textAmpAgo={textAmpAgo}
           colorVolts={colorVolts}
           colorAmps={colorAmps}
-          colorVoltThresh={colorVoltThresh}
           textVoltThresh={textVoltThresh}
-          colorAmpThresh={colorAmpThresh}
           textAmpThresh={textAmpThresh}
           textBatteryDuration={textBatteryDuration}
           textBatteryUnits={textBatteryUnits}

--- a/packages/react-ui/src/Diagrams/Vehicle.tsx
+++ b/packages/react-ui/src/Diagrams/Vehicle.tsx
@@ -110,7 +110,11 @@ export interface VehicleProps {
   colorCam2?: string
   textCameraAgo?: string
   textCtdStatus?: string
+  /** @deprecated Threshold text always renders in neutral gray — this prop is accepted but ignored. */
+  colorVoltThresh?: string
   textVoltThresh?: string
+  /** @deprecated Threshold text always renders in neutral gray — this prop is accepted but ignored. */
+  colorAmpThresh?: string
   textAmpThresh?: string
   textBatteryDuration?: number | string
   textBatteryUnits?: string

--- a/packages/react-ui/src/Diagrams/Vehicle.tsx
+++ b/packages/react-ui/src/Diagrams/Vehicle.tsx
@@ -110,10 +110,10 @@ export interface VehicleProps {
   colorCam2?: string
   textCameraAgo?: string
   textCtdStatus?: string
-  /** @deprecated Threshold text always renders in neutral gray — this prop is accepted but ignored. */
+  /** @deprecated Accepted for API compatibility but ignored. When shown (not docked), threshold text always uses neutral gray (st12) regardless of this value. */
   colorVoltThresh?: string
   textVoltThresh?: string
-  /** @deprecated Threshold text always renders in neutral gray — this prop is accepted but ignored. */
+  /** @deprecated Accepted for API compatibility but ignored. When shown (not docked), threshold text always uses neutral gray (st12) regardless of this value. */
   colorAmpThresh?: string
   textAmpThresh?: string
   textBatteryDuration?: number | string

--- a/packages/react-ui/src/Diagrams/VehicleAssets/Batteries.tsx
+++ b/packages/react-ui/src/Diagrams/VehicleAssets/Batteries.tsx
@@ -179,7 +179,7 @@ export const Batteries: React.FC<BatteryProps> = ({
         <text
           aria-label="text_voltthresh"
           transform="matrix(1 0 0 1 293.5 258.0)"
-          className={clsx('st9', isDocked ? 'st18' : colorVoltThresh ?? 'st12')}
+          className={clsx('st9', isDocked ? 'st18' : 'st12')}
           style={{ fontSize: '7px' }}
         >
           {textVoltThresh}
@@ -198,7 +198,7 @@ export const Batteries: React.FC<BatteryProps> = ({
         <text
           aria-label="text_ampthresh"
           transform="matrix(1 0 0 1 295.5 270.0)"
-          className={clsx('st9', isDocked ? 'st18' : colorAmpThresh ?? 'st12')}
+          className={clsx('st9', isDocked ? 'st18' : 'st12')}
           style={{ fontSize: '7px' }}
         >
           {textAmpThresh}

--- a/packages/react-ui/src/Diagrams/VehicleAssets/Batteries.tsx
+++ b/packages/react-ui/src/Diagrams/VehicleAssets/Batteries.tsx
@@ -16,9 +16,7 @@ export interface BatteryProps {
   textAmpAgo?: VehicleProps['textAmpAgo']
   colorVolts?: VehicleProps['colorVolts']
   colorAmps?: VehicleProps['colorAmps']
-  colorVoltThresh?: VehicleProps['colorVoltThresh']
   textVoltThresh?: VehicleProps['textVoltThresh']
-  colorAmpThresh?: VehicleProps['colorAmpThresh']
   textAmpThresh?: VehicleProps['textAmpThresh']
   textBatteryDuration?: VehicleProps['textBatteryDuration']
   textBatteryUnits?: VehicleProps['textBatteryUnits']
@@ -43,9 +41,7 @@ export const Batteries: React.FC<BatteryProps> = ({
   textAmpAgo,
   colorVolts,
   colorAmps,
-  colorVoltThresh,
   textVoltThresh,
-  colorAmpThresh,
   textAmpThresh,
   textBatteryDuration,
   textBatteryUnits,


### PR DESCRIPTION
## Summary
`colorVoltThresh` and `colorAmpThresh` fields returned by TethysDash were being applied as CSS class names to the voltage and amp threshold text labels (e.g. "13.7" and "50") in the Batteries widget. When TethysDash returns `st31` (red, `#B4372D`) for these fields, the threshold labels rendered in red — inconsistent with Dash4 which always shows them in neutral gray.

Fixed by hardcoding `st12` (dark gray) for both threshold text elements, matching Dash4 behavior.

## Test plan
- [ ] Open Opah vehicle widget — threshold labels (13.7, 50) should appear in neutral gray, not red
- [ ] Open Brizo vehicle widget — threshold labels should also appear in neutral gray
- [ ] Verify the colored background rectangles (orange/green/yellow) still reflect the correct `colorVolts`/`colorAmps` state