### PR TITLE
feat: add native phone number (SMS) support to notification dialogs

### DIFF
--- a/apps/lrauv-dash2/components/AddEmailDialog.tsx
+++ b/apps/lrauv-dash2/components/AddEmailDialog.tsx
@@ -1,5 +1,12 @@
 import React, { useState } from 'react'
 import { Modal } from '@mbari/react-ui'
+import {
+  DestinationType,
+  isValidEmail,
+  isValidPhone,
+  normalizePhone,
+  SMS_CONSENT,
+} from '../lib/notificationDestinations'
 
 interface AddEmailDialogProps {
   existingEmails: string[]
@@ -7,20 +14,6 @@ interface AddEmailDialogProps {
   onAdd: (email: string) => void
   isAdding?: boolean
 }
-
-type DestinationType = 'email' | 'phone'
-
-const isValidEmail = (value: string) =>
-  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
-
-// Accepts E.164-style international numbers after stripping spaces/dashes,
-// e.g. "+1 555 123 4567" → "+15551234567"
-const normalizePhone = (value: string) => value.replace(/[\s\-().]/g, '')
-const isValidPhone = (value: string) =>
-  /^\+[1-9]\d{6,14}$/.test(normalizePhone(value.trim()))
-
-const SMS_CONSENT =
-  'By adding a phone number you opt in to SMS alerts for the vehicles you select. Message & data rates may apply. Opt out anytime by removing the number here, or reply STOP. Replying STOP stops messages but does not remove the number from TethysDash.'
 
 const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
   existingEmails,
@@ -73,7 +66,7 @@ const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
       <article className="flex flex-col gap-4 pb-2">
         <fieldset className="flex gap-6">
           <legend className="mb-2 text-sm text-stone-600">
-            Change this to:
+            Destination type:
           </legend>
           {(['email', 'phone'] as DestinationType[]).map((type) => (
             <label

--- a/apps/lrauv-dash2/components/AddEmailDialog.tsx
+++ b/apps/lrauv-dash2/components/AddEmailDialog.tsx
@@ -27,7 +27,7 @@ const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
   const trimmed = value.trim()
   const normalized = destType === 'phone' ? normalizePhone(trimmed) : trimmed
   const isDuplicate = existingEmails
-    .map((e) => e.toLowerCase())
+    .map((e) => (destType === 'phone' ? normalizePhone(e) : e).toLowerCase())
     .includes(normalized.toLowerCase())
 
   const isValueValid =

--- a/apps/lrauv-dash2/components/AddEmailDialog.tsx
+++ b/apps/lrauv-dash2/components/AddEmailDialog.tsx
@@ -6,6 +6,8 @@ import {
   isValidPhone,
   normalizePhone,
   SMS_CONSENT,
+  getDefaultDestType,
+  saveDefaultDestType,
 } from '../lib/notificationDestinations'
 
 interface AddEmailDialogProps {
@@ -21,7 +23,8 @@ const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
   onAdd,
   isAdding,
 }) => {
-  const [destType, setDestType] = useState<DestinationType>('email')
+  const [destType, setDestType] = useState<DestinationType>(getDefaultDestType)
+  const [makeDefault, setMakeDefault] = useState(false)
   const [value, setValue] = useState('')
 
   const trimmed = value.trim()
@@ -45,7 +48,9 @@ const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
     : null
 
   const handleConfirm = () => {
-    if (isValid) onAdd(destType === 'phone' ? normalized : trimmed)
+    if (!isValid) return
+    if (makeDefault) saveDefaultDestType(destType)
+    onAdd(destType === 'phone' ? normalized : trimmed)
   }
 
   return (
@@ -64,29 +69,42 @@ const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
       style={{ minWidth: 420 }}
     >
       <article className="flex flex-col gap-4 pb-2">
-        <fieldset className="flex gap-6">
-          <legend className="mb-2 text-sm text-stone-600">
+        <fieldset className="flex flex-col gap-2">
+          <legend className="mb-1 text-sm text-stone-600">
             Destination type:
           </legend>
-          {(['email', 'phone'] as DestinationType[]).map((type) => (
-            <label
-              key={type}
-              className="flex cursor-pointer items-center gap-2 text-sm"
-            >
-              <input
-                type="radio"
-                name="dest-type"
-                value={type}
-                checked={destType === type}
-                onChange={() => {
-                  setDestType(type)
-                  setValue('')
-                }}
-                className="accent-teal-600"
-              />
-              {type === 'email' ? 'Email address' : 'Phone number'}
-            </label>
-          ))}
+          <div className="flex gap-6">
+            {(['email', 'phone'] as DestinationType[]).map((type) => (
+              <label
+                key={type}
+                className="flex cursor-pointer items-center gap-2 text-sm"
+              >
+                <input
+                  type="radio"
+                  name="dest-type"
+                  value={type}
+                  checked={destType === type}
+                  onChange={() => {
+                    setDestType(type)
+                    setValue('')
+                    setMakeDefault(false)
+                  }}
+                  className="accent-teal-600"
+                />
+                {type === 'email' ? 'Email address' : 'Phone number'}
+              </label>
+            ))}
+          </div>
+          <label className="flex cursor-pointer items-center gap-2 text-xs text-stone-500">
+            <input
+              type="checkbox"
+              checked={makeDefault}
+              onChange={(e) => setMakeDefault(e.target.checked)}
+              className="accent-teal-600"
+            />
+            Make {destType === 'email' ? 'email' : 'phone number'} my default
+            destination type
+          </label>
         </fieldset>
 
         <div className="flex flex-col gap-1">

--- a/apps/lrauv-dash2/components/AddEmailDialog.tsx
+++ b/apps/lrauv-dash2/components/AddEmailDialog.tsx
@@ -8,8 +8,19 @@ interface AddEmailDialogProps {
   isAdding?: boolean
 }
 
+type DestinationType = 'email' | 'phone'
+
 const isValidEmail = (value: string) =>
   /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
+
+// Accepts E.164-style international numbers after stripping spaces/dashes,
+// e.g. "+1 555 123 4567" → "+15551234567"
+const normalizePhone = (value: string) => value.replace(/[\s\-().]/g, '')
+const isValidPhone = (value: string) =>
+  /^\+[1-9]\d{6,14}$/.test(normalizePhone(value.trim()))
+
+const SMS_CONSENT =
+  'By adding a phone number you opt in to SMS alerts for the vehicles you select. Message & data rates may apply. Opt out anytime by removing the number here, or reply STOP. Replying STOP stops messages but does not remove the number from TethysDash.'
 
 const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
   existingEmails,
@@ -17,32 +28,41 @@ const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
   onAdd,
   isAdding,
 }) => {
+  const [destType, setDestType] = useState<DestinationType>('email')
   const [value, setValue] = useState('')
 
   const trimmed = value.trim()
+  const normalized = destType === 'phone' ? normalizePhone(trimmed) : trimmed
   const isDuplicate = existingEmails
     .map((e) => e.toLowerCase())
-    .includes(trimmed.toLowerCase())
-  const isValid = isValidEmail(trimmed) && !isDuplicate
+    .includes(normalized.toLowerCase())
+
+  const isValueValid =
+    destType === 'email' ? isValidEmail(trimmed) : isValidPhone(trimmed)
+  const isValid = isValueValid && !isDuplicate
 
   const errorMsg = trimmed
     ? isDuplicate
-      ? 'This address is already in the list.'
-      : !isValidEmail(trimmed)
-      ? 'Please enter a valid email address.'
+      ? 'This destination is already in the list.'
+      : !isValueValid
+      ? destType === 'email'
+        ? 'Please enter a valid email address.'
+        : 'Please enter a valid phone number in international format, e.g. +1 555 123 4567.'
       : null
     : null
+
+  const handleConfirm = () => {
+    if (isValid) onAdd(destType === 'phone' ? normalized : trimmed)
+  }
 
   return (
     <Modal
       title={
-        <span className="text-lg font-bold">Add notification address</span>
+        <span className="text-lg font-bold">Add notification destination</span>
       }
       open
       onClose={onClose}
-      onConfirm={() => {
-        if (isValid) onAdd(trimmed)
-      }}
+      onConfirm={handleConfirm}
       confirmButtonText={isAdding ? 'Adding…' : 'Add'}
       disableConfirm={!isValid || isAdding}
       cancelButtonText="Cancel"
@@ -50,32 +70,70 @@ const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
       blurBackground
       style={{ minWidth: 420 }}
     >
-      <article className="flex flex-col gap-3 pb-2">
-        <p className="text-sm text-stone-600">
-          Enter an email address or SMS gateway address (e.g.{' '}
-          <span className="font-mono">5551234567@vtext.com</span>) to receive
-          notifications.
-        </p>
+      <article className="flex flex-col gap-4 pb-2">
+        <fieldset className="flex gap-6">
+          <legend className="mb-2 text-sm text-stone-600">
+            Change this to:
+          </legend>
+          {(['email', 'phone'] as DestinationType[]).map((type) => (
+            <label
+              key={type}
+              className="flex cursor-pointer items-center gap-2 text-sm"
+            >
+              <input
+                type="radio"
+                name="dest-type"
+                value={type}
+                checked={destType === type}
+                onChange={() => {
+                  setDestType(type)
+                  setValue('')
+                }}
+                className="accent-teal-600"
+              />
+              {type === 'email' ? 'Email address' : 'Phone number'}
+            </label>
+          ))}
+        </fieldset>
+
         <div className="flex flex-col gap-1">
-          <label htmlFor="add-email-input" className="text-xs text-stone-600">
-            Address
+          <label
+            htmlFor="add-dest-input"
+            className="text-xs font-medium text-teal-700"
+          >
+            {destType === 'email' ? 'Email address:' : 'Phone number:'}
           </label>
           <input
-            id="add-email-input"
+            id="add-dest-input"
+            key={destType}
             autoFocus
-            type="email"
-            className={`w-full rounded border px-3 py-2 text-sm ${
-              errorMsg ? 'border-red-400' : 'border-stone-300'
+            type={destType === 'email' ? 'email' : 'tel'}
+            className={`w-full rounded border-b px-0 py-1 text-sm focus:outline-none ${
+              errorMsg ? 'border-red-400' : 'border-stone-400'
             }`}
-            placeholder="e.g. alerts@example.com"
+            placeholder={
+              destType === 'email'
+                ? 'e.g. alerts@example.com'
+                : '+1 555 123 4567'
+            }
             value={value}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter' && isValid && !isAdding) onAdd(trimmed)
+              if (e.key === 'Enter' && isValid && !isAdding) handleConfirm()
             }}
           />
           {errorMsg && <span className="text-xs text-red-600">{errorMsg}</span>}
         </div>
+
+        {destType === 'phone' && (
+          <div className="flex flex-col gap-2">
+            <p className="text-xs italic text-stone-500">
+              Enter in international format, starting with &lsquo;+&rsquo; and
+              the country code, e.g. +1 555 123 4567.
+            </p>
+            <p className="text-xs italic text-stone-500">{SMS_CONSENT}</p>
+          </div>
+        )}
       </article>
     </Modal>
   )

--- a/apps/lrauv-dash2/components/AddEmailDialog.tsx
+++ b/apps/lrauv-dash2/components/AddEmailDialog.tsx
@@ -7,13 +7,12 @@ import {
   normalizePhone,
   SMS_CONSENT,
   getDefaultDestType,
-  saveDefaultDestType,
 } from '../lib/notificationDestinations'
 
 interface AddEmailDialogProps {
   existingEmails: string[]
   onClose: () => void
-  onAdd: (email: string) => void
+  onAdd: (email: string, makeDefault?: boolean) => void
   isAdding?: boolean
 }
 
@@ -49,8 +48,7 @@ const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
 
   const handleConfirm = () => {
     if (!isValid) return
-    if (makeDefault) saveDefaultDestType(destType)
-    onAdd(destType === 'phone' ? normalized : trimmed)
+    onAdd(destType === 'phone' ? normalized : trimmed, makeDefault)
   }
 
   return (
@@ -102,8 +100,7 @@ const AddEmailDialog: React.FC<AddEmailDialogProps> = ({
               onChange={(e) => setMakeDefault(e.target.checked)}
               className="accent-teal-600"
             />
-            Make {destType === 'email' ? 'email' : 'phone number'} my default
-            destination type
+            Make this my default notification destination
           </label>
         </fieldset>
 

--- a/apps/lrauv-dash2/components/EditEmailDialog.tsx
+++ b/apps/lrauv-dash2/components/EditEmailDialog.tsx
@@ -40,7 +40,7 @@ const EditEmailDialog: React.FC<EditEmailDialogProps> = ({
   const isDuplicate =
     !isUnchanged &&
     existingEmails
-      .map((e) => e.toLowerCase())
+      .map((e) => (destType === 'phone' ? normalizePhone(e) : e).toLowerCase())
       .includes(normalized.toLowerCase())
 
   const isValueValid =

--- a/apps/lrauv-dash2/components/EditEmailDialog.tsx
+++ b/apps/lrauv-dash2/components/EditEmailDialog.tsx
@@ -36,7 +36,12 @@ const EditEmailDialog: React.FC<EditEmailDialogProps> = ({
 
   const trimmed = value.trim()
   const normalized = destType === 'phone' ? normalizePhone(trimmed) : trimmed
-  const isUnchanged = normalized.toLowerCase() === currentEmail.toLowerCase()
+  // Normalize currentEmail the same way so a pre-formatted phone like
+  // "+1 555 123 4567" correctly compares equal to its stored value.
+  const normalizedCurrent =
+    initialType === 'phone' ? normalizePhone(currentEmail) : currentEmail
+  const isUnchanged =
+    normalized.toLowerCase() === normalizedCurrent.toLowerCase()
   const isDuplicate =
     !isUnchanged &&
     existingEmails

--- a/apps/lrauv-dash2/components/EditEmailDialog.tsx
+++ b/apps/lrauv-dash2/components/EditEmailDialog.tsx
@@ -81,7 +81,7 @@ const EditEmailDialog: React.FC<EditEmailDialogProps> = ({
         {
           buttonText: isDeleting
             ? 'Deleting…'
-            : destType === 'phone'
+            : initialType === 'phone'
             ? 'Delete phone number'
             : 'Delete address',
           appearance: 'destructive' as const,

--- a/apps/lrauv-dash2/components/EditEmailDialog.tsx
+++ b/apps/lrauv-dash2/components/EditEmailDialog.tsx
@@ -11,8 +11,19 @@ interface EditEmailDialogProps {
   isDeleting?: boolean
 }
 
+type DestinationType = 'email' | 'phone'
+
 const isValidEmail = (value: string) =>
   /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
+
+const normalizePhone = (value: string) => value.replace(/[\s\-().]/g, '')
+const isValidPhone = (value: string) =>
+  /^\+[1-9]\d{6,14}$/.test(normalizePhone(value.trim()))
+
+const isPhoneNumber = (value: string) => value.trim().startsWith('+')
+
+const SMS_CONSENT =
+  'By adding a phone number you opt in to SMS alerts for the vehicles you select. Message & data rates may apply. Opt out anytime by removing the number here, or reply STOP. Replying STOP stops messages but does not remove the number from TethysDash.'
 
 const EditEmailDialog: React.FC<EditEmailDialogProps> = ({
   currentEmail,
@@ -23,44 +34,62 @@ const EditEmailDialog: React.FC<EditEmailDialogProps> = ({
   isSaving,
   isDeleting,
 }) => {
+  const initialType: DestinationType = isPhoneNumber(currentEmail)
+    ? 'phone'
+    : 'email'
+  const [destType, setDestType] = useState<DestinationType>(initialType)
   const [value, setValue] = useState(currentEmail)
 
   const trimmed = value.trim()
-  const isUnchanged = trimmed.toLowerCase() === currentEmail.toLowerCase()
+  const normalized = destType === 'phone' ? normalizePhone(trimmed) : trimmed
+  const isUnchanged = normalized.toLowerCase() === currentEmail.toLowerCase()
   const isDuplicate =
     !isUnchanged &&
-    existingEmails.map((e) => e.toLowerCase()).includes(trimmed.toLowerCase())
-  const isValid = isValidEmail(trimmed) && !isUnchanged && !isDuplicate
+    existingEmails
+      .map((e) => e.toLowerCase())
+      .includes(normalized.toLowerCase())
+
+  const isValueValid =
+    destType === 'email' ? isValidEmail(trimmed) : isValidPhone(trimmed)
+  const isValid = isValueValid && !isUnchanged && !isDuplicate
 
   const errorMsg = trimmed
     ? isUnchanged
       ? null
       : isDuplicate
-      ? 'This address is already in the list.'
-      : !isValidEmail(trimmed)
-      ? 'Please enter a valid email address.'
+      ? 'This destination is already in the list.'
+      : !isValueValid
+      ? destType === 'email'
+        ? 'Please enter a valid email address.'
+        : 'Please enter a valid phone number in international format, e.g. +1 555 123 4567.'
       : null
     : null
 
   const isBusy = isSaving || isDeleting
 
+  const handleConfirm = () => {
+    if (isValid && !isBusy) onSave(destType === 'phone' ? normalized : trimmed)
+  }
+
   return (
     <Modal
       title={
-        <span className="text-lg font-bold">Edit notification address</span>
+        <span className="text-lg font-bold">Edit notification destination</span>
       }
       open
       onClose={onClose}
-      onConfirm={() => {
-        if (isValid && !isBusy) onSave(trimmed)
-      }}
+      onConfirm={handleConfirm}
       confirmButtonText={isSaving ? 'Saving…' : 'Save'}
       disableConfirm={!isValid || isBusy}
       cancelButtonText="Cancel"
       onCancel={onClose}
       extraButtons={[
         {
-          buttonText: isDeleting ? 'Deleting…' : 'Delete address',
+          buttonText: isDeleting
+            ? 'Deleting…'
+            : destType === 'phone'
+            ? 'Delete phone number'
+            : 'Delete address',
           appearance: 'destructive' as const,
           onClick: onDelete,
           disabled: isBusy,
@@ -69,26 +98,70 @@ const EditEmailDialog: React.FC<EditEmailDialogProps> = ({
       blurBackground
       style={{ minWidth: 420 }}
     >
-      <article className="flex flex-col gap-3 pb-2">
+      <article className="flex flex-col gap-4 pb-2">
+        <fieldset className="flex gap-6">
+          <legend className="mb-2 text-sm text-stone-600">
+            Change this to:
+          </legend>
+          {(['email', 'phone'] as DestinationType[]).map((type) => (
+            <label
+              key={type}
+              className="flex cursor-pointer items-center gap-2 text-sm"
+            >
+              <input
+                type="radio"
+                name="edit-dest-type"
+                value={type}
+                checked={destType === type}
+                onChange={() => {
+                  setDestType(type)
+                  setValue('')
+                }}
+                className="accent-teal-600"
+              />
+              {type === 'email' ? 'Email address' : 'Phone number'}
+            </label>
+          ))}
+        </fieldset>
+
         <div className="flex flex-col gap-1">
-          <label htmlFor="edit-email-input" className="text-xs text-stone-600">
-            Address
+          <label
+            htmlFor="edit-dest-input"
+            className="text-xs font-medium text-teal-700"
+          >
+            {destType === 'email' ? 'Email address:' : 'Phone number:'}
           </label>
           <input
-            id="edit-email-input"
+            id="edit-dest-input"
+            key={destType}
             autoFocus
-            type="email"
-            className={`w-full rounded border px-3 py-2 text-sm ${
-              errorMsg ? 'border-red-400' : 'border-stone-300'
+            type={destType === 'email' ? 'email' : 'tel'}
+            className={`w-full rounded border-b px-0 py-1 text-sm focus:outline-none ${
+              errorMsg ? 'border-red-400' : 'border-stone-400'
             }`}
+            placeholder={
+              destType === 'email'
+                ? 'e.g. alerts@example.com'
+                : '+1 555 123 4567'
+            }
             value={value}
             onChange={(e) => setValue(e.target.value)}
             onKeyDown={(e) => {
-              if (e.key === 'Enter' && isValid && !isBusy) onSave(trimmed)
+              if (e.key === 'Enter' && isValid && !isBusy) handleConfirm()
             }}
           />
           {errorMsg && <span className="text-xs text-red-600">{errorMsg}</span>}
         </div>
+
+        {destType === 'phone' && (
+          <div className="flex flex-col gap-2">
+            <p className="text-xs italic text-stone-500">
+              Enter in international format, starting with &lsquo;+&rsquo; and
+              the country code, e.g. +1 555 123 4567.
+            </p>
+            <p className="text-xs italic text-stone-500">{SMS_CONSENT}</p>
+          </div>
+        )}
       </article>
     </Modal>
   )

--- a/apps/lrauv-dash2/components/EditEmailDialog.tsx
+++ b/apps/lrauv-dash2/components/EditEmailDialog.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react'
 import { Modal } from '@mbari/react-ui'
+import {
+  DestinationType,
+  isValidEmail,
+  isValidPhone,
+  isPhoneNumber,
+  normalizePhone,
+  SMS_CONSENT,
+} from '../lib/notificationDestinations'
 
 interface EditEmailDialogProps {
   currentEmail: string
@@ -10,20 +18,6 @@ interface EditEmailDialogProps {
   isSaving?: boolean
   isDeleting?: boolean
 }
-
-type DestinationType = 'email' | 'phone'
-
-const isValidEmail = (value: string) =>
-  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
-
-const normalizePhone = (value: string) => value.replace(/[\s\-().]/g, '')
-const isValidPhone = (value: string) =>
-  /^\+[1-9]\d{6,14}$/.test(normalizePhone(value.trim()))
-
-const isPhoneNumber = (value: string) => value.trim().startsWith('+')
-
-const SMS_CONSENT =
-  'By adding a phone number you opt in to SMS alerts for the vehicles you select. Message & data rates may apply. Opt out anytime by removing the number here, or reply STOP. Replying STOP stops messages but does not remove the number from TethysDash.'
 
 const EditEmailDialog: React.FC<EditEmailDialogProps> = ({
   currentEmail,

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -84,14 +84,20 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
   }, [accountEmail, selectedEmail])
 
   // Once the address list loads, verify the selection is still valid.
-  // If the stored default was deleted externally, fall back to account email.
+  // If the stored default was deleted externally, revert both the selection
+  // and the stored localStorage value to the account email so the stale
+  // address is not re-selected on the next open.
   useEffect(() => {
     if (!addressesData || !accountEmail || !selectedEmail) return
     const validAddresses = Object.keys(addressesData.result)
     if (!validAddresses.includes(selectedEmail)) {
       setSelectedEmail(accountEmail)
     }
-  }, [addressesData, accountEmail, selectedEmail])
+    if (defaultDest && !validAddresses.includes(defaultDest)) {
+      saveDefaultDest(accountEmail)
+      setDefaultDest(accountEmail)
+    }
+  }, [addressesData, accountEmail, selectedEmail, defaultDest])
 
   const isExtraEmail = selectedEmail !== '' && selectedEmail !== accountEmail
 

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -434,12 +434,15 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       {
         onSuccess: (data) => {
           const isPhone = isPhoneNumber(selectedEmail ?? '')
+          // For phone numbers the backend already returns a full descriptive
+          // string in email_sent (e.g. "test SMS sent to +1…"), so use it
+          // directly to avoid doubling up with our own prefix.
           const msg = data?.email_sent
             ? isPhone
-              ? `Test text message sent to ${data.email_sent}`
+              ? data.email_sent
               : `Test email sent to ${data.email_sent}`
             : isPhone
-            ? 'Test text message sent'
+            ? 'SMS sent'
             : 'Test email sent'
           setSendTestStatus('success')
           setSendTestMessage(msg)
@@ -734,7 +737,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
               <span className="text-sm text-green-600">
                 {sendTestMessage ||
                   (isPhoneNumber(selectedEmail ?? '')
-                    ? `Test text message sent to ${selectedEmail}`
+                    ? 'SMS sent'
                     : `Test email sent to ${selectedEmail}`)}
               </span>
             )}

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -24,8 +24,8 @@ import EditEmailDialog from './EditEmailDialog'
 import { FilterRowUi, FilteringType } from '../types'
 import {
   isPhoneNumber,
-  getDefaultDestType,
-  saveDefaultDestType,
+  getDefaultDest,
+  saveDefaultDest,
 } from '../lib/notificationDestinations'
 
 export interface EmailNotificationsModalProps {
@@ -53,16 +53,27 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       : []
     // Keep selectedEmail in the list during a pending refetch so the dropdown
     // never shows a selected address that isn't present in the options.
-    if (selectedEmail && !base.includes(selectedEmail)) {
-      return [...base, selectedEmail].sort()
+    const withSelected =
+      selectedEmail && !base.includes(selectedEmail)
+        ? [...base, selectedEmail].sort()
+        : base
+    // Sort so the stored default address appears first.
+    const storedDefault = getDefaultDest()
+    if (storedDefault && withSelected.includes(storedDefault)) {
+      return [storedDefault, ...withSelected.filter((e) => e !== storedDefault)]
     }
-    return base
+    return withSelected
   }, [addressesData, accountEmail, selectedEmail])
 
-  // default to account email once list loads
+  // Default to account email once the list loads. If no default has been stored
+  // in localStorage yet, treat the account email as the implicit default so
+  // the Make Default checkbox shows as checked on first open.
   useEffect(() => {
     if (!selectedEmail && accountEmail) {
       setSelectedEmail(accountEmail)
+    }
+    if (!getDefaultDest() && accountEmail) {
+      setDefaultDest(accountEmail)
     }
   }, [accountEmail, selectedEmail])
 
@@ -300,7 +311,8 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
     'idle' | 'success' | 'error'
   >('idle')
   const [sendTestMessage, setSendTestMessage] = useState<string>('')
-  const [defaultDestType, setDefaultDestType] = useState(getDefaultDestType)
+  // Tracks which specific address is the user's stored default destination.
+  const [defaultDest, setDefaultDest] = useState<string | null>(getDefaultDest)
 
   // Clear test-email feedback whenever the selected address changes so stale
   // success/error messages from a previous address don't linger.
@@ -419,7 +431,9 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
         details,
       },
       {
-        onSuccess: () => onClose?.(),
+        onSuccess: () => {
+          toast.success('Notification settings saved.')
+        },
         onError: () => {
           toast.error('Failed to save notification settings. Please try again.')
         },
@@ -488,13 +502,17 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
   }
 
   // ── extra email address management ───────────────────────────────────────
-  const handleAddEmail = (newEmail: string) => {
+  const handleAddEmail = (newEmail: string, makeDefault?: boolean) => {
     addExtraEmail(
       { email: accountEmail, addExtraEmails: newEmail },
       {
         onSuccess: () => {
           setShowAddEmail(false)
           setSelectedEmail(newEmail)
+          if (makeDefault) {
+            saveDefaultDest(newEmail)
+            setDefaultDest(newEmail)
+          }
         },
         onError: () => {
           toast.error('Failed to add email address. Please try again.')
@@ -504,16 +522,22 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
   }
 
   const handleEditSaveAddress = (newEmail: string) => {
+    const oldEmail = selectedEmail
     updateEmailAddress(
       {
         email: accountEmail,
-        extraEmail: selectedEmail,
+        extraEmail: oldEmail,
         newExtraEmail: newEmail,
       },
       {
         onSuccess: () => {
           setShowEditEmail(false)
           setSelectedEmail(newEmail)
+          // If the renamed address was the default, update to the new address.
+          if (oldEmail === defaultDest) {
+            saveDefaultDest(newEmail)
+            setDefaultDest(newEmail)
+          }
         },
         onError: () => {
           toast.error('Failed to update email address. Please try again.')
@@ -525,12 +549,18 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
   const handleDeleteAddress = () => {
     if (!confirm(`Remove ${selectedEmail} from your notification addresses?`))
       return
+    const deletedEmail = selectedEmail
     deleteEmailAddress(
-      { email: accountEmail, extraEmail: selectedEmail },
+      { email: accountEmail, extraEmail: deletedEmail },
       {
         onSuccess: () => {
           setShowEditEmail(false)
           setSelectedEmail(accountEmail)
+          // If the deleted address was the stored default, revert to account email.
+          if (deletedEmail === defaultDest) {
+            saveDefaultDest(accountEmail)
+            setDefaultDest(accountEmail)
+          }
         },
         onError: () => {
           toast.error('Failed to remove email address. Please try again.')
@@ -605,8 +635,10 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
             >
               <span className="truncate">
                 {selectedEmail || '—'}
-                {selectedEmail === accountEmail ? (
-                  <span className="ml-1 text-stone-400">(primary)</span>
+                {selectedEmail === defaultDest ? (
+                  <span className="ml-1 text-teal-600 font-medium">
+                    (Default)
+                  </span>
                 ) : null}
               </span>
               <svg
@@ -660,9 +692,9 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
                       <span className="mr-1 text-primary-500">›</span>
                     )}
                     {e}
-                    {e === accountEmail && (
-                      <span className="ml-1 text-xs font-normal text-stone-400">
-                        (primary)
+                    {e === defaultDest && (
+                      <span className="ml-1 text-xs font-medium text-teal-600">
+                        (Default)
                       </span>
                     )}
                   </li>
@@ -708,24 +740,21 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
           </Tippy>
 
           {/* Make Default checkbox — shown for all destinations.
-              Saves to localStorage immediately on click (no Save button needed).
+              Saves the specific address to localStorage immediately on click.
               stopPropagation prevents the click from bubbling to the modal
-              backdrop overlay. Checked+disabled when already the default. */}
+              backdrop overlay. Checked+disabled when this address is already
+              the stored default. */}
           {(() => {
-            const selType = isPhoneNumber(selectedEmail ?? '')
-              ? 'phone'
-              : 'email'
-            const isAlreadyDefault = defaultDestType === selType
+            const isAlreadyDefault = selectedEmail === defaultDest
+            const destLabel = isPhoneNumber(selectedEmail ?? '')
+              ? 'phone number'
+              : 'email address'
             return (
               <Tippy
                 content={
                   isAlreadyDefault
-                    ? `${
-                        selType === 'phone' ? 'Phone number' : 'Email'
-                      } is already your default — no action needed`
-                    : `Click to save ${
-                        selType === 'phone' ? 'phone number' : 'email'
-                      } as your default destination type`
+                    ? `This ${destLabel} is already your default`
+                    : `Set this ${destLabel} as your default notification destination`
                 }
                 placement="top"
               >
@@ -740,8 +769,10 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
                     onClick={(e) => e.stopPropagation()}
                     onChange={(e) => {
                       e.stopPropagation()
-                      saveDefaultDestType(selType)
-                      setDefaultDestType(selType)
+                      if (selectedEmail) {
+                        saveDefaultDest(selectedEmail)
+                        setDefaultDest(selectedEmail)
+                      }
                     }}
                     className="accent-teal-600 disabled:cursor-default"
                   />

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -45,6 +45,10 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
 
   const [selectedEmail, setSelectedEmail] = useState<string>('')
 
+  // Tracks which specific address the user has stored as their default.
+  // Declared here so allEmails can use it as a dependency for sorting.
+  const [defaultDest, setDefaultDest] = useState<string | null>(getDefaultDest)
+
   const allEmails: string[] = useMemo(() => {
     const base = addressesData?.result
       ? Object.keys(addressesData.result).sort()
@@ -57,13 +61,15 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       selectedEmail && !base.includes(selectedEmail)
         ? [...base, selectedEmail].sort()
         : base
-    // Sort so the stored default address appears first.
-    const storedDefault = getDefaultDest()
-    if (storedDefault && withSelected.includes(storedDefault)) {
-      return [storedDefault, ...withSelected.filter((e) => e !== storedDefault)]
+    // Sort so the default address always appears first in the dropdown.
+    // Uses the `defaultDest` state variable so the list re-sorts immediately
+    // whenever the user clicks "Make default" — no page reload required.
+    if (defaultDest && withSelected.includes(defaultDest)) {
+      return [defaultDest, ...withSelected.filter((e) => e !== defaultDest)]
     }
     return withSelected
-  }, [addressesData, accountEmail, selectedEmail])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [addressesData, accountEmail, selectedEmail, defaultDest])
 
   // Default to account email once the list loads. If no default has been stored
   // in localStorage yet, treat the account email as the implicit default so
@@ -311,8 +317,6 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
     'idle' | 'success' | 'error'
   >('idle')
   const [sendTestMessage, setSendTestMessage] = useState<string>('')
-  // Tracks which specific address is the user's stored default destination.
-  const [defaultDest, setDefaultDest] = useState<string | null>(getDefaultDest)
 
   // Clear test-email feedback whenever the selected address changes so stale
   // success/error messages from a previous address don't linger.

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -71,17 +71,28 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addressesData, accountEmail, selectedEmail, defaultDest])
 
-  // Default to account email once the list loads. If no default has been stored
-  // in localStorage yet, treat the account email as the implicit default so
-  // the Make Default checkbox shows as checked on first open.
+  // On first open, pre-select the stored default destination (or fall back to
+  // the account email). We do this immediately so the settings panel starts
+  // loading the right data right away.
   useEffect(() => {
-    if (!selectedEmail && accountEmail) {
-      setSelectedEmail(accountEmail)
-    }
-    if (!getDefaultDest() && accountEmail) {
+    if (selectedEmail || !accountEmail) return
+    const storedDefault = getDefaultDest()
+    setSelectedEmail(storedDefault ?? accountEmail)
+    if (!storedDefault) {
+      // Nothing stored yet — treat the account email as the implicit default.
       setDefaultDest(accountEmail)
     }
   }, [accountEmail, selectedEmail])
+
+  // Once the address list loads, verify the selection is still valid.
+  // If the stored default was deleted externally, fall back to account email.
+  useEffect(() => {
+    if (!addressesData || !accountEmail || !selectedEmail) return
+    const validAddresses = Object.keys(addressesData.result)
+    if (!validAddresses.includes(selectedEmail)) {
+      setSelectedEmail(accountEmail)
+    }
+  }, [addressesData, accountEmail, selectedEmail])
 
   const isExtraEmail = selectedEmail !== '' && selectedEmail !== accountEmail
 
@@ -221,6 +232,46 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       return prev
     })
   }, [toUiFilteredRows])
+
+  // True whenever the current notification settings differ from what was last
+  // loaded from the server. Used to gate the Save button so it's only enabled
+  // when there is actually something new to save.
+  const hasChanges = useMemo(() => {
+    if (plainText !== initialPlainText) return true
+    for (const name of vehicleNames) {
+      if (
+        Boolean(vehiclesEnabled[name]) !== Boolean(initialVehiclesEnabled[name])
+      )
+        return true
+    }
+    const initialRows = toUiFilteredRows()
+    if (filteredRows.length !== initialRows.length) return true
+    for (let i = 0; i < filteredRows.length; i += 1) {
+      const a = filteredRows[i]
+      const b = initialRows[i]
+      if (
+        a.eventKindName !== b.eventKindName ||
+        a.textFilter !== b.textFilter ||
+        a.filteringType !== b.filteringType
+      )
+        return true
+      for (const name of vehicleNames) {
+        if (
+          Boolean(a.vehiclesChecked[name]) !== Boolean(b.vehiclesChecked[name])
+        )
+          return true
+      }
+    }
+    return false
+  }, [
+    plainText,
+    initialPlainText,
+    vehiclesEnabled,
+    initialVehiclesEnabled,
+    filteredRows,
+    toUiFilteredRows,
+    vehicleNames,
+  ])
 
   // ── mutations ────────────────────────────────────────────────────────────
   const { mutate: saveSettings, isLoading: isSaving } = useUpdateEmailSettings()
@@ -604,7 +655,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       style={{ minWidth: 800 }}
       onConfirm={handleSave}
       confirmButtonText="Save"
-      disableConfirm={isBusy}
+      disableConfirm={isBusy || !hasChanges}
       onCancel={onClose}
       cancelButtonText="Close"
       extraButtons={[

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -700,37 +700,41 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
           </Tippy>
         </section>
 
-        {/* ── Plain text + test email row ── */}
+        {/* ── Plain text + test send row ── */}
         <section className="flex items-center justify-between pb-4">
           <div className="flex items-center gap-2">
-            <span id="plain-text-label" className="text-sm font-medium">
-              Send emails as plain text
-            </span>
-            {/* Toggle slider */}
-            <button
-              role="switch"
-              aria-labelledby="plain-text-label"
-              aria-checked={plainText}
-              disabled={isDataLoading}
-              onClick={() => setPlainText((v) => !v)}
-              className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 ${
-                plainText ? 'bg-primary-600' : 'bg-stone-300'
-              }`}
-            >
-              <span className="sr-only">{plainText ? 'On' : 'Off'}</span>
-              <span
-                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                  plainText ? 'translate-x-5' : 'translate-x-0'
-                }`}
-              />
-            </button>
-            <span
-              className={`text-xs font-semibold ${
-                plainText ? 'text-primary-600' : 'text-stone-400'
-              }`}
-            >
-              {plainText ? 'On' : 'Off'}
-            </span>
+            {!isPhoneNumber(selectedEmail) && (
+              <>
+                <span id="plain-text-label" className="text-sm font-medium">
+                  Send emails as plain text
+                </span>
+                {/* Toggle slider */}
+                <button
+                  role="switch"
+                  aria-labelledby="plain-text-label"
+                  aria-checked={plainText}
+                  disabled={isDataLoading}
+                  onClick={() => setPlainText((v) => !v)}
+                  className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50 ${
+                    plainText ? 'bg-primary-600' : 'bg-stone-300'
+                  }`}
+                >
+                  <span className="sr-only">{plainText ? 'On' : 'Off'}</span>
+                  <span
+                    className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                      plainText ? 'translate-x-5' : 'translate-x-0'
+                    }`}
+                  />
+                </button>
+                <span
+                  className={`text-xs font-semibold ${
+                    plainText ? 'text-primary-600' : 'text-stone-400'
+                  }`}
+                >
+                  {plainText ? 'On' : 'Off'}
+                </span>
+              </>
+            )}
           </div>
           <div className="flex items-center gap-2">
             {sendTestStatus === 'success' && (

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -693,7 +693,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
           <div ref={dropdownRef} className="relative">
             <button
               ref={triggerRef}
-              aria-label="Select notification email address"
+              aria-label="Select notification destination"
               className="flex min-w-[220px] items-center justify-between gap-2 rounded border border-stone-300 bg-white px-3 py-1 text-sm transition-colors hover:border-primary-400 hover:bg-blue-50 active:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-50"
               onClick={() => (dropdownOpen ? closeDropdown() : openDropdown())}
               onKeyDown={handleTriggerKeyDown}
@@ -730,7 +730,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
                 ref={listboxRef}
                 id="email-selector-listbox"
                 role="listbox"
-                aria-label="Notification email address"
+                aria-label="Notification destination"
                 tabIndex={-1}
                 aria-activedescendant={
                   focusedIdx >= 0 ? `email-option-${focusedIdx}` : undefined
@@ -787,7 +787,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
                 className="flex h-7 w-7 items-center justify-center rounded-full border border-stone-300 bg-white text-stone-500 transition-colors hover:border-primary-500 hover:bg-blue-100 hover:text-primary-600 active:bg-blue-200 disabled:cursor-not-allowed disabled:opacity-40"
                 onClick={() => isExtraEmail && setShowEditEmail(true)}
                 disabled={isBusy || !isExtraEmail}
-                aria-label="Edit address"
+                aria-label="Edit destination"
               >
                 <FontAwesomeIcon icon={faPencil} className="text-xs" />
               </button>

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -22,6 +22,7 @@ import FilteredNotificationEditModal from './FilteredNotificationEditModal'
 import AddEmailDialog from './AddEmailDialog'
 import EditEmailDialog from './EditEmailDialog'
 import { FilterRowUi, FilteringType } from '../types'
+import { isPhoneNumber } from '../lib/notificationDestinations'
 
 export interface EmailNotificationsModalProps {
   onClose?: () => void
@@ -432,15 +433,25 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       },
       {
         onSuccess: (data) => {
+          const isPhone = isPhoneNumber(selectedEmail ?? '')
           const msg = data?.email_sent
-            ? `Test email sent to ${data.email_sent}`
+            ? isPhone
+              ? `Test text message sent to ${data.email_sent}`
+              : `Test email sent to ${data.email_sent}`
+            : isPhone
+            ? 'Test text message sent'
             : 'Test email sent'
           setSendTestStatus('success')
           setSendTestMessage(msg)
         },
         onError: () => {
           setSendTestStatus('error')
-          setSendTestMessage('Could not send test email. Please try again.')
+          const isPhone = isPhoneNumber(selectedEmail ?? '')
+          setSendTestMessage(
+            isPhone
+              ? 'Could not send test text message. Please try again.'
+              : 'Could not send test email. Please try again.'
+          )
         },
       }
     )
@@ -721,7 +732,10 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
           <div className="flex items-center gap-2">
             {sendTestStatus === 'success' && (
               <span className="text-sm text-green-600">
-                {sendTestMessage || `Test email sent to ${selectedEmail}`}
+                {sendTestMessage ||
+                  (isPhoneNumber(selectedEmail ?? '')
+                    ? `Test text message sent to ${selectedEmail}`
+                    : `Test email sent to ${selectedEmail}`)}
               </span>
             )}
             {sendTestStatus === 'error' && (
@@ -730,7 +744,11 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
               </span>
             )}
             <Tippy
-              content={`Send a test email to ${selectedEmail}`}
+              content={
+                isPhoneNumber(selectedEmail ?? '')
+                  ? `Send a test text message to ${selectedEmail}`
+                  : `Send a test email to ${selectedEmail}`
+              }
               placement="top"
             >
               <span>
@@ -739,7 +757,11 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
                   onClick={handleSendTest}
                   disabled={isBusy}
                 >
-                  {isTesting ? 'Sending…' : 'Send test email'}
+                  {isTesting
+                    ? 'Sending…'
+                    : isPhoneNumber(selectedEmail ?? '')
+                    ? 'Send test text'
+                    : 'Send test email'}
                 </Button>
               </span>
             </Tippy>

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -538,7 +538,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
 
   return (
     <Modal
-      title={<span className="text-2xl font-bold">Email notifications</span>}
+      title={<span className="text-2xl font-bold">Notifications</span>}
       onClose={onClose}
       open
       grayHeader
@@ -654,7 +654,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
           <Tippy
             content={
               isExtraEmail
-                ? 'Edit or delete this address'
+                ? 'Edit or delete this destination'
                 : 'Primary email address cannot be edited here'
             }
             placement="top"
@@ -672,7 +672,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
           </Tippy>
 
           {/* Plus — add a new address. Wrapped in <span> so Tippy fires when disabled. */}
-          <Tippy content="Add a notification address" placement="top">
+          <Tippy content="Add a notification destination" placement="top">
             <span className="inline-flex">
               <button
                 className="flex h-7 w-7 items-center justify-center rounded-full border border-stone-300 bg-white text-stone-500 transition-colors hover:border-primary-500 hover:bg-blue-100 hover:text-primary-600 active:bg-blue-200 disabled:cursor-not-allowed disabled:opacity-40"

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -707,29 +707,37 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
             </span>
           </Tippy>
 
-          {/* Make Default checkbox — shown for extra destinations only */}
-          {isExtraEmail &&
-            (() => {
-              const selType = isPhoneNumber(selectedEmail ?? '')
-                ? 'phone'
-                : 'email'
-              const isAlreadyDefault = defaultDestType === selType
-              return (
-                <label className="ml-2 flex cursor-pointer items-center gap-1.5 text-xs text-stone-600">
-                  <input
-                    type="checkbox"
-                    checked={isAlreadyDefault}
-                    disabled={isAlreadyDefault || isBusy}
-                    onChange={() => {
-                      saveDefaultDestType(selType)
-                      setDefaultDestType(selType)
-                    }}
-                    className="accent-teal-600 disabled:cursor-default"
-                  />
-                  Make default
-                </label>
-              )
-            })()}
+          {/* Make Default checkbox — shown for extra destinations only.
+              stopPropagation on the label prevents the click from bubbling
+              to the modal overlay and accidentally closing the modal. */}
+          {isExtraEmail && (
+            <label
+              className="ml-2 flex cursor-pointer items-center gap-1.5 text-xs text-stone-600"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <input
+                type="checkbox"
+                checked={
+                  defaultDestType ===
+                  (isPhoneNumber(selectedEmail ?? '') ? 'phone' : 'email')
+                }
+                disabled={
+                  defaultDestType ===
+                    (isPhoneNumber(selectedEmail ?? '') ? 'phone' : 'email') ||
+                  isBusy
+                }
+                onChange={() => {
+                  const selType = isPhoneNumber(selectedEmail ?? '')
+                    ? 'phone'
+                    : 'email'
+                  saveDefaultDestType(selType)
+                  setDefaultDestType(selType)
+                }}
+                className="accent-teal-600 disabled:cursor-default"
+              />
+              Make default
+            </label>
+          )}
         </section>
 
         {/* ── Plain text + test send row ── */}

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -22,7 +22,11 @@ import FilteredNotificationEditModal from './FilteredNotificationEditModal'
 import AddEmailDialog from './AddEmailDialog'
 import EditEmailDialog from './EditEmailDialog'
 import { FilterRowUi, FilteringType } from '../types'
-import { isPhoneNumber } from '../lib/notificationDestinations'
+import {
+  isPhoneNumber,
+  getDefaultDestType,
+  saveDefaultDestType,
+} from '../lib/notificationDestinations'
 
 export interface EmailNotificationsModalProps {
   onClose?: () => void
@@ -296,6 +300,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
     'idle' | 'success' | 'error'
   >('idle')
   const [sendTestMessage, setSendTestMessage] = useState<string>('')
+  const [defaultDestType, setDefaultDestType] = useState(getDefaultDestType)
 
   // Clear test-email feedback whenever the selected address changes so stale
   // success/error messages from a previous address don't linger.
@@ -702,6 +707,36 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
             </span>
           </Tippy>
         </section>
+
+        {/* ── Make default row — only for extra destinations ── */}
+        {isExtraEmail && (
+          <section className="flex items-center gap-2 pb-3">
+            {(() => {
+              const selType = isPhoneNumber(selectedEmail ?? '')
+                ? 'phone'
+                : 'email'
+              const isAlreadyDefault = defaultDestType === selType
+              return isAlreadyDefault ? (
+                <span className="text-xs text-stone-400">
+                  {selType === 'phone' ? 'Phone number' : 'Email address'} is
+                  your default destination type
+                </span>
+              ) : (
+                <button
+                  className="text-xs text-teal-700 underline underline-offset-2 hover:text-teal-900 disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={isBusy}
+                  onClick={() => {
+                    saveDefaultDestType(selType)
+                    setDefaultDestType(selType)
+                  }}
+                >
+                  Make {selType === 'phone' ? 'phone number' : 'email address'}{' '}
+                  my default destination type
+                </button>
+              )
+            })()}
+          </section>
+        )}
 
         {/* ── Plain text + test send row ── */}
         <section className="flex items-center justify-between pb-4">

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -703,7 +703,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
         {/* ── Plain text + test send row ── */}
         <section className="flex items-center justify-between pb-4">
           <div className="flex items-center gap-2">
-            {!isPhoneNumber(selectedEmail) && (
+            {!isPhoneNumber(selectedEmail ?? '') && (
               <>
                 <span id="plain-text-label" className="text-sm font-medium">
                   Send emails as plain text

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -737,7 +737,9 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
                     type="checkbox"
                     checked={isAlreadyDefault}
                     disabled={isAlreadyDefault || isBusy}
-                    onChange={() => {
+                    onClick={(e) => e.stopPropagation()}
+                    onChange={(e) => {
+                      e.stopPropagation()
                       saveDefaultDestType(selType)
                       setDefaultDestType(selType)
                     }}

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -706,37 +706,31 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
               </button>
             </span>
           </Tippy>
-        </section>
 
-        {/* ── Make default row — only for extra destinations ── */}
-        {isExtraEmail && (
-          <section className="flex items-center gap-2 pb-3">
-            {(() => {
+          {/* Make Default checkbox — shown for extra destinations only */}
+          {isExtraEmail &&
+            (() => {
               const selType = isPhoneNumber(selectedEmail ?? '')
                 ? 'phone'
                 : 'email'
               const isAlreadyDefault = defaultDestType === selType
-              return isAlreadyDefault ? (
-                <span className="text-xs text-stone-400">
-                  {selType === 'phone' ? 'Phone number' : 'Email address'} is
-                  your default destination type
-                </span>
-              ) : (
-                <button
-                  className="text-xs text-teal-700 underline underline-offset-2 hover:text-teal-900 disabled:cursor-not-allowed disabled:opacity-50"
-                  disabled={isBusy}
-                  onClick={() => {
-                    saveDefaultDestType(selType)
-                    setDefaultDestType(selType)
-                  }}
-                >
-                  Make {selType === 'phone' ? 'phone number' : 'email address'}{' '}
-                  my default destination type
-                </button>
+              return (
+                <label className="ml-2 flex cursor-pointer items-center gap-1.5 text-xs text-stone-600">
+                  <input
+                    type="checkbox"
+                    checked={isAlreadyDefault}
+                    disabled={isAlreadyDefault || isBusy}
+                    onChange={() => {
+                      saveDefaultDestType(selType)
+                      setDefaultDestType(selType)
+                    }}
+                    className="accent-teal-600 disabled:cursor-default"
+                  />
+                  Make default
+                </label>
               )
             })()}
-          </section>
-        )}
+        </section>
 
         {/* ── Plain text + test send row ── */}
         <section className="flex items-center justify-between pb-4">

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -429,7 +429,10 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
     sendTest(
       {
         email: selectedEmail,
-        plainText: plainText ? 'y' : ('n' as 'y' | 'n'),
+        plainText:
+          isPhoneNumber(selectedEmail ?? '') || !plainText
+            ? ('n' as 'y' | 'n')
+            : 'y',
       },
       {
         onSuccess: (data) => {

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -73,14 +73,14 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
   // On first open, pre-select the stored default destination (or fall back to
   // the account email). We do this immediately so the settings panel starts
   // loading the right data right away.
+  // Also syncs defaultDest state from localStorage here to handle SSR
+  // hydration: the useState initialiser runs on the server where localStorage
+  // is unavailable (returns null), so the client must correct it on mount.
   useEffect(() => {
     if (selectedEmail || !accountEmail) return
     const storedDefault = getDefaultDest()
     setSelectedEmail(storedDefault ?? accountEmail)
-    if (!storedDefault) {
-      // Nothing stored yet — treat the account email as the implicit default.
-      setDefaultDest(accountEmail)
-    }
+    setDefaultDest(storedDefault ?? accountEmail)
   }, [accountEmail, selectedEmail])
 
   // Once the address list loads, verify the selection is still valid.

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -707,37 +707,47 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
             </span>
           </Tippy>
 
-          {/* Make Default checkbox — shown for extra destinations only.
-              stopPropagation on the label prevents the click from bubbling
-              to the modal overlay and accidentally closing the modal. */}
-          {isExtraEmail && (
-            <label
-              className="ml-2 flex cursor-pointer items-center gap-1.5 text-xs text-stone-600"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <input
-                type="checkbox"
-                checked={
-                  defaultDestType ===
-                  (isPhoneNumber(selectedEmail ?? '') ? 'phone' : 'email')
+          {/* Make Default checkbox — shown for all destinations.
+              Saves to localStorage immediately on click (no Save button needed).
+              stopPropagation prevents the click from bubbling to the modal
+              backdrop overlay. Checked+disabled when already the default. */}
+          {(() => {
+            const selType = isPhoneNumber(selectedEmail ?? '')
+              ? 'phone'
+              : 'email'
+            const isAlreadyDefault = defaultDestType === selType
+            return (
+              <Tippy
+                content={
+                  isAlreadyDefault
+                    ? `${
+                        selType === 'phone' ? 'Phone number' : 'Email'
+                      } is already your default — no action needed`
+                    : `Click to save ${
+                        selType === 'phone' ? 'phone number' : 'email'
+                      } as your default destination type`
                 }
-                disabled={
-                  defaultDestType ===
-                    (isPhoneNumber(selectedEmail ?? '') ? 'phone' : 'email') ||
-                  isBusy
-                }
-                onChange={() => {
-                  const selType = isPhoneNumber(selectedEmail ?? '')
-                    ? 'phone'
-                    : 'email'
-                  saveDefaultDestType(selType)
-                  setDefaultDestType(selType)
-                }}
-                className="accent-teal-600 disabled:cursor-default"
-              />
-              Make default
-            </label>
-          )}
+                placement="top"
+              >
+                <label
+                  className="ml-2 flex cursor-pointer items-center gap-1.5 text-xs text-stone-600"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isAlreadyDefault}
+                    disabled={isAlreadyDefault || isBusy}
+                    onChange={() => {
+                      saveDefaultDestType(selType)
+                      setDefaultDestType(selType)
+                    }}
+                    className="accent-teal-600 disabled:cursor-default"
+                  />
+                  Make default
+                </label>
+              </Tippy>
+            )
+          })()}
         </section>
 
         {/* ── Plain text + test send row ── */}

--- a/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
+++ b/apps/lrauv-dash2/components/EmailNotificationsModal.tsx
@@ -68,7 +68,6 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       return [defaultDest, ...withSelected.filter((e) => e !== defaultDest)]
     }
     return withSelected
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [addressesData, accountEmail, selectedEmail, defaultDest])
 
   // On first open, pre-select the stored default destination (or fall back to
@@ -479,10 +478,17 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
       vehiclesEnabled: vehiclesEnabledArray,
       notifLines,
     }
+    // Phone number destinations don't support plain-text toggling; always
+    // save as 'n' for SMS so the stored value stays consistent with test sends.
+    const effectivePlainText = isPhoneNumber(selectedEmail ?? '')
+      ? 'n'
+      : plainText
+      ? 'y'
+      : 'n'
     saveSettings(
       {
         email: selectedEmail,
-        plainText: plainText ? 'y' : 'n',
+        plainText: effectivePlainText,
         details,
       },
       {
@@ -570,7 +576,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
           }
         },
         onError: () => {
-          toast.error('Failed to add email address. Please try again.')
+          toast.error('Failed to add destination. Please try again.')
         },
       }
     )
@@ -595,14 +601,16 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
           }
         },
         onError: () => {
-          toast.error('Failed to update email address. Please try again.')
+          toast.error('Failed to update destination. Please try again.')
         },
       }
     )
   }
 
   const handleDeleteAddress = () => {
-    if (!confirm(`Remove ${selectedEmail} from your notification addresses?`))
+    if (
+      !confirm(`Remove ${selectedEmail} from your notification destinations?`)
+    )
       return
     const deletedEmail = selectedEmail
     deleteEmailAddress(
@@ -618,7 +626,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
           }
         },
         onError: () => {
-          toast.error('Failed to remove email address. Please try again.')
+          toast.error('Failed to remove destination. Please try again.')
         },
       }
     )
@@ -787,7 +795,7 @@ const EmailNotificationsModal: React.FC<EmailNotificationsModalProps> = ({
                 className="flex h-7 w-7 items-center justify-center rounded-full border border-stone-300 bg-white text-stone-500 transition-colors hover:border-primary-500 hover:bg-blue-100 hover:text-primary-600 active:bg-blue-200 disabled:cursor-not-allowed disabled:opacity-40"
                 onClick={() => setShowAddEmail(true)}
                 disabled={isBusy}
-                aria-label="Add address"
+                aria-label="Add destination"
               >
                 <FontAwesomeIcon icon={faPlus} className="text-xs" />
               </button>

--- a/apps/lrauv-dash2/components/Layout.tsx
+++ b/apps/lrauv-dash2/components/Layout.tsx
@@ -140,7 +140,7 @@ const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
                   onDismiss={dismissDropdown}
                   options={[
                     {
-                      label: 'Email notifications',
+                      label: 'Notifications',
                       onSelect: () => {
                         setGlobalModalId({ id: 'emailNotifications' })
                         dismissDropdown()

--- a/apps/lrauv-dash2/lib/notificationDestinations.test.ts
+++ b/apps/lrauv-dash2/lib/notificationDestinations.test.ts
@@ -1,0 +1,110 @@
+import {
+  isValidEmail,
+  normalizePhone,
+  isValidPhone,
+  isPhoneNumber,
+} from './notificationDestinations'
+
+describe('isValidEmail', () => {
+  it('accepts a standard email address', () => {
+    expect(isValidEmail('alerts@example.com')).toBe(true)
+  })
+
+  it('accepts an email with subdomains', () => {
+    expect(isValidEmail('user@mail.mbari.org')).toBe(true)
+  })
+
+  it('rejects an address with no @', () => {
+    expect(isValidEmail('notanemail')).toBe(false)
+  })
+
+  it('rejects an address with no domain', () => {
+    expect(isValidEmail('user@')).toBe(false)
+  })
+
+  it('rejects a bare phone number', () => {
+    expect(isValidEmail('+15551234567')).toBe(false)
+  })
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(isValidEmail('  user@example.com  ')).toBe(true)
+  })
+})
+
+describe('normalizePhone', () => {
+  it('strips spaces', () => {
+    expect(normalizePhone('+1 555 123 4567')).toBe('+15551234567')
+  })
+
+  it('strips dashes', () => {
+    expect(normalizePhone('+1-555-123-4567')).toBe('+15551234567')
+  })
+
+  it('strips parentheses and dots', () => {
+    expect(normalizePhone('+1 (555) 123.4567')).toBe('+15551234567')
+  })
+
+  it('leaves a clean E.164 number unchanged', () => {
+    expect(normalizePhone('+15551234567')).toBe('+15551234567')
+  })
+})
+
+describe('isValidPhone', () => {
+  it('accepts a valid US number with spaces', () => {
+    expect(isValidPhone('+1 555 123 4567')).toBe(true)
+  })
+
+  it('accepts a valid E.164 number without spaces', () => {
+    expect(isValidPhone('+15551234567')).toBe(true)
+  })
+
+  it('accepts a valid international number', () => {
+    expect(isValidPhone('+44 20 7946 0958')).toBe(true)
+  })
+
+  it('rejects a number with no leading +', () => {
+    expect(isValidPhone('15551234567')).toBe(false)
+  })
+
+  it('rejects a number with a leading zero after +', () => {
+    expect(isValidPhone('+05551234567')).toBe(false)
+  })
+
+  it('rejects a number that is too short (fewer than 7 digits after country code)', () => {
+    expect(isValidPhone('+1123')).toBe(false)
+  })
+
+  it('rejects a number that is too long (more than 15 digits total)', () => {
+    expect(isValidPhone('+1234567890123456')).toBe(false)
+  })
+
+  it('rejects an email address', () => {
+    expect(isValidPhone('alerts@example.com')).toBe(false)
+  })
+
+  it('rejects an email whose local-part starts with +', () => {
+    expect(isValidPhone('+user@example.com')).toBe(false)
+  })
+
+  it('trims surrounding whitespace before validating', () => {
+    expect(isValidPhone('  +15551234567  ')).toBe(true)
+  })
+})
+
+describe('isPhoneNumber', () => {
+  it('returns true for a valid phone number', () => {
+    expect(isPhoneNumber('+15551234567')).toBe(true)
+  })
+
+  it('returns false for an email address', () => {
+    expect(isPhoneNumber('alerts@example.com')).toBe(false)
+  })
+
+  it('returns false for an email whose local-part starts with +', () => {
+    expect(isPhoneNumber('+user@example.com')).toBe(false)
+  })
+
+  it('returns false for an empty string', () => {
+    expect(isPhoneNumber('')).toBe(false)
+  })
+})

--- a/apps/lrauv-dash2/lib/notificationDestinations.test.ts
+++ b/apps/lrauv-dash2/lib/notificationDestinations.test.ts
@@ -3,8 +3,9 @@ import {
   normalizePhone,
   isValidPhone,
   isPhoneNumber,
+  getDefaultDest,
+  saveDefaultDest,
   getDefaultDestType,
-  saveDefaultDestType,
 } from './notificationDestinations'
 
 describe('isValidEmail', () => {
@@ -93,27 +94,45 @@ describe('isValidPhone', () => {
   })
 })
 
-describe('getDefaultDestType / saveDefaultDestType', () => {
+describe('getDefaultDest / saveDefaultDest', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('returns null when nothing is stored', () => {
+    expect(getDefaultDest()).toBeNull()
+  })
+
+  it('returns the address after saving an email', () => {
+    saveDefaultDest('alerts@example.com')
+    expect(getDefaultDest()).toBe('alerts@example.com')
+  })
+
+  it('returns the address after saving a phone number', () => {
+    saveDefaultDest('+15551234567')
+    expect(getDefaultDest()).toBe('+15551234567')
+  })
+
+  it('overwrites a previous default when saved again', () => {
+    saveDefaultDest('first@example.com')
+    saveDefaultDest('second@example.com')
+    expect(getDefaultDest()).toBe('second@example.com')
+  })
+})
+
+describe('getDefaultDestType', () => {
   beforeEach(() => localStorage.clear())
 
   it('returns "email" when nothing is stored', () => {
     expect(getDefaultDestType()).toBe('email')
   })
 
-  it('returns the stored type after saving "phone"', () => {
-    saveDefaultDestType('phone')
+  it('returns "email" when a stored address is an email', () => {
+    saveDefaultDest('alerts@example.com')
+    expect(getDefaultDestType()).toBe('email')
+  })
+
+  it('returns "phone" when a stored address is a valid phone number', () => {
+    saveDefaultDest('+15551234567')
     expect(getDefaultDestType()).toBe('phone')
-  })
-
-  it('returns the stored type after saving "email"', () => {
-    saveDefaultDestType('phone')
-    saveDefaultDestType('email')
-    expect(getDefaultDestType()).toBe('email')
-  })
-
-  it('falls back to "email" when an unknown value is in storage', () => {
-    localStorage.setItem('notification:defaultDestType', 'fax')
-    expect(getDefaultDestType()).toBe('email')
   })
 })
 

--- a/apps/lrauv-dash2/lib/notificationDestinations.test.ts
+++ b/apps/lrauv-dash2/lib/notificationDestinations.test.ts
@@ -70,11 +70,11 @@ describe('isValidPhone', () => {
     expect(isValidPhone('+05551234567')).toBe(false)
   })
 
-  it('rejects a number that is too short (fewer than 7 digits after country code)', () => {
+  it('rejects a number that is too short (fewer than 7 digits total after +)', () => {
     expect(isValidPhone('+1123')).toBe(false)
   })
 
-  it('rejects a number that is too long (more than 15 digits total)', () => {
+  it('rejects a number that is too long (more than 15 digits total after +)', () => {
     expect(isValidPhone('+1234567890123456')).toBe(false)
   })
 

--- a/apps/lrauv-dash2/lib/notificationDestinations.test.ts
+++ b/apps/lrauv-dash2/lib/notificationDestinations.test.ts
@@ -3,6 +3,8 @@ import {
   normalizePhone,
   isValidPhone,
   isPhoneNumber,
+  getDefaultDestType,
+  saveDefaultDestType,
 } from './notificationDestinations'
 
 describe('isValidEmail', () => {
@@ -88,6 +90,30 @@ describe('isValidPhone', () => {
 
   it('trims surrounding whitespace before validating', () => {
     expect(isValidPhone('  +15551234567  ')).toBe(true)
+  })
+})
+
+describe('getDefaultDestType / saveDefaultDestType', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('returns "email" when nothing is stored', () => {
+    expect(getDefaultDestType()).toBe('email')
+  })
+
+  it('returns the stored type after saving "phone"', () => {
+    saveDefaultDestType('phone')
+    expect(getDefaultDestType()).toBe('phone')
+  })
+
+  it('returns the stored type after saving "email"', () => {
+    saveDefaultDestType('phone')
+    saveDefaultDestType('email')
+    expect(getDefaultDestType()).toBe('email')
+  })
+
+  it('falls back to "email" when an unknown value is in storage', () => {
+    localStorage.setItem('notification:defaultDestType', 'fax')
+    expect(getDefaultDestType()).toBe('email')
   })
 })
 

--- a/apps/lrauv-dash2/lib/notificationDestinations.ts
+++ b/apps/lrauv-dash2/lib/notificationDestinations.ts
@@ -1,24 +1,36 @@
 export type DestinationType = 'email' | 'phone'
 
-const DEST_TYPE_KEY = 'notification:defaultDestType'
+// Stores the specific destination address the user has chosen as their
+// default (e.g. '+15551234567' or 'alerts@example.com').
+const DEST_KEY = 'notification:defaultDest'
 
-export const getDefaultDestType = (): DestinationType => {
+/** Returns the stored default destination address, or null if none is set. */
+export const getDefaultDest = (): string | null => {
   try {
-    const stored =
-      typeof window !== 'undefined' ? localStorage.getItem(DEST_TYPE_KEY) : null
-    if (stored === 'email' || stored === 'phone') return stored
+    return typeof window !== 'undefined' ? localStorage.getItem(DEST_KEY) : null
   } catch {
     // localStorage unavailable (SSR, private browsing)
+    return null
   }
-  return 'email'
 }
 
-export const saveDefaultDestType = (type: DestinationType) => {
+/** Saves the given address as the user's default notification destination. */
+export const saveDefaultDest = (address: string) => {
   try {
-    localStorage.setItem(DEST_TYPE_KEY, type)
+    localStorage.setItem(DEST_KEY, address)
   } catch {
     // ignore storage failures
   }
+}
+
+/**
+ * Returns the DestinationType of the stored default destination.
+ * Used to pre-select the radio in AddEmailDialog.
+ * Falls back to 'email' when nothing is stored.
+ */
+export const getDefaultDestType = (): DestinationType => {
+  const dest = getDefaultDest()
+  return dest && isPhoneNumber(dest) ? 'phone' : 'email'
 }
 
 export const isValidEmail = (value: string) =>

--- a/apps/lrauv-dash2/lib/notificationDestinations.ts
+++ b/apps/lrauv-dash2/lib/notificationDestinations.ts
@@ -10,7 +10,7 @@ export const normalizePhone = (value: string) => value.replace(/[\s\-().]/g, '')
 export const isValidPhone = (value: string) =>
   /^\+[1-9]\d{6,14}$/.test(normalizePhone(value.trim()))
 
-export const isPhoneNumber = (value: string) => value.trim().startsWith('+')
+export const isPhoneNumber = (value: string) => isValidPhone(value)
 
 export const SMS_CONSENT =
   'By adding a phone number you opt in to SMS alerts for the vehicles you select. Message & data rates may apply. Opt out anytime by removing the number here, or reply STOP. Replying STOP stops messages but does not remove the number from TethysDash.'

--- a/apps/lrauv-dash2/lib/notificationDestinations.ts
+++ b/apps/lrauv-dash2/lib/notificationDestinations.ts
@@ -1,0 +1,16 @@
+export type DestinationType = 'email' | 'phone'
+
+export const isValidEmail = (value: string) =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
+
+// Strips spaces, dashes, dots, and parentheses before validating/saving,
+// e.g. "+1 555 123 4567" → "+15551234567" (E.164-style).
+export const normalizePhone = (value: string) => value.replace(/[\s\-().]/g, '')
+
+export const isValidPhone = (value: string) =>
+  /^\+[1-9]\d{6,14}$/.test(normalizePhone(value.trim()))
+
+export const isPhoneNumber = (value: string) => value.trim().startsWith('+')
+
+export const SMS_CONSENT =
+  'By adding a phone number you opt in to SMS alerts for the vehicles you select. Message & data rates may apply. Opt out anytime by removing the number here, or reply STOP. Replying STOP stops messages but does not remove the number from TethysDash.'

--- a/apps/lrauv-dash2/lib/notificationDestinations.ts
+++ b/apps/lrauv-dash2/lib/notificationDestinations.ts
@@ -1,5 +1,26 @@
 export type DestinationType = 'email' | 'phone'
 
+const DEST_TYPE_KEY = 'notification:defaultDestType'
+
+export const getDefaultDestType = (): DestinationType => {
+  try {
+    const stored =
+      typeof window !== 'undefined' ? localStorage.getItem(DEST_TYPE_KEY) : null
+    if (stored === 'email' || stored === 'phone') return stored
+  } catch {
+    // localStorage unavailable (SSR, private browsing)
+  }
+  return 'email'
+}
+
+export const saveDefaultDestType = (type: DestinationType) => {
+  try {
+    localStorage.setItem(DEST_TYPE_KEY, type)
+  } catch {
+    // ignore storage failures
+  }
+}
+
 export const isValidEmail = (value: string) =>
   /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim())
 

--- a/docs/developer-onboarding.md
+++ b/docs/developer-onboarding.md
@@ -199,28 +199,35 @@ For starter issues (see below), all your edits will be inside `apps/lrauv-dash2/
 ### Unit / component tests (Jest)
 
 ```bash
-# All packages
-yarn test
-
-# Single package
+# All packages that have Jest tests (react-ui, api-client, utils, lrauv-dash2)
 yarn workspace @mbari/react-ui test
+yarn workspace @mbari/api-client test
+yarn workspace @mbari/lrauv-dash2 test:ci
 
-# Single test file
-yarn workspace @mbari/lrauv-dash2 test:ci -- --testPathPattern=CommsSection
+# Single test file in the app
+yarn workspace @mbari/lrauv-dash2 test:ci -- --testPathPattern=notificationDestinations
 ```
+
+> **Note:** `yarn test` at the repo root runs `turbo run test`, which includes Playwright
+> for the app. Use the workspace `test:ci` command above when you only want Jest.
 
 ### End-to-end tests (Playwright)
 
 ```bash
 cd apps/lrauv-dash2
-yarn test         # runs Playwright tests (requires the dev server to be running)
+yarn test         # Playwright is pre-configured with a webServer; no need to start the dev server manually
 ```
 
 ### Linting
 
 ```bash
-yarn lint               # lint and auto-fix all packages
-yarn lint:watch         # live lint on save (useful during development)
+# Lint shared packages (react-ui, api-client, utils)
+yarn lint               # lint and auto-fix
+yarn lint:watch         # live lint on save
+
+# Lint the Next.js app separately (root lint does not cover apps/)
+cd apps/lrauv-dash2
+yarn lint
 ```
 
 ---

--- a/docs/developer-onboarding.md
+++ b/docs/developer-onboarding.md
@@ -1,0 +1,276 @@
+# Dash 5 — New Developer Onboarding Guide
+
+This document will get you from zero to a running local dev environment and give you enough context to start contributing to Dash 5 confidently.
+
+---
+
+## Table of Contents
+
+1. [What is Dash 5?](#what-is-dash-5)
+2. [Prerequisites](#prerequisites)
+3. [Clone and Install](#clone-and-install)
+4. [Project Structure](#project-structure)
+5. [Running the Dev Server](#running-the-dev-server)
+6. [Making Changes — The Critical "Rebuild" Rule](#making-changes--the-critical-rebuild-rule)
+7. [Running Tests](#running-tests)
+8. [Code Style and Conventions](#code-style-and-conventions)
+9. [Branching and Pull Request Workflow](#branching-and-pull-request-workflow)
+10. [Who to Ask](#who-to-ask)
+
+---
+
+## What is Dash 5?
+
+Dash 5 is the fifth-generation operator dashboard for MBARI's **LRAUV** (Long-Range Autonomous Underwater Vehicle) fleet. It is a React + Next.js web application that gives engineers real-time situational awareness of deployed vehicles: their location, depth, science data, mission schedules, notifications, and more.
+
+The repo is a **Yarn monorepo** managed with [Turborepo](https://turbo.build/repo). It contains:
+
+| Path                   | What it is                                                        |
+| ---------------------- | ----------------------------------------------------------------- |
+| `apps/lrauv-dash2/`    | The main Next.js application (the actual dashboard UI)            |
+| `packages/react-ui/`   | Shared React component library (Storybook-documented)             |
+| `packages/api-client/` | Typed Axios + React Query wrappers for the TethysDash backend API |
+| `packages/utils/`      | Common helpers shared across packages                             |
+
+---
+
+## Prerequisites
+
+You need the following tools installed before you can run the project.
+
+### Node.js — version 20.x
+
+The project requires **Node 20**. We strongly recommend managing Node versions with [nvm](https://github.com/nvm-sh/nvm):
+
+```bash
+# Install nvm (skip if already installed)
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+
+# Reload your shell, then:
+nvm install 20
+nvm use 20
+nvm alias default 20
+
+# Confirm
+node --version   # should print v20.x.x
+```
+
+### Yarn — version 1.22.x
+
+```bash
+npm install -g yarn@1.22
+yarn --version   # should print 1.22.x
+```
+
+### Git
+
+Make sure you have Git configured with your GitHub credentials (SSH key or HTTPS token) and that you have access to the `mbari-org/dash5` repository.
+
+---
+
+## Clone and Install
+
+```bash
+# Clone the repo (use SSH if you have a key set up)
+git clone git@github.com:mbari-org/dash5.git
+cd dash5
+
+# Install all workspace dependencies (this takes ~1–2 minutes the first time)
+yarn install
+```
+
+`yarn install` installs dependencies for every package in the monorepo in one pass. You do **not** need to `cd` into individual packages and run install separately.
+
+---
+
+## Project Structure
+
+```
+dash5/
+├── apps/
+│   └── lrauv-dash2/           # Next.js app
+│       ├── components/        # App-level React components and context providers
+│       ├── lib/               # Custom hooks, utilities, and helpers
+│       ├── pages/             # Next.js file-based routes
+│       │   ├── index.tsx      # Overview map (home page)
+│       │   └── vehicle/       # Per-vehicle deployment views
+│       └── styles/            # Global CSS
+├── packages/
+│   ├── react-ui/
+│   │   └── src/               # Shared component library
+│   │       ├── Cells/         # Small display units
+│   │       ├── Charts/
+│   │       ├── Forms/
+│   │       ├── Map/           # Leaflet/map components
+│   │       ├── Modal/         # Base modal primitives
+│   │       ├── Modals/        # Domain-specific modal components
+│   │       ├── Tables/
+│   │       └── ...
+│   ├── api-client/
+│   │   └── src/
+│   │       ├── axios/         # Raw Axios request functions
+│   │       └── react-query/   # React Query hooks wrapping the Axios calls
+│   └── utils/
+│       └── src/               # Pure helper functions (date, string, logging, etc.)
+├── docs/                      # Developer documentation (you are here)
+├── CLAUDE.md                  # AI assistant instructions — useful reading for conventions
+└── README.md                  # Quick-start overview
+```
+
+### Key files to know
+
+| File                                                     | Role                                            |
+| -------------------------------------------------------- | ----------------------------------------------- |
+| `apps/lrauv-dash2/pages/_app.tsx`                        | App entry point — providers, global layout      |
+| `apps/lrauv-dash2/components/Layout.tsx`                 | Main shell: nav, sidebar, modal triggers        |
+| `apps/lrauv-dash2/components/SelectedStationContext.tsx` | React context for map station selection state   |
+| `packages/react-ui/src/index.ts`                         | Public exports for the component library        |
+| `packages/api-client/src/index.ts`                       | Public exports for the API client               |
+| `CLAUDE.md`                                              | Project coding conventions — good early reading |
+
+---
+
+## Running the Dev Server
+
+### 1. Build the packages first
+
+The `react-ui` and `api-client` packages use pre-built `dist/` output — the Next.js app imports the **compiled** files, not the TypeScript sources. You must build them before starting the dev server (and again after any change to those packages).
+
+```bash
+# From the repo root — build both shared packages
+yarn workspace @mbari/react-ui build
+yarn workspace @mbari/api-client build
+```
+
+### 2. Start the dev server
+
+```bash
+cd apps/lrauv-dash2
+yarn dev
+```
+
+This starts two processes on the same terminal:
+
+- **Next.js dev server** on `http://localhost:3000`
+- **API proxy** on `http://localhost:3002` (forwards requests to the TethysDash backend)
+
+Wait until the terminal prints:
+
+```
+✓ Ready in Xs
+```
+
+Then open `http://localhost:3000` in your browser.
+
+> **Note:** The app proxies API calls to the TethysDash staging server. Ask Karen or the team for the correct `.env.local` file if the app shows connection errors on startup.
+
+---
+
+## Making Changes — The Critical "Rebuild" Rule
+
+This is the most important thing to understand about the local dev loop.
+
+**If you only edit files in `apps/lrauv-dash2/`**, Next.js hot-module reload (HMR) will pick up your changes automatically. You do not need to restart anything.
+
+**If you edit files in `packages/react-ui/` or `packages/api-client/`**, you **must** rebuild those packages and restart the dev server before your changes appear. The browser will silently serve stale compiled output otherwise — even after a hard refresh.
+
+Full refresh cycle after editing a shared package:
+
+```bash
+# From the repo root:
+yarn workspace @mbari/react-ui build
+yarn workspace @mbari/api-client build
+
+# Free the dev server ports
+lsof -ti :3000 | xargs kill -9 2>/dev/null
+lsof -ti :3002 | xargs kill -9 2>/dev/null
+
+# Clear Next.js cache and restart
+rm -rf apps/lrauv-dash2/.next
+cd apps/lrauv-dash2 && yarn dev
+```
+
+For starter issues (see below), all your edits will be inside `apps/lrauv-dash2/`, so you will mostly benefit from HMR and won't need the full cycle.
+
+---
+
+## Running Tests
+
+### Unit / component tests (Jest)
+
+```bash
+# All packages
+yarn test
+
+# Single package
+yarn workspace @mbari/react-ui test
+
+# Single test file
+yarn workspace @mbari/lrauv-dash2 test:ci -- --testPathPattern=CommsSection
+```
+
+### End-to-end tests (Playwright)
+
+```bash
+cd apps/lrauv-dash2
+yarn test         # runs Playwright tests (requires the dev server to be running)
+```
+
+### Linting
+
+```bash
+yarn lint               # lint and auto-fix all packages
+yarn lint:watch         # live lint on save (useful during development)
+```
+
+---
+
+## Code Style and Conventions
+
+A few things to internalize early:
+
+- **TypeScript everywhere.** All files are `.ts` or `.tsx`. Type all props, return values, hook signatures, and API shapes explicitly.
+- **2-space indentation, single quotes, no semicolons.** The linter (ESLint + Prettier) will enforce this automatically.
+- **Functional components only.** No class components. Use hooks (`useState`, `useCallback`, `useMemo`, `useContext`, etc.).
+- **Import order:** React → third-party libraries → local modules. Group by blank lines.
+- **Test file naming:** `ComponentName.test.tsx`, living alongside the component file.
+- **Avoid obvious comments.** Comments should explain _why_, not _what_. Don't narrate the code.
+- **Error handling:** use `try/catch` or the project's `tryCatch` helper from `@mbari/utils`.
+
+---
+
+## Branching and Pull Request Workflow
+
+1. **Always branch off `develop`**, not `main`.
+
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b feat/your-feature-name
+```
+
+2. **Commit messages** are conventional: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, etc.
+
+3. **Open a PR against `develop`**.
+
+4. **All PRs need Karen's review and approval before merge.** Do not merge your own PR. Ping Karen when it's ready for review — she'll take a look and may have feedback or want to discuss the change before it goes in.
+
+5. Deployment is automatic:
+   - Merges to `develop` → staging environment (automatic via Watchtower)
+   - Merges to `main` → production (manual deploy step)
+
+---
+
+## Who to Ask
+
+| Person    | Role                               | Best for                                                                                 |
+| --------- | ---------------------------------- | ---------------------------------------------------------------------------------------- |
+| **Karen** | Dash 5 lead — your primary contact | Code reviews, architecture decisions, PR merges, "is this the right approach?" questions |
+| **Quinn** | LRAUV software engineering lead    | Operational context, what features matter most to operators                              |
+| **Zack**  | Contributor, past PR reviewer      | Has reviewed most recent PRs; good for "what did we do in PR #X?" questions              |
+
+Don't hesitate to ask questions early and often. The codebase has some accumulated complexity and the team would rather answer a question upfront than have you go down a wrong path for a day.
+
+---
+
+_Last updated: June 2026_

--- a/docs/developer-onboarding.md
+++ b/docs/developer-onboarding.md
@@ -134,10 +134,15 @@ dash5/
 
 ### 1. Build the packages first
 
-The `react-ui` and `api-client` packages use pre-built `dist/` output — the Next.js app imports the **compiled** files, not the TypeScript sources. You must build them before starting the dev server (and again after any change to those packages).
+The two shared packages behave differently at the webpack level:
+
+- **`@mbari/react-ui`** — `"main"` points to `src/index.ts` and Next.js has `transpilePackages` configured, so source edits are picked up by HMR without a rebuild.
+- **`@mbari/api-client`** — has an `"exports"` field that points webpack to pre-built `dist/` files. Changes here **require a rebuild** before the app reflects them.
+
+As a safe default, build both before starting the dev server for the first time:
 
 ```bash
-# From the repo root — build both shared packages
+# From the repo root
 yarn workspace @mbari/react-ui build
 yarn workspace @mbari/api-client build
 ```
@@ -170,9 +175,11 @@ Then open `http://localhost:3000` in your browser.
 
 This is the most important thing to understand about the local dev loop.
 
-**If you only edit files in `apps/lrauv-dash2/`**, Next.js hot-module reload (HMR) will pick up your changes automatically. You do not need to restart anything.
+**If you only edit files in `apps/lrauv-dash2/`**, Next.js HMR will pick up your changes automatically. No restart needed.
 
-**If you edit files in `packages/react-ui/` or `packages/api-client/`**, you **must** rebuild those packages and restart the dev server before your changes appear. The browser will silently serve stale compiled output otherwise — even after a hard refresh.
+**If you edit `packages/react-ui/`**, HMR should also pick up changes automatically because `react-ui` exposes its TypeScript source via `"main"` and Next.js transpiles it directly.
+
+**If you edit `packages/api-client/`**, you **must** rebuild before changes appear. Its `"exports"` field points webpack to pre-built `dist/` files, so the browser will silently serve stale output otherwise — even after a hard refresh.
 
 Full refresh cycle after editing a shared package:
 


### PR DESCRIPTION
Closes #680

Brings dash5 to parity with dash4 v4.99.32 now that AWS SMS is in production (Carlos, Jun 15 2026).

## Changes

- **`lib/notificationDestinations.ts`** *(new)* — shared `DestinationType`, `isValidEmail`, `isValidPhone`, `normalizePhone`, `isPhoneNumber`, `getDefaultDest`, `saveDefaultDest`, `SMS_CONSENT`
- **`AddEmailDialog`** — radio buttons to choose Email address or Phone number; E.164 international format validation; SMS consent copy; phone number normalised before being sent to ENS API
- **`EditEmailDialog`** — auto-detects whether the saved value is a phone number and pre-selects the correct radio; delete button label reflects the type of the address being deleted (not the current radio selection)
- **`EmailNotificationsModal`**
  - Title → "Notifications"; tooltips/aria-labels updated to destination-neutral language
  - **Default destination** — user can click "Make default" next to any destination (email or phone); the choice is persisted to `localStorage` and that destination sorts to the top of the dropdown with a "(Default)" badge; reopening the modal pre-selects the stored default
  - **Save button does not close the modal** *(intentional)* — allows the user to make multiple changes in one session without reopening; only the Close button or X dismisses the modal
  - Save button is disabled until a notification setting actually differs from the last-loaded server state
  - Plain-text toggle is hidden and `plainText` is forced to `'n'` for phone number destinations (both on save and test send)
- **`Layout`** — profile menu label → "Notifications"

## Test plan
- [ ] Add a phone number (`+1 555 123 4567`) — verify it saves and appears in the list
- [ ] Add an invalid phone number — verify inline error appears
- [ ] Add a duplicate phone number — verify duplicate error appears
- [ ] Add an email address — verify existing flow is unchanged
- [ ] Open edit dialog for a saved phone number — verify Phone number radio is pre-selected and Delete button reads "Delete phone number"
- [ ] Open edit dialog for a saved email — verify Email address radio is pre-selected
- [ ] Use "Send test notification" to a phone number — verify SMS delivery end-to-end
- [ ] Select a phone number destination and click "Make default" — verify it sorts to the top with "(Default)" label
- [ ] Close and reopen the modal — verify it reopens on the stored default destination
- [ ] Click Save without making any changes — verify button is disabled
- [ ] Make a notification setting change — verify Save enables; click Save — verify modal stays open and a success toast appears
- [ ] Delete a phone number that is the current default — verify default reverts to account email
- [ ] Verify profile menu and modal title read "Notifications"