### PR TITLE
fix: remove path param from POST /commands (dropped from TethysDash API)

### DIFF
--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -282,7 +282,6 @@ const MissionModal: React.FC<MissionModalProps> = ({
       createCommand(
         {
           vehicle: confirmedVehicle?.toLowerCase() ?? '',
-          path: missionPathForCommand,
           commandNote: notes ?? '',
           runCommand: 'y',
           schedDate,

--- a/packages/api-client/src/axios/Command/createCommand.ts
+++ b/packages/api-client/src/axios/Command/createCommand.ts
@@ -4,7 +4,6 @@ import { RequestConfig } from '../types'
 
 export interface CreateCommandParams {
   vehicle: string
-  path?: string
   commandText: string
   commandNote: string
   runCommand?: string


### PR DESCRIPTION
## Summary

- TethysDash 4.99.77 removed the `path` query parameter from `POST /commands`. Under the new strict parameter validation this could cause **400 Bad Request** on every mission send from `MissionModal`.
- Remove `path` from `CreateCommandParams` interface and `MissionModal` call site.
- The mission path is already embedded in `commandText` by `makeMissionCommand` — zero functional change.

## Test plan
- [ ] Send a test mission command; verify no 400 and command appears in the schedule queue
- [ ] Verify `yarn workspace @mbari/api-client build` passes clean