### PR TITLE
fix: remove double-slash from API URL defaults in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   NEXT_PUBLIC_API_HOST: ${{ vars.NEXT_PUBLIC_API_HOST || 'https://okeanids.mbari.org/' }}
-  NEXT_PUBLIC_BASE_URL: ${{ vars.NEXT_PUBLIC_BASE_URL || 'https://okeanids.mbari.org//TethysDash/api' }}
-  NEXT_PUBLIC_ODSS2BASE_URL: ${{ vars.NEXT_PUBLIC_ODSS2BASE_URL || 'http://okeanids.mbari.org//odss2dash/api' }}
+  NEXT_PUBLIC_BASE_URL: ${{ vars.NEXT_PUBLIC_BASE_URL || 'https://okeanids.mbari.org/TethysDash/api' }}
+  NEXT_PUBLIC_ODSS2BASE_URL: ${{ vars.NEXT_PUBLIC_ODSS2BASE_URL || 'https://okeanids.mbari.org/odss2dash/api' }}
   NEXT_PUBLIC_WEBSOCKET_URL: ${{ vars.NEXT_PUBLIC_WEBSOCKET_URL || 'wss://okeanids.mbari.org/ws/' }}
   NEXT_PUBLIC_GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY || 'placeholder-api-key' }}
   NEXT_PUBLIC_ESRI_API_KEY: ${{ secrets.ESRI_API_KEY || secrets.REACT_APP_ESRI_API_KEY || 'placeholder-api-key' }}


### PR DESCRIPTION
## Summary

TethysDash `4.99.79` now returns `400 Bad Request` for requests with double-slash URLs (e.g. `//TethysDash/api`). Previous versions were lenient and normalized them silently.

The CI workflow defaults had:
- `https://okeanids.mbari.org//TethysDash/api` ← double slash
- `http://okeanids.mbari.org//odss2dash/api` ← double slash + http

Both are corrected to single-slash HTTPS URLs. Repository variables have also been set to the correct values so the fallback defaults are a safety net only.

## Impact

This was causing every API call in the production and staging deployments to return 400, including command sends, event queries, and data fetches.

## Fix
- Remove `//` → `/` in `NEXT_PUBLIC_BASE_URL` default
- Remove `//` → `/` and `http` → `https` in `NEXT_PUBLIC_ODSS2BASE_URL` default