### PR TITLE
fix: remove noteMatches from useEvents test (TS2345 compile error)

### DIFF
--- a/packages/api-client/src/react-query/Event/useEvents.test.tsx
+++ b/packages/api-client/src/react-query/Event/useEvents.test.tsx
@@ -92,7 +92,6 @@ const MockVehiclePosition: React.FC<{ from?: number }> = ({
     to: 1740767743191,
     eventTypes: ['note'],
     limit: 1000,
-    noteMatches: '',
   })
 
   // For test debugging
@@ -185,7 +184,6 @@ describe('useEvents', () => {
         to: undefined,
         eventTypes: ['note' as EventType],
         limit: 1000,
-        noteMatches: '',
       }
 
       // Initial fetch


### PR DESCRIPTION
Removes two remaining `noteMatches: ''` references from `useEvents.test.tsx` that caused a TypeScript compile error in CI after `noteMatches` was removed from `GetEventsParams` in PR #688.