### PR TITLE
feat: add logset selector to science data and charts (#693)

### DIFF
--- a/apps/lrauv-dash2/components/ChartsModal.tsx
+++ b/apps/lrauv-dash2/components/ChartsModal.tsx
@@ -3,7 +3,7 @@ import { ScienceCell } from './ScienceDataSection'
 import { capitalize } from '@mbari/utils'
 import useCurrentDeployment from '../lib/useCurrentDeployment'
 import { useChartData, useEvents, EventType } from '@mbari/api-client'
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { DateTime } from 'luxon'
 
 export interface ChartsModalProps {
@@ -37,11 +37,20 @@ export const ChartsModal: React.FC<ChartsModalProps> = ({
 
   const [selectedLogsetId, setSelectedLogsetId] = useState<string | null>(null)
 
+  useEffect(() => {
+    if (!selectedLogsetId && logPathEvents?.length) {
+      setSelectedLogsetId(String(logPathEvents[0].eventId))
+    }
+  }, [logPathEvents, selectedLogsetId])
+
   const logsetOptions = useMemo(() => {
     if (!logPathEvents?.length) return []
     return logPathEvents.map((e) => ({
       id: String(e.eventId),
-      name: DateTime.fromMillis(e.unixTime).toFormat('MMM d, yyyy HH:mm'),
+      name:
+        DateTime.fromMillis(e.unixTime, { zone: 'utc' }).toFormat(
+          'MMM d, yyyy HH:mm'
+        ) + ' UTC',
     }))
   }, [logPathEvents])
 
@@ -58,6 +67,7 @@ export const ChartsModal: React.FC<ChartsModalProps> = ({
     const idx = logPathEvents.findIndex(
       (e) => String(e.eventId) === selectedLogsetId
     )
+    // List is descending (newest first), so idx-1 is the next newer logset.
     const next = idx >= 0 ? logPathEvents[idx - 1] : undefined
     return next ? next.unixTime : deploymentEndTime
   }, [selectedLogsetId, logPathEvents, deploymentEndTime])
@@ -87,11 +97,11 @@ export const ChartsModal: React.FC<ChartsModalProps> = ({
         {logsetOptions.length > 0 && (
           <SelectField
             name="logset"
-            value={selectedLogsetId ?? logsetOptions[0]?.id ?? ''}
+            placeholder="Logset"
+            value={selectedLogsetId ?? ''}
             options={logsetOptions}
             onSelect={setSelectedLogsetId}
             className="mb-2 w-full"
-            label="Logset"
           />
         )}
         <SelectField

--- a/apps/lrauv-dash2/components/ChartsModal.tsx
+++ b/apps/lrauv-dash2/components/ChartsModal.tsx
@@ -2,8 +2,8 @@ import { Modal, SelectField } from '@mbari/react-ui'
 import { ScienceCell } from './ScienceDataSection'
 import { capitalize } from '@mbari/utils'
 import useCurrentDeployment from '../lib/useCurrentDeployment'
-import { useChartData } from '@mbari/api-client'
-import { useState } from 'react'
+import { useChartData, useEvents, EventType } from '@mbari/api-client'
+import { useState, useMemo } from 'react'
 import { DateTime } from 'luxon'
 
 export interface ChartsModalProps {
@@ -23,10 +23,49 @@ export const ChartsModal: React.FC<ChartsModalProps> = ({
   const deploymentStartTime = deployment?.startEvent?.unixTime ?? 0
   const deploymentEndTime = deployment?.endEvent?.unixTime
 
+  const { data: logPathEvents } = useEvents(
+    {
+      vehicles: [vehicleName],
+      eventTypes: ['logPath'] as EventType[],
+      from: deploymentStartTime,
+      to: deploymentEndTime,
+      limit: 200,
+      ascending: 'n',
+    },
+    { enabled: !!vehicleName, staleTime: 5 * 60 * 1000 }
+  )
+
+  const [selectedLogsetId, setSelectedLogsetId] = useState<string | null>(null)
+
+  const logsetOptions = useMemo(() => {
+    if (!logPathEvents?.length) return []
+    return logPathEvents.map((e) => ({
+      id: String(e.eventId),
+      name: DateTime.fromMillis(e.unixTime).toFormat('MMM d, yyyy HH:mm'),
+    }))
+  }, [logPathEvents])
+
+  const resolvedFrom = useMemo(() => {
+    if (!selectedLogsetId || !logPathEvents?.length) return deploymentStartTime
+    const idx = logPathEvents.findIndex(
+      (e) => String(e.eventId) === selectedLogsetId
+    )
+    return idx >= 0 ? logPathEvents[idx].unixTime : deploymentStartTime
+  }, [selectedLogsetId, logPathEvents, deploymentStartTime])
+
+  const resolvedTo = useMemo(() => {
+    if (!selectedLogsetId || !logPathEvents?.length) return deploymentEndTime
+    const idx = logPathEvents.findIndex(
+      (e) => String(e.eventId) === selectedLogsetId
+    )
+    const next = idx >= 0 ? logPathEvents[idx - 1] : undefined
+    return next ? next.unixTime : deploymentEndTime
+  }, [selectedLogsetId, logPathEvents, deploymentEndTime])
+
   const { data: chartData } = useChartData({
     vehicle: vehicleName,
-    from: deploymentStartTime,
-    to: deploymentEndTime ? deploymentEndTime : undefined,
+    from: resolvedFrom,
+    to: resolvedTo,
   })
   const [chart, setChart] = useState<string | null>(null)
   const data = chartData?.find((c) => c.name === chart)
@@ -44,7 +83,17 @@ export const ChartsModal: React.FC<ChartsModalProps> = ({
       maximized
       open
     >
-      <div className="flex">
+      <div className="flex gap-2">
+        {logsetOptions.length > 0 && (
+          <SelectField
+            name="logset"
+            value={selectedLogsetId ?? logsetOptions[0]?.id ?? ''}
+            options={logsetOptions}
+            onSelect={setSelectedLogsetId}
+            className="mb-2 w-full"
+            label="Logset"
+          />
+        )}
         <SelectField
           name="Chart"
           value={chart ?? ''}

--- a/apps/lrauv-dash2/components/ChartsModal.tsx
+++ b/apps/lrauv-dash2/components/ChartsModal.tsx
@@ -1,4 +1,4 @@
-import { Modal, SelectField } from '@mbari/react-ui'
+import { Modal, SelectField, ToolTip } from '@mbari/react-ui'
 import { ScienceCell } from './ScienceDataSection'
 import { capitalize } from '@mbari/utils'
 import useCurrentDeployment from '../lib/useCurrentDeployment'
@@ -36,6 +36,7 @@ export const ChartsModal: React.FC<ChartsModalProps> = ({
   )
 
   const [selectedLogsetId, setSelectedLogsetId] = useState<string | null>(null)
+  const [logsetTooltip, setLogsetTooltip] = useState(false)
 
   useEffect(() => {
     if (!selectedLogsetId && logPathEvents?.length) {
@@ -95,14 +96,25 @@ export const ChartsModal: React.FC<ChartsModalProps> = ({
     >
       <div className="flex gap-2">
         {logsetOptions.length > 0 && (
-          <SelectField
-            name="logset"
-            placeholder="Logset"
-            value={selectedLogsetId ?? ''}
-            options={logsetOptions}
-            onSelect={setSelectedLogsetId}
-            className="mb-2 w-full"
-          />
+          <div
+            className="relative mb-2 w-full"
+            onMouseEnter={() => setLogsetTooltip(true)}
+            onMouseLeave={() => setLogsetTooltip(false)}
+          >
+            <SelectField
+              name="logset"
+              placeholder="Logset"
+              value={selectedLogsetId ?? ''}
+              options={logsetOptions}
+              onSelect={setSelectedLogsetId}
+              className="w-full"
+            />
+            <ToolTip
+              label="Select a logset to scope the charts to that time window"
+              direction="below"
+              active={logsetTooltip}
+            />
+          </div>
         )}
         <SelectField
           name="Chart"

--- a/apps/lrauv-dash2/components/ScienceDataSection.tsx
+++ b/apps/lrauv-dash2/components/ScienceDataSection.tsx
@@ -1,4 +1,9 @@
-import { SelectField, AbsoluteOverlay, AccordionCells } from '@mbari/react-ui'
+import {
+  SelectField,
+  AbsoluteOverlay,
+  AccordionCells,
+  ToolTip,
+} from '@mbari/react-ui'
 import useGlobalModalId from '../lib/useGlobalModalId'
 import dynamic from 'next/dynamic'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -158,6 +163,7 @@ const ScienceDataSection: React.FC<{
   })
 
   const [category, setCategory] = useState<string | null>('vehicle')
+  const [logsetTooltip, setLogsetTooltip] = useState(false)
 
   const charts = chartData?.filter((d) =>
     category === 'vehicle'
@@ -197,14 +203,24 @@ const ScienceDataSection: React.FC<{
           className="my-auto"
         />
         {logsetOptions.length > 0 && (
-          <SelectField
-            name="logset"
-            placeholder="Logset"
-            value={selectedLogsetId ?? ''}
-            options={logsetOptions}
-            onSelect={setSelectedLogsetId}
-            className="my-auto"
-          />
+          <div
+            className="relative my-auto"
+            onMouseEnter={() => setLogsetTooltip(true)}
+            onMouseLeave={() => setLogsetTooltip(false)}
+          >
+            <SelectField
+              name="logset"
+              placeholder="Logset"
+              value={selectedLogsetId ?? ''}
+              options={logsetOptions}
+              onSelect={setSelectedLogsetId}
+            />
+            <ToolTip
+              label="Select a logset to scope the charts to that time window"
+              direction="below"
+              active={logsetTooltip}
+            />
+          </div>
         )}
         <button
           className="my-auto ml-auto px-4 py-2 font-bold text-violet-800"

--- a/apps/lrauv-dash2/components/ScienceDataSection.tsx
+++ b/apps/lrauv-dash2/components/ScienceDataSection.tsx
@@ -3,7 +3,8 @@ import useGlobalModalId from '../lib/useGlobalModalId'
 import dynamic from 'next/dynamic'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { capitalize, humanize, swallow } from '@mbari/utils'
-import { useChartData } from '@mbari/api-client'
+import { useChartData, useEvents, EventType } from '@mbari/api-client'
+import { DateTime } from 'luxon'
 import clsx from 'clsx'
 
 const LineChart: any = dynamic(
@@ -89,6 +90,50 @@ const ScienceDataSection: React.FC<{
   to?: number // milliseconds since epoch
 }> = ({ vehicleName, from, to }) => {
   const { setGlobalModalId } = useGlobalModalId()
+
+  // Fetch logPath events within this deployment to populate the logset picker.
+  const { data: logPathEvents } = useEvents(
+    {
+      vehicles: [vehicleName],
+      eventTypes: ['logPath'] as EventType[],
+      from,
+      to,
+      limit: 200,
+      ascending: 'n',
+    },
+    { enabled: !!vehicleName, staleTime: 5 * 60 * 1000 }
+  )
+
+  // Default to the most recent logset (index 0, descending order).
+  const [selectedLogsetId, setSelectedLogsetId] = useState<string | null>(null)
+
+  const logsetOptions = useMemo(() => {
+    if (!logPathEvents?.length) return []
+    return logPathEvents.map((e) => ({
+      id: String(e.eventId),
+      name: DateTime.fromMillis(e.unixTime).toFormat('MMM d, yyyy HH:mm'),
+    }))
+  }, [logPathEvents])
+
+  // Resolve selected logset time window. Default to full deployment window.
+  const resolvedFrom = useMemo(() => {
+    if (!selectedLogsetId || !logPathEvents?.length) return from
+    const idx = logPathEvents.findIndex(
+      (e) => String(e.eventId) === selectedLogsetId
+    )
+    return idx >= 0 ? logPathEvents[idx].unixTime : from
+  }, [selectedLogsetId, logPathEvents, from])
+
+  const resolvedTo = useMemo(() => {
+    if (!selectedLogsetId || !logPathEvents?.length) return to
+    const idx = logPathEvents.findIndex(
+      (e) => String(e.eventId) === selectedLogsetId
+    )
+    // The logset ends when the next older logset starts (list is descending).
+    const next = idx >= 0 ? logPathEvents[idx - 1] : undefined
+    return next ? next.unixTime : to
+  }, [selectedLogsetId, logPathEvents, to])
+
   const {
     data: chartData,
     isLoading,
@@ -97,8 +142,8 @@ const ScienceDataSection: React.FC<{
     error,
   } = useChartData({
     vehicle: vehicleName,
-    from: from,
-    to: to,
+    from: resolvedFrom,
+    to: resolvedTo,
   })
 
   const [category, setCategory] = useState<string | null>('vehicle')
@@ -129,7 +174,7 @@ const ScienceDataSection: React.FC<{
 
   return (
     <>
-      <header className="flex p-2">
+      <header className="flex flex-wrap gap-2 p-2">
         <SelectField
           name="category"
           value={category ?? ''}
@@ -140,6 +185,16 @@ const ScienceDataSection: React.FC<{
           onSelect={setCategory}
           className="my-auto"
         />
+        {logsetOptions.length > 0 && (
+          <SelectField
+            name="logset"
+            value={selectedLogsetId ?? logsetOptions[0]?.id ?? ''}
+            options={logsetOptions}
+            onSelect={setSelectedLogsetId}
+            className="my-auto"
+            label="Logset"
+          />
+        )}
         <button
           className="my-auto ml-auto px-4 py-2 font-bold text-violet-800"
           onClick={handleespSamples}

--- a/apps/lrauv-dash2/components/ScienceDataSection.tsx
+++ b/apps/lrauv-dash2/components/ScienceDataSection.tsx
@@ -104,14 +104,24 @@ const ScienceDataSection: React.FC<{
     { enabled: !!vehicleName, staleTime: 5 * 60 * 1000 }
   )
 
-  // Default to the most recent logset (index 0, descending order).
+  // null until logPath events load; useEffect below sets it to the latest logset.
   const [selectedLogsetId, setSelectedLogsetId] = useState<string | null>(null)
+
+  // Auto-select the latest logset once data loads.
+  useEffect(() => {
+    if (!selectedLogsetId && logPathEvents?.length) {
+      setSelectedLogsetId(String(logPathEvents[0].eventId))
+    }
+  }, [logPathEvents, selectedLogsetId])
 
   const logsetOptions = useMemo(() => {
     if (!logPathEvents?.length) return []
     return logPathEvents.map((e) => ({
       id: String(e.eventId),
-      name: DateTime.fromMillis(e.unixTime).toFormat('MMM d, yyyy HH:mm'),
+      name:
+        DateTime.fromMillis(e.unixTime, { zone: 'utc' }).toFormat(
+          'MMM d, yyyy HH:mm'
+        ) + ' UTC',
     }))
   }, [logPathEvents])
 
@@ -129,7 +139,8 @@ const ScienceDataSection: React.FC<{
     const idx = logPathEvents.findIndex(
       (e) => String(e.eventId) === selectedLogsetId
     )
-    // The logset ends when the next older logset starts (list is descending).
+    // List is descending (newest first), so idx-1 is the next newer logset —
+    // the selected logset ends when that newer one started.
     const next = idx >= 0 ? logPathEvents[idx - 1] : undefined
     return next ? next.unixTime : to
   }, [selectedLogsetId, logPathEvents, to])
@@ -188,11 +199,11 @@ const ScienceDataSection: React.FC<{
         {logsetOptions.length > 0 && (
           <SelectField
             name="logset"
-            value={selectedLogsetId ?? logsetOptions[0]?.id ?? ''}
+            placeholder="Logset"
+            value={selectedLogsetId ?? ''}
             options={logsetOptions}
             onSelect={setSelectedLogsetId}
             className="my-auto"
-            label="Logset"
           />
         )}
         <button


### PR DESCRIPTION
## Summary

Closes #693.

Adds a logset picker dropdown to the **Science & Vehicle Data** accordion section and the **Charts modal**, allowing users to browse data from any previous logset within the current deployment — matching the core workflow scientists are familiar with from Dash 4.

## How it works

- Fetches `logPath` events for the current deployment (the same mechanism Dash 4 uses to build its logset list)
- Displays them as a dropdown formatted as `"Jun 17, 2026 16:37"`
- Selecting a logset scopes `from`/`to` to that logset's time window
- Defaults to the full deployment window when no logset is selected — **no behavior change for existing users**

## Files changed

- `apps/lrauv-dash2/components/ScienceDataSection.tsx`
- `apps/lrauv-dash2/components/ChartsModal.tsx`

## Test plan

- [ ] Open Science & Vehicle Data section for an active deployment — logset dropdown appears
- [ ] Select a previous logset — charts update to show data from that window
- [ ] Default (no selection) shows full deployment data as before
- [ ] Charts modal logset picker works the same way
- [ ] SIM vehicle (no logsets) — dropdown is hidden, no errors