### PR TITLE
fix: repair broken log links and add Dash4 log navigation features

### DIFF
--- a/apps/lrauv-dash2/components/RealTimeLogs.tsx
+++ b/apps/lrauv-dash2/components/RealTimeLogs.tsx
@@ -41,6 +41,13 @@ export const RealTimeLogs: React.FC<RealTimeLogsProps> = ({
     return `${base}/data/${vehicleName}/realtime/sbdlogs/${path}/shore.log`
   }, [siteConfig, vehicleName, latestDataProcessed])
 
+  const dataUrl = useMemo(() => {
+    const base = siteConfig?.appConfig.external.tethysdash
+    const path = latestDataProcessed?.[0]?.path
+    if (!base || !vehicleName || !path) return undefined
+    return `${base}/data/${vehicleName}/realtime/sbdlogs/${path}/`
+  }, [siteConfig, vehicleName, latestDataProcessed])
+
   const handleEspClick = () => {
     if (!espUrl) return
     window.open(espUrl, '_blank', 'noopener,noreferrer')
@@ -49,6 +56,11 @@ export const RealTimeLogs: React.FC<RealTimeLogsProps> = ({
   const handleShoreClick = () => {
     if (!shoreUrl) return
     window.open(shoreUrl, '_blank', 'noopener,noreferrer')
+  }
+
+  const handleDataClick = () => {
+    if (!dataUrl) return
+    window.open(dataUrl, '_blank', 'noopener,noreferrer')
   }
 
   return (
@@ -79,6 +91,20 @@ export const RealTimeLogs: React.FC<RealTimeLogsProps> = ({
           <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
         )}
         ESP
+      </Button>
+
+      <Button
+        appearance="secondary"
+        onClick={handleDataClick}
+        disabled={!dataUrl}
+        aria-label="Open all data downloads for this log session in a new browser tab"
+        title="Data — open downloads page in new tab"
+        className="shrink-0 whitespace-nowrap"
+      >
+        {!hideIcons && (
+          <FontAwesomeIcon icon={faExternalLink} className="mr-2" />
+        )}
+        Data
       </Button>
     </>
   )

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -309,38 +309,21 @@ describe('formatEvent', () => {
       expect(dirLink!.href).toContain('/data/triton/realtime/sbdlogs/')
     })
 
-    it('renders a shore.log link', () => {
+    it('renders a "Data" button linking to the TethysDash data page', () => {
       render(formatEvent(event, DASH_URL))
-      const link = screen.getByRole('link', { name: /shore log/i })
-      expect(link).toBeInTheDocument()
-      expect(link.getAttribute('href')).toContain('shore.log')
-    })
-
-    it('renders a shore.kml link', () => {
-      render(formatEvent(event, DASH_URL))
-      const link = screen.getByRole('link', { name: /kml track/i })
-      expect(link).toBeInTheDocument()
-      expect(link.getAttribute('href')).toContain('shore.kml')
-    })
-
-    it('renders a Parent Directory link pointing to the parent path', () => {
-      render(formatEvent(event, DASH_URL))
-      const link = screen.getByRole('link', { name: /parent directory/i })
-      expect(link).toBeInTheDocument()
-      expect(link.getAttribute('href')).toContain(
-        '/data/triton/realtime/sbdlogs/2022/202207/'
+      const btn = screen.getByRole('link', { name: /view all data/i })
+      expect(btn).toBeInTheDocument()
+      expect(btn.textContent).toBe('Data')
+      expect(btn.getAttribute('href')).toBe(
+        `${DASH_URL}/data/triton/realtime/sbdlogs/${LOG_PATH}/`
       )
     })
 
-    it('all three extra links open in a new tab', () => {
-      const { container } = render(formatEvent(event, DASH_URL))
-      const extraLinks = Array.from(container.querySelectorAll('a')).filter(
-        (a) => a.textContent !== LOG_PATH
-      )
-      extraLinks.forEach((a) => {
-        expect(a).toHaveAttribute('target', '_blank')
-        expect(a).toHaveAttribute('rel', 'noopener noreferrer')
-      })
+    it('Data button opens in a new tab', () => {
+      render(formatEvent(event, DASH_URL))
+      const btn = screen.getByRole('link', { name: /view all data/i })
+      expect(btn).toHaveAttribute('target', '_blank')
+      expect(btn).toHaveAttribute('rel', 'noopener noreferrer')
     })
   })
 

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -289,7 +289,7 @@ describe('formatEvent', () => {
       const { container } = render(formatEvent(event, DASH_URL))
       const link = container.querySelector('a') as HTMLAnchorElement
       // Old URL was: ${dashUrl}/triton/realtime/... (no /data/ after the base)
-      expect(link.href).not.toMatch(new RegExp(`${DASH_URL}/triton/`))
+      expect(link.href).not.toContain(`${DASH_URL}/triton/`)
     })
   })
 

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -311,9 +311,13 @@ describe('formatEvent', () => {
 
     it('the path link opens in a new tab', () => {
       const { container } = render(formatEvent(event, DASH_URL))
-      const link = container.querySelector('a') as HTMLAnchorElement
-      expect(link).toHaveAttribute('target', '_blank')
-      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+      const links = container.querySelectorAll('a')
+      const dirLink = Array.from(links).find(
+        (a) => a.textContent === LOG_PATH
+      ) as HTMLAnchorElement
+      expect(dirLink).toBeDefined()
+      expect(dirLink).toHaveAttribute('target', '_blank')
+      expect(dirLink).toHaveAttribute('rel', 'noopener noreferrer')
     })
   })
 

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -272,6 +272,96 @@ describe('formatEvent', () => {
     })
   })
 
+  describe('dataProcessed URL', () => {
+    const event: GetEventsResponse = {
+      ...baseEvent,
+      eventType: 'dataProcessed',
+      path: '2022/202207/20220712T221014',
+    } as GetEventsResponse
+
+    it('includes /data/ in the href', () => {
+      const { container } = render(formatEvent(event, DASH_URL))
+      const link = container.querySelector('a') as HTMLAnchorElement
+      expect(link.href).toContain('/data/triton/realtime/sbdlogs/')
+    })
+
+    it('does not omit /data/ (old bug produced .../TethysDash/triton/... without /data/)', () => {
+      const { container } = render(formatEvent(event, DASH_URL))
+      const link = container.querySelector('a') as HTMLAnchorElement
+      // Old URL was: ${dashUrl}/triton/realtime/... (no /data/ after the base)
+      expect(link.href).not.toMatch(new RegExp(`${DASH_URL}/triton/`))
+    })
+  })
+
+  describe('logPath event', () => {
+    const LOG_PATH = '2022/202207/20220712T221014'
+    const event: GetEventsResponse = {
+      ...baseEvent,
+      eventType: 'logPath',
+      path: LOG_PATH,
+    } as GetEventsResponse
+
+    it('includes /data/ in the directory href', () => {
+      const { container } = render(formatEvent(event, DASH_URL))
+      const links = container.querySelectorAll('a')
+      const dirLink = Array.from(links).find((a) => a.textContent === LOG_PATH)
+      expect(dirLink).toBeDefined()
+      expect(dirLink!.href).toContain('/data/triton/realtime/sbdlogs/')
+    })
+
+    it('renders a shore.log link', () => {
+      render(formatEvent(event, DASH_URL))
+      const link = screen.getByRole('link', { name: /shore log/i })
+      expect(link).toBeInTheDocument()
+      expect(link.getAttribute('href')).toContain('shore.log')
+    })
+
+    it('renders a .kml link', () => {
+      render(formatEvent(event, DASH_URL))
+      const link = screen.getByRole('link', { name: /kml track/i })
+      expect(link).toBeInTheDocument()
+      expect(link.getAttribute('href')).toContain('.kml')
+    })
+
+    it('renders a Parent Directory link pointing to the parent path', () => {
+      render(formatEvent(event, DASH_URL))
+      const link = screen.getByRole('link', { name: /parent directory/i })
+      expect(link).toBeInTheDocument()
+      expect(link.getAttribute('href')).toContain(
+        '/data/triton/realtime/sbdlogs/2022/202207/'
+      )
+    })
+
+    it('all three extra links open in a new tab', () => {
+      const { container } = render(formatEvent(event, DASH_URL))
+      const extraLinks = Array.from(container.querySelectorAll('a')).filter(
+        (a) => a.textContent !== LOG_PATH
+      )
+      extraLinks.forEach((a) => {
+        expect(a).toHaveAttribute('target', '_blank')
+        expect(a).toHaveAttribute('rel', 'noopener noreferrer')
+      })
+    })
+  })
+
+  describe('sbdReceive URL with path', () => {
+    const event: GetEventsResponse = {
+      ...baseEvent,
+      eventType: 'sbdReceive',
+      state: 2,
+      dataLen: 840,
+      path: '2022/202207/20220712T221014/Express0196.lzma',
+      momsn: 1234 as unknown as string,
+    } as GetEventsResponse
+
+    it('includes /data/ in the file href', () => {
+      const { container } = render(formatEvent(event, DASH_URL))
+      const link = container.querySelector('a') as HTMLAnchorElement
+      expect(link).toBeInTheDocument()
+      expect(link.href).toContain('/data/triton/realtime/sbdlogs/')
+    })
+  })
+
   describe('command event with newline in data', () => {
     const event: GetEventsResponse = {
       ...baseEvent,

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -316,11 +316,11 @@ describe('formatEvent', () => {
       expect(link.getAttribute('href')).toContain('shore.log')
     })
 
-    it('renders a .kml link', () => {
+    it('renders a shore.kml link', () => {
       render(formatEvent(event, DASH_URL))
       const link = screen.getByRole('link', { name: /kml track/i })
       expect(link).toBeInTheDocument()
-      expect(link.getAttribute('href')).toContain('.kml')
+      expect(link.getAttribute('href')).toContain('shore.kml')
     })
 
     it('renders a Parent Directory link pointing to the parent path', () => {

--- a/apps/lrauv-dash2/jest/formatEvent.test.tsx
+++ b/apps/lrauv-dash2/jest/formatEvent.test.tsx
@@ -309,21 +309,11 @@ describe('formatEvent', () => {
       expect(dirLink!.href).toContain('/data/triton/realtime/sbdlogs/')
     })
 
-    it('renders a "Data" button linking to the TethysDash data page', () => {
-      render(formatEvent(event, DASH_URL))
-      const btn = screen.getByRole('link', { name: /view all data/i })
-      expect(btn).toBeInTheDocument()
-      expect(btn.textContent).toBe('Data')
-      expect(btn.getAttribute('href')).toBe(
-        `${DASH_URL}/data/triton/realtime/sbdlogs/${LOG_PATH}/`
-      )
-    })
-
-    it('Data button opens in a new tab', () => {
-      render(formatEvent(event, DASH_URL))
-      const btn = screen.getByRole('link', { name: /view all data/i })
-      expect(btn).toHaveAttribute('target', '_blank')
-      expect(btn).toHaveAttribute('rel', 'noopener noreferrer')
+    it('the path link opens in a new tab', () => {
+      const { container } = render(formatEvent(event, DASH_URL))
+      const link = container.querySelector('a') as HTMLAnchorElement
+      expect(link).toHaveAttribute('target', '_blank')
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer')
     })
   })
 

--- a/apps/lrauv-dash2/lib/formatEvent.tsx
+++ b/apps/lrauv-dash2/lib/formatEvent.tsx
@@ -101,7 +101,8 @@ const formatEvent = (
   const text = event.text ? event.text.split('\n') : ''
   const mtmsn = event.mtmsn ? event.mtmsn : ''
   const momsn = event.momsn ? event.momsn : ''
-  const url = `${dashUrl}/${event.vehicleName}/realtime/sbdlogs/${path}`
+  // /data/ segment is required — matches the pattern used by RealTimeLogs and useChartData
+  const url = `${dashUrl}/data/${event.vehicleName}/realtime/sbdlogs/${path}`
   const startedMission =
     eventType === 'logImportant' && event.text?.startsWith('Started mission ')
   const defaultMission =
@@ -254,7 +255,16 @@ const formatEvent = (
         </p>
       )
 
-    case 'logPath':
+    case 'logPath': {
+      const shoreLogUrl = `${url}/shore.log`
+      const kmlUrl = `${url}/${event.vehicleName}.kml`
+      const pathParts = path.split('/')
+      const parentUrl =
+        pathParts.length > 1
+          ? `${dashUrl}/data/${event.vehicleName}/realtime/sbdlogs/${pathParts
+              .slice(0, -1)
+              .join('/')}/`
+          : `${dashUrl}/data/${event.vehicleName}/realtime/sbdlogs/`
       return (
         <p className="flex flex-col">
           New data path{' '}
@@ -266,8 +276,38 @@ const formatEvent = (
           >
             {path}
           </a>
+          <span className="mt-1 flex flex-wrap gap-3 text-xs">
+            <a
+              href={shoreLogUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-600 hover:underline"
+              aria-label="shore log"
+            >
+              shore.log
+            </a>
+            <a
+              href={kmlUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-600 hover:underline"
+              aria-label="kml track"
+            >
+              .kml
+            </a>
+            <a
+              href={parentUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-primary-600 hover:underline"
+              aria-label="parent directory"
+            >
+              Parent Directory
+            </a>
+          </span>
         </p>
       )
+    }
 
     case 'launch':
     case 'recover':

--- a/apps/lrauv-dash2/lib/formatEvent.tsx
+++ b/apps/lrauv-dash2/lib/formatEvent.tsx
@@ -255,16 +255,7 @@ const formatEvent = (
         </p>
       )
 
-    case 'logPath': {
-      const shoreLogUrl = `${url}/shore.log`
-      const kmlUrl = `${url}/shore.kml`
-      const pathParts = path.split('/')
-      const parentUrl =
-        pathParts.length > 1
-          ? `${dashUrl}/data/${event.vehicleName}/realtime/sbdlogs/${pathParts
-              .slice(0, -1)
-              .join('/')}/`
-          : `${dashUrl}/data/${event.vehicleName}/realtime/sbdlogs/`
+    case 'logPath':
       return (
         <p className="flex flex-col">
           New data path{' '}
@@ -276,38 +267,17 @@ const formatEvent = (
           >
             {path}
           </a>
-          <span className="mt-1 flex flex-wrap gap-3 text-xs">
-            <a
-              href={shoreLogUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary-600 hover:underline"
-              aria-label="shore log"
-            >
-              shore.log
-            </a>
-            <a
-              href={kmlUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary-600 hover:underline"
-              aria-label="kml track"
-            >
-              .kml
-            </a>
-            <a
-              href={parentUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary-600 hover:underline"
-              aria-label="parent directory"
-            >
-              Parent Directory
-            </a>
-          </span>
+          <a
+            href={`${url}/`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-1 self-start rounded bg-teal-500 px-2 py-0.5 text-xs font-semibold text-white hover:bg-teal-400"
+            aria-label="view all data for this log session"
+          >
+            Data
+          </a>
         </p>
       )
-    }
 
     case 'launch':
     case 'recover':

--- a/apps/lrauv-dash2/lib/formatEvent.tsx
+++ b/apps/lrauv-dash2/lib/formatEvent.tsx
@@ -257,7 +257,7 @@ const formatEvent = (
 
     case 'logPath': {
       const shoreLogUrl = `${url}/shore.log`
-      const kmlUrl = `${url}/${event.vehicleName}.kml`
+      const kmlUrl = `${url}/shore.kml`
       const pathParts = path.split('/')
       const parentUrl =
         pathParts.length > 1

--- a/apps/lrauv-dash2/lib/formatEvent.tsx
+++ b/apps/lrauv-dash2/lib/formatEvent.tsx
@@ -267,15 +267,6 @@ const formatEvent = (
           >
             {path}
           </a>
-          <a
-            href={`${url}/`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-1 self-start rounded bg-teal-500 px-2 py-0.5 text-xs font-semibold text-white hover:bg-teal-400"
-            aria-label="view all data for this log session"
-          >
-            Data
-          </a>
         </p>
       )
 


### PR DESCRIPTION
Closes #676

## Summary

- **Bug fix**: All `dataProcessed`, `logPath`, and `sbdReceive` log entry links were broken — the URL was missing the required `/data/` path segment. Every other log URL in the codebase (`RealTimeLogs`, `useChartData`) correctly includes `/data/`; this was an isolated omission in `formatEvent.tsx`.

- **Enhancement**: A **Data** button has been added to the `RealTimeLogs` toolbar alongside Shore and ESP. It opens the TethysDash session data page for the latest log session — providing all data downloads (`shore.nc`, `shore.mat`, `shore.kml`, `shore.kmz`, `shore.asc`, `shore.dir`, `shore.csv`, `shore.log`), an interactive Leaflet map, and Highcharts science plots. This replaces Dash4 data page links ahead of Dash4 deprecation. URL is driven by `siteConfig.tethysdash`.

> Note: shore.log, .kml, and Parent Directory inline links on `logPath` entries were considered and then consolidated into the single Data toolbar button for a cleaner UX.

## Files changed

| File | Change |
|------|--------|
| `apps/lrauv-dash2/lib/formatEvent.tsx` | Fix missing `/data/` segment in SBD log URL construction |
| `apps/lrauv-dash2/components/RealTimeLogs.tsx` | Add Data button to toolbar (alongside Shore and ESP) linking to the TethysDash session data page |
| `apps/lrauv-dash2/jest/formatEvent.test.tsx` | Tests verifying `/data/` is present in dataProcessed, logPath, and sbdReceive URLs |

## Test plan

- [ ] Open the Log tab — `dataProcessed` and `logPath` links resolve correctly (no more 404s)
- [ ] Log toolbar shows **Shore | ESP | Data** buttons
- [ ] Click **Data** → opens TethysDash session data page with all downloads, map, and charts
- [ ] 29 `formatEvent` unit tests pass (`yarn workspace @mbari/lrauv-dash2 test:ci jest/formatEvent.test.tsx`)