### PR TITLE
feat: unify vehicle widget + sparkline scaling and add Okeanids link button

### DIFF
--- a/apps/lrauv-dash2/components/VehicleDiagram.tsx
+++ b/apps/lrauv-dash2/components/VehicleDiagram.tsx
@@ -108,7 +108,8 @@ const VehicleDiagram: React.FC<{
       />
     ) : undefined
 
-  const okeanidsUrl = `https://okeanids.mbari.org/widget/auv_${name}.svg?dummy=${Date.now()}`
+  // No cache-busting timestamp — opening in a new tab always fetches fresh from the server.
+  const okeanidsUrl = `https://okeanids.mbari.org/widget/auv_${name}.svg`
 
   const sharedDiagramProps: FullWidthVehicleDiagramProps = {
     textAmpAgo: vehicle?.text_ampago,
@@ -218,7 +219,7 @@ const VehicleDiagram: React.FC<{
     colorOt: vehicle?.color_ot,
     onBatteryClick: handleBatteryClick,
     sparklineContent,
-    actionButton: (
+    actionButton: isDocked ? undefined : (
       <a
         href={okeanidsUrl}
         target="_blank"

--- a/apps/lrauv-dash2/components/VehicleDiagram.tsx
+++ b/apps/lrauv-dash2/components/VehicleDiagram.tsx
@@ -112,17 +112,17 @@ const VehicleDiagram: React.FC<{
     ) : undefined
 
   // Prefer the URL pattern from siteConfig so staging/dev deployments work without
-  // hardcoding the production host. Fall back to the known production URL.
+  // hardcoding the production host. Use a case-insensitive regex so the pattern
+  // works regardless of server config casing (<vehicleName> or <VehicleName>).
+  // Fall back to the known production URL.
   const OKEANIDS_FALLBACK = `https://okeanids.mbari.org/widget/auv_${encodeURIComponent(
     name
   )}.svg`
-  const okeanidsUrl = siteConfig?.appConfig.external.statusWidgets
-    .lrauvStatusWidgetUrlPattern
-    ? siteConfig.appConfig.external.statusWidgets.lrauvStatusWidgetUrlPattern.replace(
-        '<vehicleName>',
-        encodeURIComponent(name)
-      )
-    : OKEANIDS_FALLBACK
+  const okeanidsUrl =
+    siteConfig?.appConfig?.external?.statusWidgets?.lrauvStatusWidgetUrlPattern?.replace(
+      /<vehicleName>/gi,
+      encodeURIComponent(name)
+    ) ?? OKEANIDS_FALLBACK
 
   const sharedDiagramProps: FullWidthVehicleDiagramProps = {
     textAmpAgo: vehicle?.text_ampago,

--- a/apps/lrauv-dash2/components/VehicleDiagram.tsx
+++ b/apps/lrauv-dash2/components/VehicleDiagram.tsx
@@ -11,7 +11,10 @@ import {
   FullWidthVehicleDiagramProps,
 } from '@mbari/react-ui'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons'
+import {
+  faTriangleExclamation,
+  faArrowUpRightFromSquare,
+} from '@fortawesome/free-solid-svg-icons'
 import clsx from 'clsx'
 import { DateTime } from 'luxon'
 import { decodeHtmlEntities, formatCompactDuration } from '@mbari/utils'
@@ -62,13 +65,8 @@ const VehicleDiagram: React.FC<{
       ? undefined
       : (vehicleInfo as GetVehicleInfoResponse)
 
-  // Derive mission text once for both the isDocked check and the status prop.
   const missionText = vehicle?.text_mission ?? ''
 
-  // The sparkline is only shown for on-mission vehicles. Gate on !!vehicle so
-  // we don't start polling before vehicleInfo has loaded, and suppress polling
-  // for both plugged-in and recovered vehicles — FullWidthVehicleDiagram never
-  // renders the sparkline overlay in either of those states.
   const isDocked =
     missionText.indexOf('PLUGGED') >= 0 || missionText.indexOf('RECOVERED') >= 0
   const { data: sparklineData } = useDepthSparkline(
@@ -96,6 +94,147 @@ const VehicleDiagram: React.FC<{
 
   const formattedNextComm = nextCommsText ?? vehicle?.text_nextcomm
 
+  const sparklineContent =
+    sparklineData && sparklineData.depthTimes.length > 0 ? (
+      <DepthSparkline
+        depthTimes={sparklineData.depthTimes}
+        depthValues={sparklineData.depthValues}
+        celTimes={sparklineData.celTimes}
+        satTimes={sparklineData.satTimes}
+        gpsTimes={sparklineData.gpsTimes}
+        argoTimes={sparklineData.argoTimes}
+        padded={sparklineData.padded}
+        responsive
+      />
+    ) : undefined
+
+  const okeanidsUrl = `https://okeanids.mbari.org/widget/auv_${name}.svg?dummy=${Date.now()}`
+
+  const sharedDiagramProps: FullWidthVehicleDiagramProps = {
+    textAmpAgo: vehicle?.text_ampago,
+    textVehicle: vehicle?.text_vehicle ?? name,
+    textCell: formattedCellTime,
+    colorCell: vehicle?.color_cell,
+    colorDirtbox: vehicle?.color_dirtbox,
+    textSpeed: vehicle?.text_speed,
+    textDvlStatus: vehicle?.text_dvlstatus,
+    textStationDist: vehicle?.text_stationdist,
+    textCommAgo: formattedSatAgo,
+    textNextComm: formattedNextComm,
+    textCriticalError: vehicle?.text_criticalerror,
+    textTimeout: vehicle?.text_timeout,
+    colorSatComm: vehicle?.color_satcomm,
+    colorNextComm: vehicle?.color_satcomm,
+    colorSmallCable: vehicle?.color_smallcable,
+    textNote: vehicle?.text_note,
+    textArriveStation: vehicle?.text_arrivestation,
+    colorMissionAgo: vehicle?.color_missionago,
+    textGps: vehicle?.text_gps,
+    colorGps: vehicle?.color_gps,
+    colorSw: vehicle?.color_sw,
+    textCurrentDist: vehicle?.text_currentdist,
+    textDroptime: vehicle?.text_droptime,
+    colorDrop: vehicle?.color_drop,
+    colorScheduled: vehicle?.color_scheduled,
+    colorHw: vehicle?.color_hw,
+    colorArrow: vehicle?.color_arrow,
+    colorGf: vehicle?.color_gf,
+    colorLowGf: vehicle?.color_lowgf,
+    colorHighGf: vehicle?.color_highgf,
+    colorMissionText: vehicle?.color_missiontext,
+    colorLogAgo: vehicle?.color_logago,
+    colorSatCommsText: vehicle?.color_satcommstext,
+    colorNextCommsText: vehicle?.color_nextcommstext,
+    colorTimeoutText: vehicle?.color_timeouttext,
+    dockBuoy: vehicle?.dock_buoy,
+    dockEye: vehicle?.dock_eye,
+    dockLine: vehicle?.dock_line,
+    dockTri: vehicle?.dock_tri,
+    textGf: vehicle?.text_gf,
+    colorFlow: vehicle?.color_flow,
+    colorWavecolor: vehicle?.color_wavecolor ?? 'st0',
+    textAmps: vehicle?.text_amps,
+    colorAmps: vehicle?.color_amps,
+    colorDvl: vehicle?.color_dvl,
+    textGpsAgo: vehicle?.text_gpsago,
+    colorArgo: vehicle?.color_argo,
+    textCellAgo: formattedCellAgo,
+    textNoteTime: vehicle?.text_notetime,
+    textArrow: vehicle?.text_arrow,
+    colorBat1: vehicle?.color_bat1,
+    colorBat2: vehicle?.color_bat2,
+    colorBat3: vehicle?.color_bat3,
+    colorBat4: vehicle?.color_bat4,
+    colorBat5: vehicle?.color_bat5,
+    colorBat6: vehicle?.color_bat6,
+    colorBat7: vehicle?.color_bat7,
+    colorBat8: vehicle?.color_bat8,
+    colorCart: vehicle?.color_cart,
+    colorCartCircle: vehicle?.color_cartcircle,
+    colorThrust: vehicle?.color_thrust,
+    textSat: formattedSatTime,
+    textLogTime: vehicle?.text_logtime,
+    textMission: vehicle?.text_mission
+      ? decodeHtmlEntities(vehicle.text_mission)
+      : '',
+    textReckonDistance: vehicle?.text_reckondistance,
+    textCriticalTime: vehicle?.text_criticaltime,
+    textGfTime: vehicle?.text_gftime,
+    textThrustTime: vehicle?.text_thrusttime,
+    textLogAgo: vehicle?.text_logago,
+    colorBigCable: vehicle?.color_bigcable,
+    textScheduled: vehicle?.text_scheduled,
+    textLastUpdate: vehicle?.text_lastupdate,
+    colorMissionDefault: vehicle?.color_missiondefault,
+    textVolts: vehicle?.text_volts,
+    colorVolts: vehicle?.color_volts,
+    status:
+      missionText.indexOf('PLUGGED') >= 0
+        ? 'pluggedIn'
+        : missionText.indexOf('RECOVERED') >= 0
+        ? 'recovered'
+        : 'onMission',
+    colorLeak: vehicle?.color_leak,
+    textLeakAgo: vehicle?.text_leakago,
+    textLeak: vehicle?.text_leak,
+    colorCtd: vehicle?.color_ctd,
+    colorCameraBody: vehicle?.color_camerabody,
+    colorCameraLens: vehicle?.color_cameralens,
+    colorCam1: vehicle?.color_cam1,
+    colorCam2: vehicle?.color_cam2,
+    textCameraAgo: vehicle?.text_cameraago,
+    colorVoltThresh: vehicle?.color_voltthresh,
+    textVoltThresh: vehicle?.text_voltthresh,
+    colorAmpThresh: vehicle?.color_ampthresh,
+    textAmpThresh: vehicle?.text_ampthresh,
+    textBatteryDuration: vehicle?.text_batteryduration,
+    textBatteryUnits: vehicle?.text_batteryunits,
+    textCurrent: vehicle?.text_current,
+    textNeedsComms: vehicle?.text_needcomms,
+    textMissionAgo: vehicle?.text_missionago,
+    textVersion: vehicle?.text_version,
+    svgCurrent: vehicle?.svg_current,
+    colorDuration: vehicle?.color_duration,
+    colorOt: vehicle?.color_ot,
+    onBatteryClick: handleBatteryClick,
+    sparklineContent,
+    actionButton: (
+      <a
+        href={okeanidsUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Open in Okeanids"
+        aria-label="Open in Okeanids"
+        className="flex h-9 w-9 items-center justify-center rounded bg-teal-500 text-white shadow-md transition-colors hover:bg-teal-400"
+      >
+        <FontAwesomeIcon
+          icon={faArrowUpRightFromSquare}
+          className="text-base"
+        />
+      </a>
+    ),
+  }
+
   return (
     <div
       className={clsx(className, 'relative flex overflow-hidden')}
@@ -109,129 +248,10 @@ const VehicleDiagram: React.FC<{
           </div>
         </div>
       ) : null}
+
       <FullWidthVehicleDiagram
-        className={clsx(className, !vehicle && 'opacity-40', 'min-h-[200px]')}
-        textAmpAgo={vehicle?.text_ampago}
-        textVehicle={vehicle?.text_vehicle ?? name}
-        textCell={formattedCellTime}
-        colorCell={vehicle?.color_cell}
-        colorDirtbox={vehicle?.color_dirtbox}
-        textSpeed={vehicle?.text_speed}
-        textDvlStatus={vehicle?.text_dvlstatus}
-        textStationDist={vehicle?.text_stationdist}
-        textCommAgo={formattedSatAgo}
-        textNextComm={formattedNextComm}
-        textCriticalError={vehicle?.text_criticalerror}
-        textTimeout={vehicle?.text_timeout}
-        colorSatComm={vehicle?.color_satcomm}
-        colorNextComm={vehicle?.color_satcomm}
-        colorSmallCable={vehicle?.color_smallcable}
-        textNote={vehicle?.text_note}
-        textArriveStation={vehicle?.text_arrivestation}
-        colorMissionAgo={vehicle?.color_missionago}
-        textGps={vehicle?.text_gps}
-        colorGps={vehicle?.color_gps}
-        colorSw={vehicle?.color_sw}
-        textCurrentDist={vehicle?.text_currentdist}
-        textDroptime={vehicle?.text_droptime}
-        colorDrop={vehicle?.color_drop}
-        colorScheduled={vehicle?.color_scheduled}
-        colorHw={vehicle?.color_hw}
-        colorArrow={vehicle?.color_arrow}
-        colorGf={vehicle?.color_gf}
-        colorLowGf={vehicle?.color_lowgf}
-        colorHighGf={vehicle?.color_highgf}
-        colorMissionText={vehicle?.color_missiontext}
-        colorLogAgo={vehicle?.color_logago}
-        colorSatCommsText={vehicle?.color_satcommstext}
-        colorNextCommsText={vehicle?.color_nextcommstext}
-        colorTimeoutText={vehicle?.color_timeouttext}
-        dockBuoy={vehicle?.dock_buoy}
-        dockEye={vehicle?.dock_eye}
-        dockLine={vehicle?.dock_line}
-        dockTri={vehicle?.dock_tri}
-        textGf={vehicle?.text_gf}
-        colorFlow={vehicle?.color_flow}
-        colorWavecolor={vehicle?.color_wavecolor ?? 'st0'}
-        textAmps={vehicle?.text_amps}
-        colorAmps={vehicle?.color_amps}
-        colorDvl={vehicle?.color_dvl}
-        textGpsAgo={vehicle?.text_gpsago}
-        colorArgo={vehicle?.color_argo}
-        textCellAgo={formattedCellAgo}
-        textNoteTime={vehicle?.text_notetime}
-        textArrow={vehicle?.text_arrow}
-        colorBat1={vehicle?.color_bat1}
-        colorBat2={vehicle?.color_bat2}
-        colorBat3={vehicle?.color_bat3}
-        colorBat4={vehicle?.color_bat4}
-        colorBat5={vehicle?.color_bat5}
-        colorBat6={vehicle?.color_bat6}
-        colorBat7={vehicle?.color_bat7}
-        colorBat8={vehicle?.color_bat8}
-        colorCart={vehicle?.color_cart}
-        colorCartCircle={vehicle?.color_cartcircle}
-        colorThrust={vehicle?.color_thrust}
-        textSat={formattedSatTime}
-        textLogTime={vehicle?.text_logtime}
-        textMission={
-          vehicle?.text_mission ? decodeHtmlEntities(vehicle.text_mission) : ''
-        }
-        textReckonDistance={vehicle?.text_reckondistance}
-        textCriticalTime={vehicle?.text_criticaltime}
-        textGfTime={vehicle?.text_gftime}
-        textThrustTime={vehicle?.text_thrusttime}
-        textLogAgo={vehicle?.text_logago}
-        colorBigCable={vehicle?.color_bigcable}
-        textScheduled={vehicle?.text_scheduled}
-        textLastUpdate={vehicle?.text_lastupdate}
-        colorMissionDefault={vehicle?.color_missiondefault}
-        textVolts={vehicle?.text_volts}
-        colorVolts={vehicle?.color_volts}
-        status={
-          missionText.indexOf('PLUGGED') >= 0
-            ? 'pluggedIn'
-            : missionText.indexOf('RECOVERED') >= 0
-            ? 'recovered'
-            : 'onMission'
-        }
-        colorLeak={vehicle?.color_leak}
-        textLeakAgo={vehicle?.text_leakago}
-        textLeak={vehicle?.text_leak}
-        colorCtd={vehicle?.color_ctd}
-        colorCameraBody={vehicle?.color_camerabody}
-        colorCameraLens={vehicle?.color_cameralens}
-        colorCam1={vehicle?.color_cam1}
-        colorCam2={vehicle?.color_cam2}
-        textCameraAgo={vehicle?.text_cameraago}
-        colorVoltThresh={vehicle?.color_voltthresh}
-        textVoltThresh={vehicle?.text_voltthresh}
-        colorAmpThresh={vehicle?.color_ampthresh}
-        textAmpThresh={vehicle?.text_ampthresh}
-        textBatteryDuration={vehicle?.text_batteryduration}
-        textBatteryUnits={vehicle?.text_batteryunits}
-        textCurrent={vehicle?.text_current}
-        textNeedsComms={vehicle?.text_needcomms}
-        textMissionAgo={vehicle?.text_missionago}
-        textVersion={vehicle?.text_version}
-        svgCurrent={vehicle?.svg_current}
-        colorDuration={vehicle?.color_duration}
-        colorOt={vehicle?.color_ot}
-        onBatteryClick={handleBatteryClick}
-        sparklineContent={
-          sparklineData && sparklineData.depthTimes.length > 0 ? (
-            <DepthSparkline
-              depthTimes={sparklineData.depthTimes}
-              depthValues={sparklineData.depthValues}
-              celTimes={sparklineData.celTimes}
-              satTimes={sparklineData.satTimes}
-              gpsTimes={sparklineData.gpsTimes}
-              argoTimes={sparklineData.argoTimes}
-              padded={sparklineData.padded}
-              responsive
-            />
-          ) : undefined
-        }
+        {...sharedDiagramProps}
+        className={clsx(!vehicle && 'opacity-40', 'min-h-[200px]')}
       />
     </div>
   )

--- a/apps/lrauv-dash2/components/VehicleDiagram.tsx
+++ b/apps/lrauv-dash2/components/VehicleDiagram.tsx
@@ -232,21 +232,22 @@ const VehicleDiagram: React.FC<{
     colorOt: vehicle?.color_ot,
     onBatteryClick: handleBatteryClick,
     sparklineContent,
-    actionButton: isDocked ? undefined : (
-      <a
-        href={okeanidsUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        title="Open in Okeanids"
-        aria-label="Open in Okeanids"
-        className="flex h-9 w-9 items-center justify-center rounded bg-teal-500 text-white shadow-md transition-colors hover:bg-teal-400"
-      >
-        <FontAwesomeIcon
-          icon={faArrowUpRightFromSquare}
-          className="text-base"
-        />
-      </a>
-    ),
+    actionButton:
+      !vehicle || isDocked ? undefined : (
+        <a
+          href={okeanidsUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="Open in Okeanids"
+          aria-label="Open in Okeanids"
+          className="flex h-9 w-9 items-center justify-center rounded bg-teal-500 text-white shadow-md transition-colors hover:bg-teal-400"
+        >
+          <FontAwesomeIcon
+            icon={faArrowUpRightFromSquare}
+            className="text-base"
+          />
+        </a>
+      ),
   }
 
   return (

--- a/apps/lrauv-dash2/components/VehicleDiagram.tsx
+++ b/apps/lrauv-dash2/components/VehicleDiagram.tsx
@@ -18,6 +18,7 @@ import {
 import clsx from 'clsx'
 import { DateTime } from 'luxon'
 import { decodeHtmlEntities, formatCompactDuration } from '@mbari/utils'
+import { useTethysApiContext } from 'api-client'
 
 const DepthSparkline = dynamic(
   () =>
@@ -94,6 +95,8 @@ const VehicleDiagram: React.FC<{
 
   const formattedNextComm = nextCommsText ?? vehicle?.text_nextcomm
 
+  const { siteConfig } = useTethysApiContext()
+
   const sparklineContent =
     sparklineData && sparklineData.depthTimes.length > 0 ? (
       <DepthSparkline
@@ -108,8 +111,18 @@ const VehicleDiagram: React.FC<{
       />
     ) : undefined
 
-  // No cache-busting timestamp — opening in a new tab always fetches fresh from the server.
-  const okeanidsUrl = `https://okeanids.mbari.org/widget/auv_${name}.svg`
+  // Prefer the URL pattern from siteConfig so staging/dev deployments work without
+  // hardcoding the production host. Fall back to the known production URL.
+  const OKEANIDS_FALLBACK = `https://okeanids.mbari.org/widget/auv_${encodeURIComponent(
+    name
+  )}.svg`
+  const okeanidsUrl = siteConfig?.appConfig.external.statusWidgets
+    .lrauvStatusWidgetUrlPattern
+    ? siteConfig.appConfig.external.statusWidgets.lrauvStatusWidgetUrlPattern.replace(
+        '<vehicleName>',
+        encodeURIComponent(name)
+      )
+    : OKEANIDS_FALLBACK
 
   const sharedDiagramProps: FullWidthVehicleDiagramProps = {
     textAmpAgo: vehicle?.text_ampago,

--- a/packages/react-ui/src/Charts/DepthSparkline.tsx
+++ b/packages/react-ui/src/Charts/DepthSparkline.tsx
@@ -99,7 +99,7 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
 
   const xdiv = windowMinutes / w // minutes per pixel
 
-  const svgWidth = w + 66 // extra right margin for single-row legend + time/ago
+  const svgWidth = w + 68 // right margin: comms legend row + combined time·dot·ago row
 
   // Rows of comms ticks sit above the depth box
   const tickRowHeight = 1.5
@@ -411,7 +411,7 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
         {depthScale}m
       </text>
 
-      {/* Last data time with freshness dot inline, then age — just below the legend */}
+      {/* Last data: time · freshness dot · age — all on one line */}
       <text x={x0 + w + 2} y={y0 + 10} fontSize={6} fill="#374151">
         {timeLabel}
       </text>
@@ -421,8 +421,8 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
         r={2}
         fill={isPadded && isStale ? '#f97316' : '#22c55e'}
       />
-      <text x={x0 + w + 2} y={y0 + 16} fontSize={6} fill="#6b7280">
-        {agoLabel}
+      <text x={x0 + w + 27} y={y0 + 10} fontSize={5} fill="#6b7280">
+        ({agoLabel})
       </text>
 
       {/* Border rendered last so it sits on top of grid lines and polygons */}

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.test.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.test.tsx
@@ -4,6 +4,13 @@ import '@testing-library/jest-dom'
 import { VehicleProps } from './Vehicle'
 import { FullWidthVehicleDiagram } from './FullWidthVehicleDiagram'
 
+// JSDOM reports zero layout dimensions; return a real size so guards
+// that rely on cW > 0 && cH > 0 don't suppress content in tests.
+jest.mock('@mbari/utils', () => ({
+  ...jest.requireActual('@mbari/utils'),
+  useResizeObserver: () => ({ size: { width: 800, height: 300 } }),
+}))
+
 const props: VehicleProps = {
   textVehicle: 'BRIZO',
   status: 'onMission',
@@ -426,4 +433,49 @@ test('should display next comm text with colorNextCommsText class', async () => 
     />
   )
   expect(screen.queryByLabelText('next comm')).toHaveClass('st31')
+})
+
+test('should render actionButton when provided and vehicle is on mission', async () => {
+  render(
+    <FullWidthVehicleDiagram
+      {...props}
+      status="onMission"
+      actionButton={
+        <a href="https://example.com" aria-label="test action">
+          link
+        </a>
+      }
+    />
+  )
+  expect(screen.queryByLabelText('test action')).toBeInTheDocument()
+})
+
+test('should not render actionButton when vehicle is pluggedIn', async () => {
+  render(
+    <FullWidthVehicleDiagram
+      {...props}
+      status="pluggedIn"
+      actionButton={
+        <a href="https://example.com" aria-label="test action">
+          link
+        </a>
+      }
+    />
+  )
+  expect(screen.queryByLabelText('test action')).not.toBeInTheDocument()
+})
+
+test('should not render actionButton when vehicle is recovered', async () => {
+  render(
+    <FullWidthVehicleDiagram
+      {...props}
+      status="recovered"
+      actionButton={
+        <a href="https://example.com" aria-label="test action">
+          link
+        </a>
+      }
+    />
+  )
+  expect(screen.queryByLabelText('test action')).not.toBeInTheDocument()
 })

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
@@ -149,8 +149,11 @@ export const FullWidthVehicleDiagram: React.FC<
   // Sparkline base dimensions — correct size when the vehicle is height-bound (wide container)
   const SPARKLINE_BASE_W = 503 // 529 × 0.95
   const SPARKLINE_BASE_H = 126 // 133 × 0.95
-  // Vertical offset above the container top at full scale. Scaled by effectiveScale
-  // so the sparkline tracks the vehicle body as the container narrows.
+  // Vertical offset at full scale. Negative = the sparkline div extends above the
+  // container's overflow-hidden boundary, intentionally clipping the comms tick rows
+  // (supplementary decoration). The depth chart (primary content) starts at y=0 inside
+  // the SVG and remains fully visible. Scaled by effectiveScale so the overlay tracks
+  // the vehicle body as the container narrows.
   const SPARKLINE_BASE_Y = -12
 
   // Vehicle SVG viewBox dimensions

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
@@ -203,8 +203,12 @@ export const FullWidthVehicleDiagram: React.FC<
   const sparklineW = Math.round(SPARKLINE_BASE_W * effectiveScale)
   const sparklineH = Math.round(SPARKLINE_BASE_H * effectiveScale)
 
+  // Guard on both dimensions: ResizeObserver can transiently report cW=0 while
+  // cH is already non-zero, which would produce a large negative left offset.
   const sparklinePosLeft =
-    cH > 0 ? Math.round(vehicleOffsetLeft + sparklineFrac * vehicleRenderW) : 0
+    cW > 0 && cH > 0
+      ? Math.round(vehicleOffsetLeft + sparklineFrac * vehicleRenderW)
+      : 0
 
   // Button position: same SVG-coordinate transform as the vehicle, so it
   // moves and scales in lockstep with the vehicle body and sparkline.
@@ -522,8 +526,8 @@ export const FullWidthVehicleDiagram: React.FC<
       )}
 
       {/* Action button — anchored in vehicle SVG coordinates, scales with vehicle.
-          Hidden when docked to match sparkline behaviour. */}
-      {!isDocked && actionButton && vehicleRenderW > 0 && (
+          Hidden when docked or before both container dimensions are known. */}
+      {!isDocked && actionButton && cW > 0 && cH > 0 && vehicleRenderW > 0 && (
         <div className="absolute z-30" style={{ left: btnLeft, top: btnTop }}>
           {actionButton}
         </div>

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useRef, useState } from 'react'
 import clsx from 'clsx'
 import { DropWeightIndicator } from './VehicleAssets/DropWeightIndicator'
 import { DvlIndicator } from './VehicleAssets/DvlIndicator'
@@ -139,14 +139,29 @@ export const FullWidthVehicleDiagram: React.FC<
   const containerRef = useRef<HTMLDivElement | null>(null)
   const { size: containerSize } = useResizeObserver({ element: containerRef })
 
+  // Drag state for the sparkline overlay. dragDelta accumulates pixel offsets
+  // from the computed position so the user can fine-tune placement visually.
+  // On mouseup the SVG anchor x is logged to the console so the constant can
+  // be updated permanently.
+  const [dragDelta, setDragDelta] = useState({ x: 0, y: 0 })
+  const dragOrigin = useRef<{
+    mouseX: number
+    mouseY: number
+    deltaX: number
+    deltaY: number
+  } | null>(null)
+
   const isDocked = status === 'pluggedIn' || status === 'recovered'
 
   // px to push vehicle + waves down, creating white space at top
   const VEHICLE_TOP_OFFSET = 20
 
   // Sparkline base dimensions — correct size when the vehicle is height-bound (wide container)
-  const SPARKLINE_BASE_W = 384 // 480 × 0.8
-  const SPARKLINE_BASE_H = 96 // 120 × 0.8
+  const SPARKLINE_BASE_W = 503 // 529 × 0.95
+  const SPARKLINE_BASE_H = 126 // 133 × 0.95
+  // Vertical offset from letterboxTop in px — i.e. distance above the vehicle body's
+  // top edge. Negative = above. Calibrated by dragging; logged to console on drop.
+  const SPARKLINE_BASE_Y = -12
 
   // Vehicle SVG viewBox dimensions
   const VB_W = 534
@@ -155,19 +170,100 @@ export const FullWidthVehicleDiagram: React.FC<
   const cW = containerSize?.width ?? 0
   const cH = containerSize?.height ?? 0
 
-  // normalizedVehicleScale = 1 when the container is wide enough that the vehicle is
-  // height-bound (no horizontal squeeze). Drops below 1 only when the container narrows
-  // enough that the vehicle SVG itself starts to shrink — the sparkline follows exactly.
-  const normalizedVehicleScale =
-    cW > 0 && cH > 0 ? Math.min(1, (cW * VB_H) / (VB_W * cH)) : 1
+  // --- Unified scaling: vehicle + sparkline shrink together ---
+  //
+  // The sparkline anchor (SPARKLINE_SVG_ANC_X = 53) is LEFT of the viewBox
+  // origin (VB_MIN_X = 120), so the sparkline occupies the horizontal letterbox.
+  // The letterbox only exists while the vehicle is height-bound. As the container
+  // narrows the letterbox shrinks and the sparkline hits the left edge ~250 px
+  // BEFORE the vehicle's own aspect-ratio constraint would start scaling.
+  //
+  // We derive effectiveScale from the sparkline-edge constraint so both items
+  // start shrinking at the same moment. The vehicle SVG is then given explicit
+  // pixel dimensions (not h-full w-full) so it truly follows effectiveScale.
+  //
+  // At scale s (vehicle rendered at s·cH·vehicleAR, horizontally centred):
+  //   sparklinePosLeft = (cW − s·cH·AR)/2  +  sparklineFrac·s·cH·AR
+  // Setting sparklinePosLeft = SPARKLINE_MARGIN and solving:
+  //   s = (cW − 2·MARGIN) / ((1 − 2·sparklineFrac) · cH · AR)
+  const VB_MIN_X = 120
+  const SPARKLINE_SVG_ANC_X = 53 // calibrated by dragging; update via console log
+  const vehicleAR = VB_W / VB_H // ≈ 3.034
+  const sparklineFrac = (SPARKLINE_SVG_ANC_X - VB_MIN_X) / VB_W // ≈ −0.1254
+  const SPARKLINE_MARGIN = 4 // min px of clear space at left of sparkline
 
-  const sparklineW = Math.round(SPARKLINE_BASE_W * normalizedVehicleScale)
-  const sparklineH = Math.round(SPARKLINE_BASE_H * normalizedVehicleScale)
+  const sparklineDrivenScale =
+    cH > 0 && cW > 0
+      ? (cW - 2 * SPARKLINE_MARGIN) / ((1 - 2 * sparklineFrac) * cH * vehicleAR)
+      : 1
+  const effectiveScale = Math.min(1, Math.max(0.1, sparklineDrivenScale))
 
-  // Position locked at { x: 306, y: 0 } — fine-tuned by dragging, then fixed.
-  // Note: only sparklineW/sparklineH scale with normalizedVehicleScale when the
-  // container narrows; the overlay position itself does not scale or reflow.
-  const sparklinePos = { x: 306, y: 0 }
+  // Vehicle explicit render dimensions — these replace h-full w-full on the SVG
+  const vehicleRenderW = Math.round(effectiveScale * cH * vehicleAR)
+  const vehicleRenderH = Math.round(effectiveScale * cH)
+  const vehicleOffsetLeft = cW > 0 ? Math.round((cW - vehicleRenderW) / 2) : 0
+
+  // Sparkline size and position both driven by effectiveScale
+  const sparklineW = Math.round(SPARKLINE_BASE_W * effectiveScale)
+  const sparklineH = Math.round(SPARKLINE_BASE_H * effectiveScale)
+
+  const sparklinePosLeft =
+    cH > 0 ? Math.round(vehicleOffsetLeft + sparklineFrac * vehicleRenderW) : 0
+
+  // Vehicle is pinned to top=0 + translateY(VEHICLE_TOP_OFFSET) — no vertical
+  // letterbox drift — so SPARKLINE_BASE_Y is a fixed offset from the container top.
+  const sparklinePos = {
+    x: sparklinePosLeft + dragDelta.x,
+    y: SPARKLINE_BASE_Y + dragDelta.y,
+  }
+
+  const handleSparklineMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault()
+    dragOrigin.current = {
+      mouseX: e.clientX,
+      mouseY: e.clientY,
+      deltaX: dragDelta.x,
+      deltaY: dragDelta.y,
+    }
+
+    const onMove = (ev: MouseEvent) => {
+      if (!dragOrigin.current) return
+      setDragDelta({
+        x: dragOrigin.current.deltaX + ev.clientX - dragOrigin.current.mouseX,
+        y: dragOrigin.current.deltaY + ev.clientY - dragOrigin.current.mouseY,
+      })
+    }
+
+    const onUp = (ev: MouseEvent) => {
+      if (!dragOrigin.current) return
+      const finalDomX =
+        sparklinePosLeft +
+        dragOrigin.current.deltaX +
+        ev.clientX -
+        dragOrigin.current.mouseX
+      const finalDomY =
+        SPARKLINE_BASE_Y +
+        dragOrigin.current.deltaY +
+        ev.clientY -
+        dragOrigin.current.mouseY
+      const finalSvgX =
+        vehicleRenderW > 0
+          ? VB_MIN_X + ((finalDomX - vehicleOffsetLeft) / vehicleRenderW) * VB_W
+          : SPARKLINE_SVG_ANC_X
+      // eslint-disable-next-line no-console
+      console.log(
+        `[DepthSparkline] → SPARKLINE_SVG_ANC_X = ${Math.round(
+          finalSvgX
+        )},  SPARKLINE_BASE_Y = ${Math.round(finalDomY)}`
+      )
+      dragOrigin.current = null
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+  }
 
   const containerH = containerSize?.height ?? 0
   const containerW = containerSize?.width ?? 0
@@ -221,7 +317,8 @@ export const FullWidthVehicleDiagram: React.FC<
         )}
       </svg>
 
-      {/* Vehicle diagram: scales to fill container while preserving aspect ratio */}
+      {/* Vehicle diagram: explicit pixel dimensions from effectiveScale so it
+          shrinks in lockstep with the sparkline when the container narrows */}
       <svg
         xmlns="http://www.w3.org/2000/svg"
         xmlnsXlink="http://www.w3.org/1999/xlink"
@@ -232,8 +329,14 @@ export const FullWidthVehicleDiagram: React.FC<
         viewBox="120 155 534 176"
         preserveAspectRatio="xMidYMid meet"
         xmlSpace="preserve"
-        className="absolute inset-0 z-10 h-full w-full"
-        style={{ transform: `translateY(${VEHICLE_TOP_OFFSET}px)` }}
+        className="absolute z-10"
+        style={{
+          width: vehicleRenderW,
+          height: vehicleRenderH,
+          left: vehicleOffsetLeft,
+          top: 0,
+          transform: `translateY(${VEHICLE_TOP_OFFSET}px)`,
+        }}
       >
         <g>
           <ChargingCable
@@ -445,16 +548,17 @@ export const FullWidthVehicleDiagram: React.FC<
         </g>
       </svg>
 
-      {/* Sparkline overlay — position locked at { x: 306, y: 0 } */}
+      {/* Sparkline overlay — draggable for calibration; drop logs SPARKLINE_SVG_ANC_X to console */}
       {!isDocked && sparklineContent && (
         <div
-          className="absolute z-20 select-none pointer-events-none"
+          className="absolute z-20 select-none cursor-grab active:cursor-grabbing"
           style={{
             left: sparklinePos.x,
             top: sparklinePos.y,
             width: sparklineW,
             height: sparklineH,
           }}
+          onMouseDown={handleSparklineMouseDown}
         >
           {sparklineContent}
         </div>

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
@@ -149,8 +149,8 @@ export const FullWidthVehicleDiagram: React.FC<
   // Sparkline base dimensions — correct size when the vehicle is height-bound (wide container)
   const SPARKLINE_BASE_W = 503 // 529 × 0.95
   const SPARKLINE_BASE_H = 126 // 133 × 0.95
-  // Vertical offset from letterboxTop in px — i.e. distance above the vehicle body's
-  // top edge. Negative = above. Calibrated by dragging; logged to console on drop.
+  // Vertical offset above the container top at full scale. Scaled by effectiveScale
+  // so the sparkline tracks the vehicle body as the container narrows.
   const SPARKLINE_BASE_Y = -12
 
   // Vehicle SVG viewBox dimensions
@@ -178,8 +178,10 @@ export const FullWidthVehicleDiagram: React.FC<
   //   s = (cW − 2·MARGIN) / ((1 − 2·sparklineFrac) · cH · AR)
   const VB_MIN_X = 120
   const VB_MIN_Y = 155
-  const SPARKLINE_SVG_ANC_X = 53 // calibrated by dragging; update via console log
-  // Action-button SVG anchor — calibrated via drag on 2026-06-09
+  // Sparkline left-edge anchor in vehicle SVG viewBox coordinates (x=53 is left of VB_MIN_X=120,
+  // placing the sparkline in the horizontal letterbox to the left of the vehicle body).
+  const SPARKLINE_SVG_ANC_X = 53
+  // Action-button SVG anchor in vehicle viewBox coordinates — calibrated 2026-06-09.
   const BTN_SVG_ANC_X = 64
   const BTN_SVG_ANC_Y = 245
   const vehicleAR = VB_W / VB_H // ≈ 3.034
@@ -504,13 +506,13 @@ export const FullWidthVehicleDiagram: React.FC<
         </g>
       </svg>
 
-      {/* Sparkline overlay */}
+      {/* Sparkline overlay — pointer-events-none so underlying vehicle SVG stays interactive */}
       {!isDocked && sparklineContent && (
         <div
-          className="absolute z-20"
+          className="absolute z-20 pointer-events-none"
           style={{
             left: sparklinePosLeft,
-            top: SPARKLINE_BASE_Y,
+            top: Math.round(SPARKLINE_BASE_Y * effectiveScale),
             width: sparklineW,
             height: sparklineH,
           }}
@@ -519,8 +521,9 @@ export const FullWidthVehicleDiagram: React.FC<
         </div>
       )}
 
-      {/* Action button — anchored in vehicle SVG coordinates, scales with vehicle */}
-      {actionButton && vehicleRenderW > 0 && (
+      {/* Action button — anchored in vehicle SVG coordinates, scales with vehicle.
+          Hidden when docked to match sparkline behaviour. */}
+      {!isDocked && actionButton && vehicleRenderW > 0 && (
         <div className="absolute z-30" style={{ left: btnLeft, top: btnTop }}>
           {actionButton}
         </div>

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
@@ -192,7 +192,9 @@ export const FullWidthVehicleDiagram: React.FC<
     cH > 0 && cW > 0
       ? (cW - 2 * SPARKLINE_MARGIN) / ((1 - 2 * sparklineFrac) * cH * vehicleAR)
       : 1
-  const effectiveScale = Math.min(1, Math.max(0.1, sparklineDrivenScale))
+  // Lower bound is 0 (not 0.1) so the widget can shrink fully in very narrow
+  // panes rather than forcing a minimum size that overflows the container.
+  const effectiveScale = Math.min(1, Math.max(0, sparklineDrivenScale))
 
   // Vehicle explicit render dimensions — these replace h-full w-full on the SVG
   const vehicleRenderW = Math.round(effectiveScale * cH * vehicleAR)

--- a/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
+++ b/packages/react-ui/src/Diagrams/FullWidthVehicleDiagram.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react'
+import React, { useRef } from 'react'
 import clsx from 'clsx'
 import { DropWeightIndicator } from './VehicleAssets/DropWeightIndicator'
 import { DvlIndicator } from './VehicleAssets/DvlIndicator'
@@ -29,6 +29,7 @@ import { Leak } from './VehicleAssets/Leak'
 export interface FullWidthVehicleDiagramProps extends VehicleProps {
   onBatteryClick?: BatteryProps['onClick']
   sparklineContent?: React.ReactNode
+  actionButton?: React.ReactNode
 }
 
 export const FullWidthVehicleDiagram: React.FC<
@@ -135,21 +136,10 @@ export const FullWidthVehicleDiagram: React.FC<
   svgCurrent,
   colorDuration,
   onBatteryClick: handleBatteryClick,
+  actionButton,
 }) => {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const { size: containerSize } = useResizeObserver({ element: containerRef })
-
-  // Drag state for the sparkline overlay. dragDelta accumulates pixel offsets
-  // from the computed position so the user can fine-tune placement visually.
-  // On mouseup the SVG anchor x is logged to the console so the constant can
-  // be updated permanently.
-  const [dragDelta, setDragDelta] = useState({ x: 0, y: 0 })
-  const dragOrigin = useRef<{
-    mouseX: number
-    mouseY: number
-    deltaX: number
-    deltaY: number
-  } | null>(null)
 
   const isDocked = status === 'pluggedIn' || status === 'recovered'
 
@@ -187,7 +177,11 @@ export const FullWidthVehicleDiagram: React.FC<
   // Setting sparklinePosLeft = SPARKLINE_MARGIN and solving:
   //   s = (cW − 2·MARGIN) / ((1 − 2·sparklineFrac) · cH · AR)
   const VB_MIN_X = 120
+  const VB_MIN_Y = 155
   const SPARKLINE_SVG_ANC_X = 53 // calibrated by dragging; update via console log
+  // Action-button SVG anchor — calibrated via drag on 2026-06-09
+  const BTN_SVG_ANC_X = 64
+  const BTN_SVG_ANC_Y = 245
   const vehicleAR = VB_W / VB_H // ≈ 3.034
   const sparklineFrac = (SPARKLINE_SVG_ANC_X - VB_MIN_X) / VB_W // ≈ −0.1254
   const SPARKLINE_MARGIN = 4 // min px of clear space at left of sparkline
@@ -210,60 +204,22 @@ export const FullWidthVehicleDiagram: React.FC<
   const sparklinePosLeft =
     cH > 0 ? Math.round(vehicleOffsetLeft + sparklineFrac * vehicleRenderW) : 0
 
-  // Vehicle is pinned to top=0 + translateY(VEHICLE_TOP_OFFSET) — no vertical
-  // letterbox drift — so SPARKLINE_BASE_Y is a fixed offset from the container top.
-  const sparklinePos = {
-    x: sparklinePosLeft + dragDelta.x,
-    y: SPARKLINE_BASE_Y + dragDelta.y,
-  }
-
-  const handleSparklineMouseDown = (e: React.MouseEvent) => {
-    e.preventDefault()
-    dragOrigin.current = {
-      mouseX: e.clientX,
-      mouseY: e.clientY,
-      deltaX: dragDelta.x,
-      deltaY: dragDelta.y,
-    }
-
-    const onMove = (ev: MouseEvent) => {
-      if (!dragOrigin.current) return
-      setDragDelta({
-        x: dragOrigin.current.deltaX + ev.clientX - dragOrigin.current.mouseX,
-        y: dragOrigin.current.deltaY + ev.clientY - dragOrigin.current.mouseY,
-      })
-    }
-
-    const onUp = (ev: MouseEvent) => {
-      if (!dragOrigin.current) return
-      const finalDomX =
-        sparklinePosLeft +
-        dragOrigin.current.deltaX +
-        ev.clientX -
-        dragOrigin.current.mouseX
-      const finalDomY =
-        SPARKLINE_BASE_Y +
-        dragOrigin.current.deltaY +
-        ev.clientY -
-        dragOrigin.current.mouseY
-      const finalSvgX =
-        vehicleRenderW > 0
-          ? VB_MIN_X + ((finalDomX - vehicleOffsetLeft) / vehicleRenderW) * VB_W
-          : SPARKLINE_SVG_ANC_X
-      // eslint-disable-next-line no-console
-      console.log(
-        `[DepthSparkline] → SPARKLINE_SVG_ANC_X = ${Math.round(
-          finalSvgX
-        )},  SPARKLINE_BASE_Y = ${Math.round(finalDomY)}`
-      )
-      dragOrigin.current = null
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
-    }
-
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-  }
+  // Button position: same SVG-coordinate transform as the vehicle, so it
+  // moves and scales in lockstep with the vehicle body and sparkline.
+  const btnLeft =
+    vehicleRenderW > 0
+      ? Math.round(
+          vehicleOffsetLeft +
+            ((BTN_SVG_ANC_X - VB_MIN_X) / VB_W) * vehicleRenderW
+        )
+      : 0
+  const btnTop =
+    vehicleRenderH > 0
+      ? Math.round(
+          VEHICLE_TOP_OFFSET +
+            ((BTN_SVG_ANC_Y - VB_MIN_Y) / VB_H) * vehicleRenderH
+        )
+      : 0
 
   const containerH = containerSize?.height ?? 0
   const containerW = containerSize?.width ?? 0
@@ -548,19 +504,25 @@ export const FullWidthVehicleDiagram: React.FC<
         </g>
       </svg>
 
-      {/* Sparkline overlay — draggable for calibration; drop logs SPARKLINE_SVG_ANC_X to console */}
+      {/* Sparkline overlay */}
       {!isDocked && sparklineContent && (
         <div
-          className="absolute z-20 select-none cursor-grab active:cursor-grabbing"
+          className="absolute z-20"
           style={{
-            left: sparklinePos.x,
-            top: sparklinePos.y,
+            left: sparklinePosLeft,
+            top: SPARKLINE_BASE_Y,
             width: sparklineW,
             height: sparklineH,
           }}
-          onMouseDown={handleSparklineMouseDown}
         >
           {sparklineContent}
+        </div>
+      )}
+
+      {/* Action button — anchored in vehicle SVG coordinates, scales with vehicle */}
+      {actionButton && vehicleRenderW > 0 && (
+        <div className="absolute z-30" style={{ left: btnLeft, top: btnTop }}>
+          {actionButton}
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes #674

## Summary

- **Unified scaling** (`54ac6a3e`): introduces `effectiveScale` so the `DepthSparkline` overlay and vehicle SVG shrink together as one unit when the allotment pane is resized; vehicle SVG given explicit pixel dimensions instead of `h-full w-full`; sparkline drag-to-calibrate machinery removed and SVG anchor baked in
- **DepthSparkline label polish** (`54ac6a3e`): time, freshness dot, and age consolidated onto one line (`12:30 • 1.5h ago`) with age text slightly smaller
- **Okeanids link button** (`252567f6`): teal `↗` button (matching Dash4 style) added via new `actionButton` prop on `FullWidthVehicleDiagram`; positioned using SVG-coordinate math (`BTN_SVG_ANC_X = 64, BTN_SVG_ANC_Y = 245`) so it moves and scales in lockstep with the vehicle body and sparkline; clicking opens `https://okeanids.mbari.org/widget/auv_{name}.svg` in a new tab

## Test plan

- [ ] Verify sparkline and vehicle SVG scale together when dragging the pane divider narrower
- [ ] Verify the Okeanids button appears on each on-mission vehicle card at the calibrated position
- [ ] Verify the button moves/scales with the vehicle when the pane is resized
- [ ] Verify clicking the button opens the correct Okeanids SVG URL in a new tab
- [ ] Verify docked vehicles (`PLUGGED` / `RECOVERED`) do not show the sparkline or the Okeanids button