### PR TITLE
fix: remove path from createCommand test (TS2322)

### DIFF
--- a/packages/api-client/src/axios/Command/createCommand.test.ts
+++ b/packages/api-client/src/axios/Command/createCommand.test.ts
@@ -4,7 +4,6 @@ import { createCommand, CreateCommandParams } from './createCommand'
 
 let params: CreateCommandParams = {
   vehicle: 'example',
-  path: 'example',
   commandText: 'example',
   commandNote: 'example',
   runCommand: 'example',


### PR DESCRIPTION
Removes leftover `path: 'example'` from `createCommand.test.ts` that caused TypeScript compile error after `path` was removed from `CreateCommandParams` in PR #689.