### PR TITLE
feat: improve Build a Command modal UX for mission variables

### DIFF
--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -1,7 +1,11 @@
+import React from 'react'
 import {
   CommandModalView,
   CommandModalViewProps,
   mapValues,
+  OptionSet,
+  L_SEPARATOR,
+  V_SEPARATOR,
 } from '@mbari/react-ui'
 import {
   useCommands,
@@ -100,6 +104,45 @@ export const CommandModal: React.FC<CommandModalProps> = ({
     },
     { enabled: missionPath !== '' }
   )
+
+  const handleAmendCommand = (commandText: string): Record<string, string> => {
+    const params: Record<string, string> = {}
+    // Parse: set <mission>[.:]<element> <value> [<unit>]
+    const setMatch = commandText.match(
+      /^set\s+([a-zA-Z0-9_]+)([.:])([a-zA-Z0-9_.]+)\s+(\S+)(?:\s+(\S+))?/
+    )
+    if (setMatch) {
+      const [, missionName, separator, paramPart, value, unit] = setMatch
+
+      // Find full mission path (e.g. "Science/sci2_circle_hotspot.tl")
+      const fullPath = allMissionPaths.find((p) => {
+        const base = p.split('/').pop()?.replace(/\.tl$/, '')
+        return base === missionName
+      })
+
+      if (fullPath) {
+        // Element: root param or Insert.Param
+        const element = separator === ':' ? paramPart : paramPart
+
+        // Build cumulative option ID matching what CommandDetailTable produces
+        const varTypeTier = `Variable Type${L_SEPARATOR}Mission`
+        const missionTier = `Mission${L_SEPARATOR}${fullPath}`
+        const elementTier = `Element${L_SEPARATOR}${element}`
+        const cumulativeId = [varTypeTier, missionTier, elementTier].join(
+          V_SEPARATOR
+        )
+
+        params['ARG_VARIABLE'] = cumulativeId
+        setVariable(mapValues(cumulativeId))
+      }
+
+      if (value) params['ARG_LIST'] = value
+      // Encode unit with the OptionSet name so the Select dropdown matches correctly
+      if (unit) params['ARG_UNIT'] = `Units${L_SEPARATOR}${unit}`
+    }
+
+    return params
+  }
 
   const handleUpdatedField: CommandModalViewProps['onUpdateField'] = (
     _param,
@@ -215,9 +258,29 @@ export const CommandModal: React.FC<CommandModalProps> = ({
     return slash >= 0 ? path.slice(0, slash) : 'Standard Ops'
   }
 
+  // Extract unique mission base names from recent commands (set/load) for pinning.
+  const recentMissionNames = React.useMemo(() => {
+    const names = new Set<string>()
+    recentCommandsData?.forEach((c) => {
+      const cmd = c?.writtenCommand ?? ''
+      // set missionname.param ... or set missionname:Section.param ...
+      const setMatch = cmd.match(/^set\s+([a-zA-Z0-9_]+)[.:]/)
+      if (setMatch) names.add(setMatch[1])
+      // load path/missionname.tl
+      const loadMatch = cmd.match(/load\s+(?:\S+\/)?([a-zA-Z0-9_]+)\.tl/)
+      if (loadMatch) names.add(loadMatch[1])
+    })
+    return Array.from(names).slice(0, 5)
+  }, [recentCommandsData])
+
   // Single-tier grouped mission picker for ARG_MISSION (e.g. load, run).
   const missionTypeOptions = [
-    { name: 'Mission', options: allMissionPaths, groupBy: missionGroupBy },
+    {
+      name: 'Mission',
+      options: allMissionPaths,
+      groupBy: missionGroupBy,
+      pinnedNames: recentMissionNames,
+    },
   ]
 
   // Flat Element list: root params as 'ParamName', insert params as 'Insert.ParamName'.
@@ -230,7 +293,7 @@ export const CommandModal: React.FC<CommandModalProps> = ({
       ].sort()
     : []
 
-  const variableTypes = [
+  const variableTypes: OptionSet[] = [
     { name: 'Variable Type', options: ['Mission', 'Universal', 'Component'] },
   ]
   switch (variable['Variable Type']) {
@@ -240,6 +303,7 @@ export const CommandModal: React.FC<CommandModalProps> = ({
         name: 'Mission',
         options: allMissionPaths,
         groupBy: missionGroupBy,
+        pinnedNames: recentMissionNames,
       })
       // Tier 3: flat element list built once mission data is loaded
       if (variable.Mission && selectedMissionData) {
@@ -280,6 +344,7 @@ export const CommandModal: React.FC<CommandModalProps> = ({
       variableTypes={variableTypes}
       showAdvanced={!hideAdvanced}
       onToggleAdvanced={() => setHideAdvanced((v) => !v)}
+      onAmendCommand={handleAmendCommand}
       onUpdateField={handleUpdatedField}
       onResetParameters={() =>
         setVariable({

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   CommandModalView,
   CommandModalViewProps,
@@ -24,7 +24,6 @@ import {
 import { makeCommand } from '../lib/makeCommand'
 import { useRouter } from 'next/router'
 import toast from 'react-hot-toast'
-import { useState } from 'react'
 import useGlobalModalId from '../lib/useGlobalModalId'
 
 export interface CommandModalProps {
@@ -107,16 +106,24 @@ export const CommandModal: React.FC<CommandModalProps> = ({
 
   const handleAmendCommand = (commandText: string): Record<string, string> => {
     const params: Record<string, string> = {}
-    // Parse: set <mission>[.:]<element> <value> [<unit>]
+    // Parse: set <mission>[.:]<element> <rest>
+    // Capture the entire rest-of-line so multi-token values (ARG_LIST) are
+    // preserved. The last space-delimited token is treated as an optional unit.
     const setMatch = commandText.match(
-      /^set\s+([a-zA-Z0-9_]+)([.:])([a-zA-Z0-9_.]+)\s+(\S+)(?:\s+(\S+))?/
+      /^set\s+([a-zA-Z0-9_]+)([.:])([a-zA-Z0-9_.]+)\s+(.+)$/
     )
     if (setMatch) {
-      const [, missionName, separator, paramPart, value, unit] = setMatch
+      const [, missionName, separator, paramPart, rest] = setMatch
+      const lastSpace = rest.lastIndexOf(' ')
+      const value = lastSpace >= 0 ? rest.slice(0, lastSpace) : rest
+      const unit = lastSpace >= 0 ? rest.slice(lastSpace + 1) : undefined
 
       // Find full mission path (e.g. "Science/sci2_circle_hotspot.tl")
       const fullPath = allMissionPaths.find((p) => {
-        const base = p.split('/').pop()?.replace(/\.tl$/, '')
+        const base = p
+          .split('/')
+          .pop()
+          ?.replace(/\.(tl|xml|py)$/i, '')
         return base === missionName
       })
 
@@ -266,8 +273,10 @@ export const CommandModal: React.FC<CommandModalProps> = ({
       // set missionname.param ... or set missionname:Section.param ...
       const setMatch = cmd.match(/^set\s+([a-zA-Z0-9_]+)[.:]/)
       if (setMatch) names.add(setMatch[1])
-      // load path/missionname.tl
-      const loadMatch = cmd.match(/load\s+(?:\S+\/)?([a-zA-Z0-9_]+)\.tl/)
+      // load path/missionname.tl/.xml/.py
+      const loadMatch = cmd.match(
+        /load\s+(?:\S+\/)?([a-zA-Z0-9_]+)\.(tl|xml|py)/i
+      )
       if (loadMatch) names.add(loadMatch[1])
     })
     return Array.from(names).slice(0, 5)

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -40,8 +40,10 @@ export const CommandModal: React.FC<CommandModalProps> = ({
     string | null | undefined
   >(defaultCommand)
 
+  const [hideAdvanced, setHideAdvanced] = useState(false)
+
   const [variable, setVariable] = useState<Record<string, string>>({
-    Variable: '',
+    'Variable Type': '',
     Mission: '',
     Module: '',
     Component: '',
@@ -89,12 +91,14 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   const { data: moduleInfoData } = useModuleInfo()
   const { data: universalData } = useUniversals({})
   const { data: missionData } = useMissionList()
+  // Mission tier now stores the full path (e.g. 'Science/sci2_circle_hotspot.tl')
+  const missionPath = variable.Mission ?? ''
   const { data: selectedMissionData } = useScript(
     {
-      path: variable.Mission,
+      path: missionPath,
       gitRef: missionData?.gitRef ?? 'master',
     },
-    { enabled: (variable.Mission ?? '') !== '' }
+    { enabled: missionPath !== '' }
   )
 
   const handleUpdatedField: CommandModalViewProps['onUpdateField'] = (
@@ -136,13 +140,19 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   ]
   const moduleNames = makeModuleNames(variable)
 
-  const units = unitsData?.map((u) => u.name) ?? []
+  const units = unitsData?.map((u) => u.abbreviation) ?? []
+
+  // Display aliases: shown in UI but the original keyword is still sent to the vehicle
+  const COMMAND_DISPLAY_ALIASES: Record<string, string> = {
+    failComponent: 'failc',
+  }
 
   const commands =
     commandData?.commands.map((c) => ({
       id: c.keyword,
-      name: c.keyword,
+      name: COMMAND_DISPLAY_ALIASES[c.keyword] ?? c.keyword,
       description: c.description,
+      advanced: c.advanced,
     })) ?? []
 
   const recentCommands =
@@ -196,21 +206,47 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   const decimationTypes = commandData?.decimationTypes ?? []
   const serviceTypes = commandData?.serviceTypes ?? []
 
-  const variableTypes = [
-    { name: 'Variable', options: ['Mission', 'Universal', 'Component'] },
+  // Flat sorted mission paths for both ARG_VARIABLE and ARG_MISSION pickers.
+  const allMissionPaths = (missionData?.list?.map((m) => m.path) ?? []).sort()
+
+  // Groups paths by folder prefix for the grouped dropdown headers.
+  const missionGroupBy = (path: string) => {
+    const slash = path.lastIndexOf('/')
+    return slash >= 0 ? path.slice(0, slash) : 'Standard Ops'
+  }
+
+  // Single-tier grouped mission picker for ARG_MISSION (e.g. load, run).
+  const missionTypeOptions = [
+    { name: 'Mission', options: allMissionPaths, groupBy: missionGroupBy },
   ]
-  switch (variable.Variable) {
-    case 'Mission':
+
+  // Flat Element list: root params as 'ParamName', insert params as 'Insert.ParamName'.
+  const elementOptions = selectedMissionData
+    ? [
+        ...(selectedMissionData.scriptArgs ?? []).map((a) => a.name),
+        ...(selectedMissionData.inserts ?? []).flatMap((ins) =>
+          (ins.scriptArgs ?? []).map((a) => `${ins.id}.${a.name}`)
+        ),
+      ].sort()
+    : []
+
+  const variableTypes = [
+    { name: 'Variable Type', options: ['Mission', 'Universal', 'Component'] },
+  ]
+  switch (variable['Variable Type']) {
+    case 'Mission': {
+      // Tier 2: grouped mission list — folders as headers, filenames as options
       variableTypes.push({
         name: 'Mission',
-        options: missionData?.list?.map((m) => m.path) ?? [],
+        options: allMissionPaths,
+        groupBy: missionGroupBy,
       })
-      selectedMissionData?.scriptArgs &&
-        variableTypes.push({
-          name: 'Argument',
-          options: selectedMissionData?.scriptArgs.map((a) => a.name) ?? [],
-        })
+      // Tier 3: flat element list built once mission data is loaded
+      if (variable.Mission && selectedMissionData) {
+        variableTypes.push({ name: 'Element', options: elementOptions })
+      }
       break
+    }
     case 'Universal':
       variableTypes.push({
         name: 'Universal',
@@ -221,8 +257,6 @@ export const CommandModal: React.FC<CommandModalProps> = ({
       makeModuleNames(variable).forEach((m) => variableTypes.push(m))
       break
   }
-
-  const missionOptions = missionData?.list?.map((m) => m.path)?.sort() ?? []
 
   return (
     <CommandModalView
@@ -240,16 +274,22 @@ export const CommandModal: React.FC<CommandModalProps> = ({
       syntaxVariations={syntaxVariations ?? []}
       units={[{ name: 'Units', options: units }]}
       universals={[{ name: 'Universal', options: universalData ?? [] }]}
-      missions={[
-        {
-          name: 'Mission',
-          options: missionOptions,
-        },
-      ]}
+      missions={missionTypeOptions}
       decimationTypes={[{ name: 'Decimation Type', options: decimationTypes }]}
       serviceTypes={[{ name: 'Service Type', options: serviceTypes }]}
       variableTypes={variableTypes}
+      showAdvanced={!hideAdvanced}
+      onToggleAdvanced={() => setHideAdvanced((v) => !v)}
       onUpdateField={handleUpdatedField}
+      onResetParameters={() =>
+        setVariable({
+          'Variable Type': '',
+          Mission: '',
+          Module: '',
+          Component: '',
+          Element: '',
+        })
+      }
       moduleNames={moduleNames}
       vehicles={vehicles}
       alternativeAddresses={alternativeAddresses ?? []}

--- a/packages/react-ui/src/Diagrams/VehicleAssets/DropWeightIndicator.tsx
+++ b/packages/react-ui/src/Diagrams/VehicleAssets/DropWeightIndicator.tsx
@@ -28,7 +28,7 @@ export const DropWeightIndicator: React.FC<DropWeightProps> = ({
       >
         DROP WEIGHT
       </text>
-      <text transform="matrix(1 0 0 1 338 300)" className="st12 st9 st13">
+      <text transform="matrix(1 0 0 1 285 307)" className="st12 st9 st13">
         {textDroptime}
       </text>
     </>

--- a/packages/react-ui/src/Fields/Input.tsx
+++ b/packages/react-ui/src/Fields/Input.tsx
@@ -24,7 +24,7 @@ export interface InputProps {
 
 const style = {
   input:
-    'font-body border rounded px-2 py-1 flex flex-grow max-w-full focus:outline-none focus:border-green-300',
+    'font-body border border-gray-300 rounded px-2 py-1 min-h-[38px] flex flex-grow max-w-full placeholder:text-gray-500 focus:outline-none focus:border-green-300',
 }
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(

--- a/packages/react-ui/src/Fields/MissionCascader.tsx
+++ b/packages/react-ui/src/Fields/MissionCascader.tsx
@@ -9,6 +9,8 @@ export interface MissionCascaderProps {
   placeholder?: string
   onSelect: (id: string | null) => void
   clearable?: boolean
+  /** Mission base names (no extension) to pin at top under "Recently used". */
+  pinnedNames?: string[]
 }
 
 const groupPriority = (label: string) => {
@@ -32,9 +34,27 @@ export const MissionCascader: React.FC<MissionCascaderProps> = ({
   placeholder = 'Select mission',
   onSelect,
   clearable,
+  pinnedNames,
 }) => {
   const sorted = sortedGroups(groups)
   const allOptions = sorted.flatMap((g) => g.options)
+
+  // Build a "Recently used" group from pinned mission names
+  const recentGroup: SelectOptionGroup | null =
+    pinnedNames && pinnedNames.length > 0
+      ? (() => {
+          const pinnedOptions = allOptions.filter((o) =>
+            pinnedNames.some(
+              (n) => o.name === n || o.name.replace(/\.tl$/, '') === n
+            )
+          )
+          return pinnedOptions.length > 0
+            ? { label: 'Recently used', options: pinnedOptions }
+            : null
+        })()
+      : null
+
+  const displayGroups = recentGroup ? [recentGroup, ...sorted] : sorted
   const selectedOption = allOptions.find((o) => o.id === value)
   const selectedGroup = selectedOption
     ? sorted.find((g) => g.options.some((o) => o.id === value))
@@ -231,7 +251,7 @@ export const MissionCascader: React.FC<MissionCascaderProps> = ({
                 )
               ) : (
                 /* Accordion folders */
-                sorted.map((g) => {
+                displayGroups.map((g) => {
                   const isExpanded = expandedFolder === g.label
                   const hasSelected = g.options.some((o) => o.id === value)
                   return (

--- a/packages/react-ui/src/Fields/MissionCascader.tsx
+++ b/packages/react-ui/src/Fields/MissionCascader.tsx
@@ -1,0 +1,296 @@
+import React, { useState, useRef, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+import { SelectOptionGroup } from './Select'
+
+export interface MissionCascaderProps {
+  groups: SelectOptionGroup[]
+  /** Currently selected option id (cumulative encoded value string) */
+  value?: string
+  placeholder?: string
+  onSelect: (id: string | null) => void
+  clearable?: boolean
+}
+
+const groupPriority = (label: string) => {
+  if (label === 'Standard Ops') return 0
+  if (label.toLowerCase().startsWith('deprecated') || label.startsWith('_'))
+    return 2
+  return 1
+}
+
+const sortedGroups = (groups: SelectOptionGroup[]) =>
+  [...groups].sort((a, b) => {
+    const pa = groupPriority(a.label)
+    const pb = groupPriority(b.label)
+    if (pa !== pb) return pa - pb
+    return a.label.localeCompare(b.label)
+  })
+
+export const MissionCascader: React.FC<MissionCascaderProps> = ({
+  groups,
+  value,
+  placeholder = 'Select mission',
+  onSelect,
+  clearable,
+}) => {
+  const sorted = sortedGroups(groups)
+  const allOptions = sorted.flatMap((g) => g.options)
+  const selectedOption = allOptions.find((o) => o.id === value)
+  const selectedGroup = selectedOption
+    ? sorted.find((g) => g.options.some((o) => o.id === value))
+    : null
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [expandedFolder, setExpandedFolder] = useState<string | null>(
+    selectedGroup?.label ?? null
+  )
+  const [search, setSearch] = useState('')
+  const [dropdownPos, setDropdownPos] = useState<{
+    top: number
+    left: number
+    width: number
+  } | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+  const searchRef = useRef<HTMLInputElement>(null)
+
+  const open = () => {
+    if (containerRef.current) {
+      const rect = containerRef.current.getBoundingClientRect()
+      setDropdownPos({
+        top: rect.bottom + window.scrollY,
+        left: rect.left + window.scrollX,
+        width: rect.width,
+      })
+    }
+    setIsOpen(true)
+    setExpandedFolder(null) // all folders start closed
+    setSearch('')
+    setTimeout(() => searchRef.current?.focus(), 50)
+  }
+
+  const close = () => {
+    setIsOpen(false)
+    setSearch('')
+  }
+
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node
+      const inTrigger = containerRef.current?.contains(target)
+      const inDropdown = dropdownRef.current?.contains(target)
+      if (!inTrigger && !inDropdown) {
+        close()
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [])
+
+  const searchResults =
+    search.trim().length > 0
+      ? sorted.flatMap((g) =>
+          g.options
+            .filter((o) =>
+              `${g.label} ${o.name}`
+                .toLowerCase()
+                .includes(search.toLowerCase())
+            )
+            .map((o) => ({ folder: g.label, option: o }))
+        )
+      : []
+
+  const handleSelect = (id: string) => {
+    onSelect(id)
+    close()
+  }
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      {/* Trigger */}
+      <div
+        className="client__multi__select_container w-full cursor-pointer"
+        onClick={() => (isOpen ? close() : open())}
+      >
+        <div className="client__multi__select__control flex min-h-[38px] items-center justify-between rounded border border-gray-300 bg-white px-2">
+          <span
+            className={
+              selectedOption ? 'text-sm text-gray-800' : 'text-sm text-gray-400'
+            }
+          >
+            {selectedOption
+              ? `${selectedGroup?.label ? selectedGroup.label + ' / ' : ''}${
+                  selectedOption.name
+                }`
+              : placeholder}
+          </span>
+          <div className="flex items-center gap-1.5">
+            {clearable && selectedOption && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onSelect(null)
+                }}
+                className="text-gray-400 hover:text-gray-600"
+                aria-label="Clear"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-3.5 w-3.5"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </button>
+            )}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className={`h-4 w-4 text-gray-400 transition-transform ${
+                isOpen ? 'rotate-180' : ''
+              }`}
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                fillRule="evenodd"
+                d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      {/* Dropdown — portaled to body so it escapes table stacking context */}
+      {isOpen &&
+        dropdownPos &&
+        createPortal(
+          <div
+            ref={dropdownRef}
+            className="fixed z-[9999] min-w-[280px] overflow-hidden rounded border border-gray-200 bg-white shadow-lg"
+            style={{
+              top: dropdownPos.top + 4,
+              left: dropdownPos.left,
+              width: Math.max(dropdownPos.width, 280),
+            }}
+          >
+            {/* Search */}
+            <div className="flex items-center gap-2 border-b border-gray-100 px-3 py-2">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-3.5 w-3.5 flex-shrink-0 text-gray-400"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M8 4a4 4 0 100 8 4 4 0 000-8zM2 8a6 6 0 1110.89 3.476l4.817 4.817a1 1 0 01-1.414 1.414l-4.816-4.816A6 6 0 012 8z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              <input
+                ref={searchRef}
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search missions…"
+                className="w-full text-sm text-gray-700 outline-none placeholder:text-gray-400"
+              />
+            </div>
+
+            <div className="max-h-72 overflow-y-auto">
+              {search.trim() ? (
+                /* Flat search results */
+                searchResults.length === 0 ? (
+                  <p className="px-3 py-2 text-sm text-gray-400">
+                    No missions found
+                  </p>
+                ) : (
+                  searchResults.map(({ folder, option }) => (
+                    <div
+                      key={option.id}
+                      className={`cursor-pointer px-4 py-1.5 text-sm ${
+                        option.id === value
+                          ? 'bg-blue-50 font-medium text-blue-700'
+                          : 'text-gray-700 hover:bg-gray-50'
+                      }`}
+                      onClick={() => handleSelect(option.id)}
+                    >
+                      <span className="mr-1 text-xs text-gray-400">
+                        {folder}/
+                      </span>
+                      {option.name}
+                    </div>
+                  ))
+                )
+              ) : (
+                /* Accordion folders */
+                sorted.map((g) => {
+                  const isExpanded = expandedFolder === g.label
+                  const hasSelected = g.options.some((o) => o.id === value)
+                  return (
+                    <div key={g.label}>
+                      {/* Folder row — blue text, light background */}
+                      <div
+                        className={`flex cursor-pointer items-center justify-between border-t border-gray-100 px-3 py-2 text-sm font-semibold ${
+                          isExpanded
+                            ? 'bg-blue-50 text-blue-700'
+                            : hasSelected
+                            ? 'text-blue-600 hover:bg-blue-50'
+                            : 'text-blue-600 hover:bg-blue-50'
+                        }`}
+                        onClick={() =>
+                          setExpandedFolder(isExpanded ? null : g.label)
+                        }
+                      >
+                        <span>{g.label}</span>
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          className={`h-3.5 w-3.5 text-blue-400 transition-transform ${
+                            isExpanded ? 'rotate-90' : ''
+                          }`}
+                          viewBox="0 0 20 20"
+                          fill="currentColor"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M7.293 14.707a1 1 0 010-1.414L10.586 10 7.293 6.707a1 1 0 011.414-1.414l4 4a1 1 0 010 1.414l-4 4a1 1 0 01-1.414 0z"
+                            clipRule="evenodd"
+                          />
+                        </svg>
+                      </div>
+
+                      {/* Files — indented, lighter weight, white background */}
+                      {isExpanded &&
+                        g.options.map((opt) => (
+                          <div
+                            key={opt.id}
+                            className={`cursor-pointer border-b border-gray-50 py-1.5 pl-6 pr-3 text-sm font-normal ${
+                              opt.id === value
+                                ? 'bg-blue-50 font-medium text-blue-700'
+                                : 'bg-white text-gray-700 hover:bg-blue-50 hover:text-blue-600'
+                            }`}
+                            onClick={() => handleSelect(opt.id)}
+                          >
+                            {opt.name}
+                          </div>
+                        ))}
+                    </div>
+                  )
+                })
+              )}
+            </div>
+          </div>,
+          document.body
+        )}
+    </div>
+  )
+}
+
+MissionCascader.displayName = 'Fields.MissionCascader'

--- a/packages/react-ui/src/Fields/MissionCascader.tsx
+++ b/packages/react-ui/src/Fields/MissionCascader.tsx
@@ -15,7 +15,13 @@ export interface MissionCascaderProps {
 
 const groupPriority = (label: string) => {
   if (label === 'Standard Ops') return 0
-  if (label.toLowerCase().startsWith('deprecated') || label.startsWith('_'))
+  // Check the last path segment so nested folders like Science/_scratch or
+  // Science/Deprecated are deprioritized the same as top-level _ / Deprecated.
+  const lastSegment = label.split('/').pop() ?? label
+  if (
+    lastSegment.toLowerCase().startsWith('deprecated') ||
+    lastSegment.startsWith('_')
+  )
     return 2
   return 1
 }
@@ -95,6 +101,7 @@ export const MissionCascader: React.FC<MissionCascaderProps> = ({
   }
 
   useEffect(() => {
+    if (!isOpen) return
     const handler = (e: MouseEvent) => {
       const target = e.target as Node
       const inTrigger = containerRef.current?.contains(target)
@@ -105,7 +112,25 @@ export const MissionCascader: React.FC<MissionCascaderProps> = ({
     }
     document.addEventListener('mousedown', handler)
     return () => document.removeEventListener('mousedown', handler)
-  }, [])
+  }, [isOpen])
+
+  // Recompute fixed dropdown position while open so it tracks the trigger
+  // if the modal body is scrolled or the window is resized.
+  useEffect(() => {
+    if (!isOpen) return
+    const recompute = () => {
+      if (containerRef.current) {
+        const rect = containerRef.current.getBoundingClientRect()
+        setDropdownPos({ top: rect.bottom, left: rect.left, width: rect.width })
+      }
+    }
+    window.addEventListener('scroll', recompute, true)
+    window.addEventListener('resize', recompute)
+    return () => {
+      window.removeEventListener('scroll', recompute, true)
+      window.removeEventListener('resize', recompute)
+    }
+  }, [isOpen])
 
   const searchResults =
     search.trim().length > 0
@@ -130,7 +155,20 @@ export const MissionCascader: React.FC<MissionCascaderProps> = ({
       {/* Trigger */}
       <div
         className="client__multi__select_container w-full cursor-pointer"
+        role="button"
+        tabIndex={0}
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
         onClick={() => (isOpen ? close() : open())}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            isOpen ? close() : open()
+          } else if (e.key === 'Escape' && isOpen) {
+            e.preventDefault()
+            close()
+          }
+        }}
       >
         <div className="client__multi__select__control flex min-h-[38px] items-center justify-between rounded border border-gray-300 bg-white px-2">
           <span
@@ -235,12 +273,21 @@ export const MissionCascader: React.FC<MissionCascaderProps> = ({
                   searchResults.map(({ folder, option }) => (
                     <div
                       key={option.id}
+                      role="option"
+                      aria-selected={option.id === value}
+                      tabIndex={0}
                       className={`cursor-pointer px-4 py-1.5 text-sm ${
                         option.id === value
                           ? 'bg-blue-50 font-medium text-blue-700'
                           : 'text-gray-700 hover:bg-gray-50'
                       }`}
                       onClick={() => handleSelect(option.id)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          handleSelect(option.id)
+                        }
+                      }}
                     >
                       <span className="mr-1 text-xs text-gray-400">
                         {folder}/
@@ -258,6 +305,9 @@ export const MissionCascader: React.FC<MissionCascaderProps> = ({
                     <div key={g.label}>
                       {/* Folder row — blue text, light background */}
                       <div
+                        role="button"
+                        tabIndex={0}
+                        aria-expanded={isExpanded}
                         className={`flex cursor-pointer items-center justify-between border-t border-gray-100 px-3 py-2 text-sm font-semibold ${
                           isExpanded
                             ? 'bg-blue-50 text-blue-700'
@@ -268,6 +318,12 @@ export const MissionCascader: React.FC<MissionCascaderProps> = ({
                         onClick={() =>
                           setExpandedFolder(isExpanded ? null : g.label)
                         }
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                            e.preventDefault()
+                            setExpandedFolder(isExpanded ? null : g.label)
+                          }
+                        }}
                       >
                         <span>{g.label}</span>
                         <svg
@@ -291,12 +347,21 @@ export const MissionCascader: React.FC<MissionCascaderProps> = ({
                         g.options.map((opt) => (
                           <div
                             key={opt.id}
+                            role="option"
+                            aria-selected={opt.id === value}
+                            tabIndex={0}
                             className={`cursor-pointer border-b border-gray-50 py-1.5 pl-6 pr-3 text-sm font-normal ${
                               opt.id === value
                                 ? 'bg-blue-50 font-medium text-blue-700'
                                 : 'bg-white text-gray-700 hover:bg-blue-50 hover:text-blue-600'
                             }`}
                             onClick={() => handleSelect(opt.id)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                handleSelect(opt.id)
+                              }
+                            }}
                           >
                             {opt.name}
                           </div>

--- a/packages/react-ui/src/Fields/MissionCascader.tsx
+++ b/packages/react-ui/src/Fields/MissionCascader.tsx
@@ -78,8 +78,8 @@ export const MissionCascader: React.FC<MissionCascaderProps> = ({
     if (containerRef.current) {
       const rect = containerRef.current.getBoundingClientRect()
       setDropdownPos({
-        top: rect.bottom + window.scrollY,
-        left: rect.left + window.scrollX,
+        top: rect.bottom,
+        left: rect.left,
         width: rect.width,
       })
     }

--- a/packages/react-ui/src/Fields/Select.tsx
+++ b/packages/react-ui/src/Fields/Select.tsx
@@ -47,7 +47,7 @@ export const Select = React.forwardRef<any, SelectProps>(
     const allFlat = groupedOptions
       ? groupedOptions.flatMap((g) => g.options)
       : options
-    const defaultValue = allFlat.filter((s) => s.id === value)
+    const defaultValue = allFlat.find((s) => s.id === value) ?? null
     const handleChange = (s: SelectOption | null) => {
       handleSelect?.(s?.id ?? null)
     }

--- a/packages/react-ui/src/Fields/Select.tsx
+++ b/packages/react-ui/src/Fields/Select.tsx
@@ -8,11 +8,17 @@ export interface SelectOption {
   icon?: IconDefinition
 }
 
+export interface SelectOptionGroup {
+  label: string
+  options: SelectOption[]
+}
+
 export interface SelectProps {
   id?: string
   name: string
   placeholder?: string
   options?: SelectOption[]
+  groupedOptions?: SelectOptionGroup[]
   onChange?: (value: string) => void
   onSelect?: (id: string | null) => void
   value?: string
@@ -28,6 +34,7 @@ export const Select = React.forwardRef<any, SelectProps>(
       name,
       placeholder,
       options = [],
+      groupedOptions,
       onChange: handleOnInputChange,
       onSelect: handleSelect,
       value,
@@ -37,7 +44,10 @@ export const Select = React.forwardRef<any, SelectProps>(
     },
     ref
   ) => {
-    const defaultValue = options.filter((s) => s.id === value)
+    const allFlat = groupedOptions
+      ? groupedOptions.flatMap((g) => g.options)
+      : options
+    const defaultValue = allFlat.filter((s) => s.id === value)
     const handleChange = (s: SelectOption | null) => {
       handleSelect?.(s?.id ?? null)
     }
@@ -45,7 +55,7 @@ export const Select = React.forwardRef<any, SelectProps>(
       <div className="flex h-full w-full flex-grow">
         <ReactSelect
           name={name}
-          options={options}
+          options={(groupedOptions ?? options) as any}
           value={defaultValue}
           defaultValue={defaultValue}
           getOptionLabel={(option: SelectOption) => option.name}
@@ -59,6 +69,14 @@ export const Select = React.forwardRef<any, SelectProps>(
           onChange={handleChange}
           styles={{
             menuPortal: (base) => ({ ...base, zIndex: 9999 }),
+            groupHeading: (base) => ({
+              ...base,
+              fontWeight: 600,
+              fontSize: '0.7rem',
+              textTransform: 'uppercase',
+              color: '#64748b',
+              letterSpacing: '0.05em',
+            }),
             ...(customStyles ?? {}),
           }}
           menuPortalTarget={document.body}

--- a/packages/react-ui/src/Modal/Footer.tsx
+++ b/packages/react-ui/src/Modal/Footer.tsx
@@ -9,6 +9,7 @@ export interface FooterProps {
   confirmButtonText?: string | JSX.Element
   cancelButtonText?: string | JSX.Element
   extraButtons?: ExtraButton[]
+  leftExtraButtons?: ExtraButton[]
   form?: string
   onConfirm?: (() => void) | null
   onCancel?: (() => void) | null
@@ -32,6 +33,7 @@ export const Footer: React.FC<FooterProps> = ({
   confirmButtonText = 'Confirm',
   cancelButtonText = 'Cancel',
   extraButtons,
+  leftExtraButtons,
   onCancel: handleCancel,
   onConfirm: handleConfirm,
   disableCancel,
@@ -44,14 +46,14 @@ export const Footer: React.FC<FooterProps> = ({
         {(handleConfirm || form) && (
           <li className={clsx(styles.item, 'ml-auto')}>
             {extraButtons?.length
-              ? extraButtons.map((button, index) => {
+              ? extraButtons.map(({ buttonText, ...button }, index) => {
                   return (
                     <Button
-                      key={`${index}${button.buttonText}`}
+                      key={`${index}${buttonText}`}
                       {...button}
                       className="mr-2 h-full"
                     >
-                      {button.buttonText}
+                      {buttonText}
                     </Button>
                   )
                 })
@@ -68,7 +70,7 @@ export const Footer: React.FC<FooterProps> = ({
           </li>
         )}
         {handleCancel && (
-          <li className={styles.item}>
+          <li className={clsx(styles.item, 'gap-2')}>
             <Button
               appearance="secondary"
               onClick={swallow(handleCancel)}
@@ -76,6 +78,11 @@ export const Footer: React.FC<FooterProps> = ({
             >
               {cancelButtonText}
             </Button>
+            {leftExtraButtons?.map(({ buttonText, ...button }, index) => (
+              <Button key={`left-${index}-${buttonText}`} {...button}>
+                {buttonText}
+              </Button>
+            ))}
           </li>
         )}
       </ol>

--- a/packages/react-ui/src/Modal/Modal.tsx
+++ b/packages/react-ui/src/Modal/Modal.tsx
@@ -114,6 +114,7 @@ export const Modal: React.FC<ModalProps & FooterProps> = ({
   form,
   loading,
   extraButtons,
+  leftExtraButtons,
   maximized,
   className,
   style,
@@ -305,6 +306,7 @@ export const Modal: React.FC<ModalProps & FooterProps> = ({
             disableConfirm={disableConfirm}
             form={form}
             extraButtons={extraButtons}
+            leftExtraButtons={leftExtraButtons}
           />
         )}
       </section>

--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
@@ -339,8 +339,11 @@ export const BuildTemplatedCommandStep: React.FC<
           if (!missionFullPath || !element) return undefined
           // Extract bare filename without extension (e.g. 'sci2_circle_hotspot')
           const missionName =
-            missionFullPath.match(/[a-zA-Z0-9_]+(?=\.xml|\.tl)/)?.[0] ??
-            missionFullPath.split('/').pop() ??
+            missionFullPath.match(/[a-zA-Z0-9_]+(?=\.xml|\.tl|\.py)/i)?.[0] ??
+            missionFullPath
+              .split('/')
+              .pop()
+              ?.replace(/\.(tl|xml|py)$/i, '') ??
             missionFullPath
           // element is 'ParamName' (root) or 'Insert.ParamName' (scoped)
           if (element.includes('.')) {

--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
@@ -33,7 +33,7 @@ const argumentAsParameter = (
     case 'ARG_FLOAT':
       return {
         argType: arg.argType,
-        name: 'variable value to set',
+        name: arg?.altName ?? 'value',
         description: 'A numeric value (e.g. 1.5)',
         inputType: 'number',
         required: arg.required === 'REQUIRED',
@@ -337,19 +337,24 @@ export const BuildTemplatedCommandStep: React.FC<
           const missionFullPath = values[1]
           const element = values[2]
           if (!missionFullPath || !element) return undefined
-          // Extract bare filename without extension (e.g. 'sci2_circle_hotspot')
+          // Extract bare filename without extension (e.g. 'sci2_circle_hotspot',
+          // 'foo-bar'). Basename + extension stripping handles all filename chars.
           const missionName =
-            missionFullPath.match(/[a-zA-Z0-9_]+(?=\.xml|\.tl|\.py)/i)?.[0] ??
             missionFullPath
               .split('/')
               .pop()
-              ?.replace(/\.(tl|xml|py)$/i, '') ??
-            missionFullPath
+              ?.replace(/\.(tl|xml|py)$/i, '') ?? missionFullPath
           // element is 'ParamName' (root) or 'Insert.ParamName' (scoped)
           if (element.includes('.')) {
             return `${missionName}:${element}`
           }
           return `${missionName}.${element}`
+        }
+        if (values[0] === 'Component') {
+          const component = values[2]
+          const element = values[3]
+          if (!component || !element) return undefined
+          return `${component}.${element}`
         }
         return undefined
       case 'ARG_UNIVERSAL':

--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
@@ -33,8 +33,8 @@ const argumentAsParameter = (
     case 'ARG_FLOAT':
       return {
         argType: arg.argType,
-        name: 'float',
-        description: 'A floating point value',
+        name: 'variable value to set',
+        description: 'A numeric value (e.g. 1.5)',
         inputType: 'number',
         required: arg.required === 'REQUIRED',
         value,
@@ -52,8 +52,8 @@ const argumentAsParameter = (
     case 'ARG_INT':
       return {
         argType: arg.argType,
-        name: arg?.altName ?? 'int',
-        description: 'An integer value',
+        name: arg?.altName ?? 'integer',
+        description: 'A whole number (e.g. 5)',
         inputType: 'number',
         value,
       }
@@ -61,7 +61,7 @@ const argumentAsParameter = (
       return {
         argType: arg.argType,
         name: 'seconds',
-        description: 'A value in seconds.',
+        description: 'Time in seconds (e.g. 300)',
         inputType: 'number',
         required: arg.required === 'REQUIRED',
         value,
@@ -141,8 +141,8 @@ const argumentAsParameter = (
     case 'ARG_UNIT':
       return {
         argType: arg.argType,
-        name: 'unit',
-        description: 'A unit name',
+        name: 'variable unit',
+        description: 'Unit for the value (e.g. count, meters, degrees)',
         inputType: 'string',
         required: arg.required === 'REQUIRED',
         value,
@@ -162,7 +162,17 @@ const argumentAsParameter = (
       return {
         argType: arg.argType,
         name: 'variable',
-        description: 'A variable name',
+        description: 'Mission-level vs insert parameter syntax',
+        helpLinks: [
+          {
+            label: 'Syntax guide',
+            url: 'https://docs.mbari.org/tethysdash/mission/',
+          },
+          {
+            label: 'LRAUV missions',
+            url: 'https://docs.mbari.org/lrauvmissions/missions/',
+          },
+        ],
         inputType: 'string',
         required: arg.required === 'REQUIRED',
         value,
@@ -181,8 +191,9 @@ const argumentAsParameter = (
     case 'ARG_LIST':
       return {
         argType: arg.argType,
-        name: 'float list',
-        description: 'A list of floating point values',
+        name: 'variable value(s) to set',
+        description:
+          'One or more numbers, comma-separated (e.g. 1 or 1.5, 2.0)',
         inputType: 'string',
         required: arg.required === 'REQUIRED',
         value,
@@ -254,6 +265,7 @@ export interface BuildTemplatedCommandStepProps {
   universals?: OptionSet[]
   onUpdateField?: CommandDetailProps['onSelect']
   onCommandTextChange?: (text: string) => void
+  onReset?: () => void
 }
 
 export const BuildTemplatedCommandStep: React.FC<
@@ -274,6 +286,7 @@ export const BuildTemplatedCommandStep: React.FC<
   onSelectSyntax: handleSelectSyntax,
   onUpdateField: handleUpdatedField,
   onCommandTextChange: handleCommandTextChange,
+  onReset: handleReset,
 }) => {
   // Assign default syntax if none is selected
   useEffect(() => {
@@ -322,16 +335,22 @@ export const BuildTemplatedCommandStep: React.FC<
         if (values[0] === 'Universal') {
           return values?.slice(-1)[0] ?? undefined
         }
-        return values.length > 2
-          ? values
-              .map((v) => {
-                // extract any file name from a path i.e. script path
-                const file = v.match(/[a-zA-Z_]+(?=\.xml|\.tl)/)
-                return file ? file[0] : v
-              })
-              ?.slice(-2)
-              .join('.')
-          : undefined
+        if (values[0] === 'Mission' && values.length >= 2) {
+          const missionFullPath = values[1]
+          const element = values[2]
+          if (!missionFullPath || !element) return undefined
+          // Extract bare filename without extension (e.g. 'sci2_circle_hotspot')
+          const missionName =
+            missionFullPath.match(/[a-zA-Z0-9_]+(?=\.xml|\.tl)/)?.[0] ??
+            missionFullPath.split('/').pop() ??
+            missionFullPath
+          // element is 'ParamName' (root) or 'Insert.ParamName' (scoped)
+          if (element.includes('.')) {
+            return `${missionName}:${element}`
+          }
+          return `${missionName}.${element}`
+        }
+        return undefined
       case 'ARG_UNIVERSAL':
         return values?.slice(-1)[0] ?? undefined
       case 'ARG_COMPONENT':
@@ -339,7 +358,9 @@ export const BuildTemplatedCommandStep: React.FC<
       case 'ARG_COMMAND':
         return value ? values[0] : value
       case 'ARG_MISSION':
-        return value ? values[0] : value
+        if (!value) return value
+        // Single-tier flat path (e.g. 'Science/sci2_circle_hotspot.tl')
+        return values[0]
       case 'ARG_QUOTED_STRING':
         return value ? `"${value}"` : value
       default:
@@ -377,11 +398,21 @@ export const BuildTemplatedCommandStep: React.FC<
   return (
     <section className="flex h-full flex-col">
       <ul className="flex flex-col">
-        <li className="w-full">
-          Build command{' '}
-          <span className="text-teal-500" data-testid="vehicle name">
-            {selectedCommandName}
+        <li className="flex w-full items-center justify-between">
+          <span>
+            Build command{' '}
+            <span className="text-teal-500" data-testid="vehicle name">
+              {selectedCommandName}
+            </span>
           </span>
+          <a
+            href="https://docs.mbari.org/tethysdash/mission/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-blue-500 hover:text-blue-700 hover:underline"
+          >
+            Mission Script Structure Guide
+          </a>
         </li>
         <li className="my-4 flex w-full items-center">
           <p className="mr-2 flex-shrink-0">Choose a syntax</p>

--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
@@ -265,7 +265,6 @@ export interface BuildTemplatedCommandStepProps {
   universals?: OptionSet[]
   onUpdateField?: CommandDetailProps['onSelect']
   onCommandTextChange?: (text: string) => void
-  onReset?: () => void
 }
 
 export const BuildTemplatedCommandStep: React.FC<
@@ -286,7 +285,6 @@ export const BuildTemplatedCommandStep: React.FC<
   onSelectSyntax: handleSelectSyntax,
   onUpdateField: handleUpdatedField,
   onCommandTextChange: handleCommandTextChange,
-  onReset: handleReset,
 }) => {
   // Assign default syntax if none is selected
   useEffect(() => {

--- a/packages/react-ui/src/Modals/CommandModalSteps/SelectCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/SelectCommandStep.tsx
@@ -31,6 +31,8 @@ export interface SelectCommandStepProps extends CommandTableProps {
   frequentCommands?: Command[]
   vehicleName: string
   onMoreInfo?: () => void
+  showAdvanced?: boolean
+  onToggleAdvanced?: () => void
 }
 
 export const SelectCommandStep: React.FC<SelectCommandStepProps> = ({
@@ -42,12 +44,20 @@ export const SelectCommandStep: React.FC<SelectCommandStepProps> = ({
   vehicleName,
   selectedCommandName,
   onMoreInfo: handleMoreInfo,
+  showAdvanced,
+  onToggleAdvanced: handleToggleAdvanced,
 }) => {
   const [selectedCommandId, setSelectedCommandId] =
     useState<SelectCommandStepProps['selectedId']>(selectedId)
   const [selectedFilter, setSelectedFilter] = useState<CommandFilter>('all')
   const [searchTerm, setSearchTerm] = useState('')
-  const [filteredCommands, setFilteredCommands] = useState<Command[]>(commands)
+  const sortedCommands = React.useMemo(
+    () => [...commands].sort((a, b) => a.name.localeCompare(b.name)),
+    [commands]
+  )
+
+  const [filteredCommands, setFilteredCommands] =
+    useState<Command[]>(sortedCommands)
   const [sortColumn, setSortColumn] = useState<number | null | undefined>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>(null)
 
@@ -120,13 +130,21 @@ export const SelectCommandStep: React.FC<SelectCommandStepProps> = ({
     onSelectCommandId,
   ])
 
+  // Commands that are marked advanced in the API but should always appear in the standard list
+  const ALWAYS_SHOW_IN_STANDARD = new Set(['quit', 'strobe'])
+
+  const standardCommands = React.useMemo(
+    () =>
+      commands.filter((c) => !c.advanced || ALWAYS_SHOW_IN_STANDARD.has(c.id)),
+    [commands]
+  )
+
   const lastSelectedFilter = useRef(selectedFilter)
   useEffect(() => {
     if (selectedFilter) {
       if (selectedFilter !== lastSelectedFilter.current) {
         lastSelectedFilter.current = selectedFilter
       }
-      //setSearchTerm('')
       setSortDirection(null)
       switch (selectedFilter) {
         case 'recent':
@@ -136,23 +154,24 @@ export const SelectCommandStep: React.FC<SelectCommandStepProps> = ({
           setFilteredCommands(frequentCommands || [])
           break
         default:
-          setFilteredCommands(commands)
+          setFilteredCommands(sortedCommands)
           break
       }
     }
 
     if (searchTerm) {
+      // Search always runs against all commands regardless of the standard-only toggle
       setSortDirection(null)
-      const searchResults = filteredCommands.filter(({ name }) =>
+      const searchResults = sortedCommands.filter(({ name }) =>
         name.includes(searchTerm)
       )
       setFilteredCommands(searchResults)
     }
 
     if (!selectedFilter && !searchTerm) {
-      setFilteredCommands(commands)
+      setFilteredCommands(sortedCommands)
     }
-  }, [searchTerm, selectedFilter, commands])
+  }, [searchTerm, selectedFilter, sortedCommands])
 
   return (
     <section className="h-full">
@@ -170,7 +189,7 @@ export const SelectCommandStep: React.FC<SelectCommandStepProps> = ({
             />
           )}
         </li>
-        <li className="col-span-3 flex items-center">
+        <li className="col-span-3 flex items-center gap-2">
           <SelectField
             name="Recent commands"
             placeholder="Recent Commands"
@@ -181,15 +200,32 @@ export const SelectCommandStep: React.FC<SelectCommandStepProps> = ({
           <Input
             name="Search commands field"
             placeholder="Search commands"
-            className="ml-2 h-full flex-grow"
+            className="h-full flex-grow"
             value={searchTerm}
             onChange={(e) => handleSearch(e.target.value)}
           />
+          {handleToggleAdvanced && (
+            <label className="flex flex-shrink-0 cursor-pointer items-center gap-1.5 text-xs text-gray-500 select-none">
+              <input
+                type="checkbox"
+                checked={!(showAdvanced ?? true)}
+                onChange={handleToggleAdvanced}
+                className="h-3.5 w-3.5 accent-blue-600"
+              />
+              Standard only
+            </label>
+          )}
         </li>
       </ul>
 
       <CommandTable
-        commands={filteredCommands}
+        commands={
+          !searchTerm && !(showAdvanced ?? true)
+            ? filteredCommands.filter(
+                (c) => !c.advanced || ALWAYS_SHOW_IN_STANDARD.has(c.id)
+              )
+            : filteredCommands
+        }
         selectedId={selectedCommandId ? selectedCommandId : ''}
         onSelectCommand={handleSelectedCommandId}
         onSortColumn={handleSort}

--- a/packages/react-ui/src/Modals/CommandModalSteps/SelectCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/SelectCommandStep.tsx
@@ -133,12 +133,6 @@ export const SelectCommandStep: React.FC<SelectCommandStepProps> = ({
   // Commands that are marked advanced in the API but should always appear in the standard list
   const ALWAYS_SHOW_IN_STANDARD = new Set(['quit', 'strobe'])
 
-  const standardCommands = React.useMemo(
-    () =>
-      commands.filter((c) => !c.advanced || ALWAYS_SHOW_IN_STANDARD.has(c.id)),
-    [commands]
-  )
-
   const lastSelectedFilter = useRef(selectedFilter)
   useEffect(() => {
     if (selectedFilter) {

--- a/packages/react-ui/src/Modals/CommandModalSteps/SelectCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/SelectCommandStep.tsx
@@ -167,7 +167,13 @@ export const SelectCommandStep: React.FC<SelectCommandStepProps> = ({
     if (!selectedFilter && !searchTerm) {
       setFilteredCommands(sortedCommands)
     }
-  }, [searchTerm, selectedFilter, sortedCommands])
+  }, [
+    searchTerm,
+    selectedFilter,
+    sortedCommands,
+    recentCommands,
+    frequentCommands,
+  ])
 
   return (
     <section className="h-full">

--- a/packages/react-ui/src/Modals/CommandModalSteps/SelectCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/SelectCommandStep.tsx
@@ -156,8 +156,10 @@ export const SelectCommandStep: React.FC<SelectCommandStepProps> = ({
     if (searchTerm) {
       // Search always runs against all commands regardless of the standard-only toggle
       setSortDirection(null)
-      const searchResults = sortedCommands.filter(({ name }) =>
-        name.includes(searchTerm)
+      const term = searchTerm.toLowerCase()
+      const searchResults = sortedCommands.filter(
+        ({ name, id }) =>
+          name.toLowerCase().includes(term) || id.toLowerCase().includes(term)
       )
       setFilteredCommands(searchResults)
     }

--- a/packages/react-ui/src/Modals/CommandModalView.tsx
+++ b/packages/react-ui/src/Modals/CommandModalView.tsx
@@ -69,6 +69,8 @@ export interface CommandModalViewProps
   vehicles?: string[]
   showAdvanced?: boolean
   onToggleAdvanced?: () => void
+  /** Called when user clicks Amend Command; returns initial selectedParameters to pre-fill. */
+  onAmendCommand?: (commandText: string) => Record<string, string>
 }
 
 export const CommandModalView: React.FC<CommandModalViewProps> = (props) => (
@@ -112,6 +114,7 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
   onResetParameters: handleResetParameters,
   showAdvanced,
   onToggleAdvanced: handleToggleAdvanced,
+  onAmendCommand: handleAmendCommandExternal,
   defaultCommand,
 }) => {
   const [selectedCommandId, setSelectedCommandId] =
@@ -231,14 +234,36 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
     handleResetParameters?.()
   }
 
-  /* Reset params when command or syntax changes */
+  const handleAmendCommand = () => {
+    const text = commandText ?? selectedCommandName ?? ''
+    const keyword = text.split(/\s+/)[0]?.toLowerCase()
+    const matchingCommand = commands.find(
+      (c) => c.id === keyword || c.name === keyword
+    )
+    if (matchingCommand) {
+      // Parse and store initial params — applied after the reset useEffect fires
+      const initialParams = handleAmendCommandExternal?.(text) ?? {}
+      pendingInitialParams.current = Object.keys(initialParams).length
+        ? initialParams
+        : null
+      // Reset the command name to just the keyword so the Build step header is clean
+      setSelectedCommandName(matchingCommand.name ?? matchingCommand.id)
+      setSelectedCommandId(matchingCommand.id)
+      setUseTemplateStep(true)
+      onSelectCommandId?.(matchingCommand.id)
+    }
+  }
+
+  /* Reset params when command or syntax changes; apply pending amend params if present */
+  const pendingInitialParams = useRef<Record<string, string> | null>(null)
   const lastSyntax = useRef({ selectedSyntax, selectedCommandId })
   useEffect(() => {
     if (
       selectedCommandId !== lastSyntax.current.selectedCommandId ||
       selectedSyntax !== lastSyntax.current.selectedSyntax
     ) {
-      setSelectedParameters({})
+      setSelectedParameters(pendingInitialParams.current ?? {})
+      pendingInitialParams.current = null
       lastSyntax.current = { selectedSyntax, selectedCommandId }
     }
   }, [selectedCommandId, selectedSyntax])
@@ -285,13 +310,21 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
       extraButtons={extraButtons()}
       leftExtraButtons={
         currentStep === 1
-          ? [
-              {
-                buttonText: 'Reset',
-                appearance: 'secondary',
-                onClick: handleReset,
-              },
-            ]
+          ? useTemplateStep
+            ? [
+                {
+                  buttonText: 'Reset',
+                  appearance: 'secondary',
+                  onClick: handleReset,
+                },
+              ]
+            : [
+                {
+                  buttonText: 'Amend Command',
+                  appearance: 'secondary',
+                  onClick: handleAmendCommand,
+                },
+              ]
           : []
       }
       extraWideModal

--- a/packages/react-ui/src/Modals/CommandModalView.tsx
+++ b/packages/react-ui/src/Modals/CommandModalView.tsx
@@ -63,9 +63,12 @@ export interface CommandModalViewProps
   variableTypes?: OptionSet[]
   universals?: OptionSet[]
   onUpdateField?: CommandDetailProps['onSelect']
+  onResetParameters?: () => void
   onSelectModule?: (module: string) => void
   onSelectOutputUri?: (outputUri: string) => void
   vehicles?: string[]
+  showAdvanced?: boolean
+  onToggleAdvanced?: () => void
 }
 
 export const CommandModalView: React.FC<CommandModalViewProps> = (props) => (
@@ -106,6 +109,9 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
   universals,
   decimationTypes,
   onUpdateField: handleUpdatedField,
+  onResetParameters: handleResetParameters,
+  showAdvanced,
+  onToggleAdvanced: handleToggleAdvanced,
   defaultCommand,
 }) => {
   const [selectedCommandId, setSelectedCommandId] =
@@ -220,6 +226,11 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
       handleUpdatedField?.(param, argType, value)
     }
 
+  const handleReset = () => {
+    setSelectedParameters({})
+    handleResetParameters?.()
+  }
+
   /* Reset params when command or syntax changes */
   const lastSyntax = useRef({ selectedSyntax, selectedCommandId })
   useEffect(() => {
@@ -272,6 +283,17 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
       onCancel={onCancel}
       confirmButtonText={confirmButtonText}
       extraButtons={extraButtons()}
+      leftExtraButtons={
+        currentStep === 1
+          ? [
+              {
+                buttonText: 'Reset',
+                appearance: 'secondary',
+                onClick: handleReset,
+              },
+            ]
+          : []
+      }
       extraWideModal
       bodyOverflowHidden
       snapTo="top-right"
@@ -286,6 +308,8 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
           onSelectCommandId={handleSelectCommandId}
           onMoreInfo={handleMoreInfo}
           vehicleName={vehicleName}
+          showAdvanced={showAdvanced}
+          onToggleAdvanced={handleToggleAdvanced}
         />
       )}
 
@@ -312,6 +336,7 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
               },
             ]}
             onCommandTextChange={setCommandText}
+            onReset={handleReset}
           />
         ) : (
           <BuildFreeformCommandStep

--- a/packages/react-ui/src/Modals/CommandModalView.tsx
+++ b/packages/react-ui/src/Modals/CommandModalView.tsx
@@ -229,6 +229,7 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
 
   const handleReset = () => {
     setSelectedParameters({})
+    setSelectedSyntax(null)
     handleResetParameters?.()
   }
 
@@ -244,8 +245,9 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
       pendingInitialParams.current = Object.keys(initialParams).length
         ? initialParams
         : null
-      // Reset the command name to just the keyword so the Build step header is clean
-      setSelectedCommandName(matchingCommand.name ?? matchingCommand.id)
+      // Use the canonical keyword (id) so the correct keyword is sent to the vehicle,
+      // not a display alias such as 'failc' instead of 'failComponent'
+      setSelectedCommandName(matchingCommand.id)
       setSelectedCommandId(matchingCommand.id)
       setUseTemplateStep(true)
       onSelectCommandId?.(matchingCommand.id)

--- a/packages/react-ui/src/Modals/CommandModalView.tsx
+++ b/packages/react-ui/src/Modals/CommandModalView.tsx
@@ -254,19 +254,19 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
     }
   }
 
-  /* Reset params when command or syntax changes; apply pending amend params if present */
+  /* Reset params when command changes; apply pending amend params if present.
+     Intentionally excludes selectedSyntax: BuildTemplatedCommandStep auto-selects
+     the default syntax on mount, which would fire a second time and wipe pending
+     amend params after pendingInitialParams has already been cleared. */
   const pendingInitialParams = useRef<Record<string, string> | null>(null)
-  const lastSyntax = useRef({ selectedSyntax, selectedCommandId })
+  const lastCommandId = useRef(selectedCommandId)
   useEffect(() => {
-    if (
-      selectedCommandId !== lastSyntax.current.selectedCommandId ||
-      selectedSyntax !== lastSyntax.current.selectedSyntax
-    ) {
+    if (selectedCommandId !== lastCommandId.current) {
       setSelectedParameters(pendingInitialParams.current ?? {})
       pendingInitialParams.current = null
-      lastSyntax.current = { selectedSyntax, selectedCommandId }
+      lastCommandId.current = selectedCommandId
     }
-  }, [selectedCommandId, selectedSyntax])
+  }, [selectedCommandId])
 
   const handleSchedule = () => {
     onSchedule({

--- a/packages/react-ui/src/Modals/CommandModalView.tsx
+++ b/packages/react-ui/src/Modals/CommandModalView.tsx
@@ -238,7 +238,7 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
     const text = commandText ?? selectedCommandName ?? ''
     const keyword = text.split(/\s+/)[0]?.toLowerCase()
     const matchingCommand = commands.find(
-      (c) => c.id === keyword || c.name === keyword
+      (c) => c.id.toLowerCase() === keyword || c.name.toLowerCase() === keyword
     )
     if (matchingCommand) {
       // Parse and store initial params — applied after the reset useEffect fires

--- a/packages/react-ui/src/Modals/CommandModalView.tsx
+++ b/packages/react-ui/src/Modals/CommandModalView.tsx
@@ -67,8 +67,6 @@ export interface CommandModalViewProps
   onSelectModule?: (module: string) => void
   onSelectOutputUri?: (outputUri: string) => void
   vehicles?: string[]
-  showAdvanced?: boolean
-  onToggleAdvanced?: () => void
   /** Called when user clicks Amend Command; returns initial selectedParameters to pre-fill. */
   onAmendCommand?: (commandText: string) => Record<string, string>
 }
@@ -369,7 +367,6 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
               },
             ]}
             onCommandTextChange={setCommandText}
-            onReset={handleReset}
           />
         ) : (
           <BuildFreeformCommandStep

--- a/packages/react-ui/src/Modals/CommandModalView.tsx
+++ b/packages/react-ui/src/Modals/CommandModalView.tsx
@@ -255,18 +255,31 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
   }
 
   /* Reset params when command changes; apply pending amend params if present.
-     Intentionally excludes selectedSyntax: BuildTemplatedCommandStep auto-selects
-     the default syntax on mount, which would fire a second time and wipe pending
-     amend params after pendingInitialParams has already been cleared. */
+     skipNextSyntaxReset is set when a command changes so the first
+     auto-selected syntax (from BuildTemplatedCommandStep mount) doesn't wipe
+     the amend params that were just applied. Subsequent manual syntax switches
+     by the user DO reset params as expected. */
   const pendingInitialParams = useRef<Record<string, string> | null>(null)
   const lastCommandId = useRef(selectedCommandId)
+  const skipNextSyntaxReset = useRef(false)
+
   useEffect(() => {
     if (selectedCommandId !== lastCommandId.current) {
       setSelectedParameters(pendingInitialParams.current ?? {})
       pendingInitialParams.current = null
       lastCommandId.current = selectedCommandId
+      skipNextSyntaxReset.current = true
     }
   }, [selectedCommandId])
+
+  useEffect(() => {
+    if (!selectedSyntax) return
+    if (skipNextSyntaxReset.current) {
+      skipNextSyntaxReset.current = false
+      return
+    }
+    setSelectedParameters({})
+  }, [selectedSyntax])
 
   const handleSchedule = () => {
     onSchedule({
@@ -318,13 +331,15 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
                   onClick: handleReset,
                 },
               ]
-            : [
+            : handleAmendCommandExternal
+            ? [
                 {
                   buttonText: 'Amend Command',
                   appearance: 'secondary',
                   onClick: handleAmendCommand,
                 },
               ]
+            : []
           : []
       }
       extraWideModal
@@ -365,7 +380,7 @@ const CommandModalBody: React.FC<CommandModalViewProps> = ({
             commands={[
               {
                 name: 'Command',
-                options: commands.map((c) => c.name),
+                options: commands.map((c) => c.id),
               },
             ]}
             onCommandTextChange={setCommandText}

--- a/packages/react-ui/src/Tables/CommandDetailTable.test.tsx
+++ b/packages/react-ui/src/Tables/CommandDetailTable.test.tsx
@@ -4,6 +4,7 @@ import {
   CommandDetailTable,
   CommandDetailProps,
   getValues,
+  mapValues,
   scopedValues,
   OptionSet,
   scopedSelectOptions,
@@ -145,6 +146,12 @@ describe('scopedSelectOptions', () => {
     ])
   })
 
+  test('should not include groupedOptions or pinnedNames keys when not provided', () => {
+    const values = scopedSelectOptions('', optionSets)
+    expect(Object.keys(values[0])).not.toContain('groupedOptions')
+    expect(Object.keys(values[0])).not.toContain('pinnedNames')
+  })
+
   test('should extract the sets for all three levels if the first two options are selected', async () => {
     const testValue = 'Module____Control::::Component____LoopControl'
     const values = scopedSelectOptions(testValue, optionSets)
@@ -187,5 +194,86 @@ describe('scopedSelectOptions', () => {
         ],
       },
     ])
+  })
+})
+
+describe('scopedSelectOptions with groupBy', () => {
+  const missionGroupBy = (path: string) => {
+    const slash = path.lastIndexOf('/')
+    return slash >= 0 ? path.slice(0, slash) : 'Standard Ops'
+  }
+
+  const missionOptionSets: OptionSet[] = [
+    {
+      name: 'Mission',
+      options: ['Science/sci2_circle.tl', 'Science/profile.xml', 'quick.tl'],
+      groupBy: missionGroupBy,
+    },
+  ]
+
+  test('should produce groupedOptions when groupBy is provided', () => {
+    const [tier] = scopedSelectOptions('', missionOptionSets)
+    expect(tier.groupedOptions).toBeDefined()
+    const labels = tier.groupedOptions?.map((g) => g.label)
+    expect(labels).toContain('Science')
+    expect(labels).toContain('Standard Ops')
+  })
+
+  test('should strip file extensions from grouped option display names', () => {
+    const [tier] = scopedSelectOptions('', missionOptionSets)
+    const scienceGroup = tier.groupedOptions?.find((g) => g.label === 'Science')
+    expect(scienceGroup?.options.map((o) => o.name)).toEqual([
+      'sci2_circle',
+      'profile',
+    ])
+  })
+
+  test('should strip file extensions from flat option display names', () => {
+    const [tier] = scopedSelectOptions('', missionOptionSets)
+    const rootGroup = tier.groupedOptions?.find(
+      (g) => g.label === 'Standard Ops'
+    )
+    expect(rootGroup?.options.map((o) => o.name)).toEqual(['quick'])
+  })
+
+  test('should not include groupedOptions key when groupBy is not provided', () => {
+    const flatSets: OptionSet[] = [{ name: 'Module', options: ['A', 'B'] }]
+    const [tier] = scopedSelectOptions('', flatSets)
+    expect(Object.keys(tier)).not.toContain('groupedOptions')
+  })
+})
+
+describe('scopedSelectOptions with pinnedNames', () => {
+  test('should include pinnedNames key when provided', () => {
+    const sets: OptionSet[] = [
+      { name: 'Mission', options: ['Science/sci2.tl'], pinnedNames: ['sci2'] },
+    ]
+    const [tier] = scopedSelectOptions('', sets)
+    expect(tier.pinnedNames).toEqual(['sci2'])
+  })
+
+  test('should not include pinnedNames key when not provided', () => {
+    const sets: OptionSet[] = [
+      { name: 'Mission', options: ['Science/sci2.tl'] },
+    ]
+    const [tier] = scopedSelectOptions('', sets)
+    expect(Object.keys(tier)).not.toContain('pinnedNames')
+  })
+})
+
+describe('mapValues', () => {
+  test('should return an empty object for an empty string', () => {
+    expect(mapValues('')).toEqual({})
+  })
+
+  test('should return the correct key-value map for a single tier', () => {
+    expect(mapValues('Module____Science')).toEqual({ Module: 'Science' })
+  })
+
+  test('should return the correct key-value map for multiple tiers', () => {
+    expect(mapValues('Module____Control::::Component____LoopControl')).toEqual({
+      Module: 'Control',
+      Component: 'LoopControl',
+    })
   })
 })

--- a/packages/react-ui/src/Tables/CommandDetailTable.tsx
+++ b/packages/react-ui/src/Tables/CommandDetailTable.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import clsx from 'clsx'
 import { Table } from '../Data/Table'
-import { Select, SelectOption } from '../Fields/Select'
+import { Select, SelectOption, SelectOptionGroup } from '../Fields/Select'
+import { MissionCascader } from '../Fields/MissionCascader'
 import { Input } from '../Fields/Input'
 
 const L_SEPARATOR = '____'
@@ -39,12 +40,20 @@ export interface CommandDetailProps {
 export interface OptionSet {
   name: string
   options: string[]
+  /** When provided, groups options under labelled headings inside a single dropdown. */
+  groupBy?: (option: string) => string
+}
+
+export interface HelpLink {
+  label: string
+  url: string
 }
 
 export interface CommandParameter {
   argType: ArgumentType
   name: string
   description: string
+  helpLinks?: HelpLink[]
   value?: string
   options?: OptionSet[]
   inputType: 'string' | 'boolean' | 'number'
@@ -55,6 +64,7 @@ export interface ScopedOptionGroup {
   name: string
   value?: string
   options: SelectOption[]
+  groupedOptions?: SelectOptionGroup[]
 }
 
 export const explodeValues = (valueString: string) =>
@@ -86,28 +96,58 @@ export const scopedSelectOptions = (
   const values = scopedValues(valueString ?? '')
   const options = optionSets
     .filter((_, i) => i <= values.length)
-    .map(({ name, options }, i) => ({
-      name,
-      value: values[i],
-      options: options.map((option) => ({
-        id: [i ? values[i - 1] : '', [name, option].join(L_SEPARATOR)]
-          .filter((i) => i)
-          .join(V_SEPARATOR),
-        name: option,
-      })),
-    }))
+    .map(({ name, options, groupBy }, i) => {
+      const buildId = (option: string) =>
+        [i ? values[i - 1] : '', [name, option].join(L_SEPARATOR)]
+          .filter((x) => x)
+          .join(V_SEPARATOR)
+
+      const flatOptions: SelectOption[] = options.map((option) => ({
+        id: buildId(option),
+        name: groupBy ? option.split('/').pop() ?? option : option,
+      }))
+
+      let groupedOptions: SelectOptionGroup[] | undefined
+      if (groupBy) {
+        const map = new Map<string, SelectOption[]>()
+        options.forEach((option) => {
+          const label = groupBy(option)
+          if (!map.has(label)) map.set(label, [])
+          map.get(label)!.push({
+            id: buildId(option),
+            name: option.split('/').pop() ?? option,
+          })
+        })
+        groupedOptions = Array.from(map.entries()).map(([label, opts]) => ({
+          label,
+          options: opts,
+        }))
+      }
+
+      return { name, value: values[i], options: flatOptions, groupedOptions }
+    })
   return options
 }
 
-const makePlaceholder = (name: string, required?: boolean) =>
-  `${name} (${required ? 'Required' : 'Optional'})`
+const makePlaceholder = (name: string, required?: boolean) => {
+  const capitalized = name.charAt(0).toUpperCase() + name.slice(1)
+  return `${capitalized} (${required ? 'Required' : 'Optional'})`
+}
 
 const makeRow = (
   command: CommandParameter,
   onSelect: CommandDetailProps['onSelect']
 ) => {
-  const { argType, name, description, value, options, required, inputType } =
-    command
+  const {
+    argType,
+    name,
+    description,
+    helpLinks,
+    value,
+    options,
+    required,
+    inputType,
+  } = command
 
   const handleSelect = (id: string) => {
     onSelect(name, argType, id)
@@ -154,22 +194,51 @@ const makeRow = (
   return {
     cells: [
       { label: name },
-      { label: description },
+      {
+        label: (
+          <span className="flex flex-wrap items-center gap-1">
+            <span>{description}</span>
+            {helpLinks?.map(({ label, url }) => (
+              <a
+                key={url}
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center rounded border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-xs text-blue-600 hover:bg-blue-100 hover:text-blue-800"
+              >
+                {label}
+              </a>
+            ))}
+          </span>
+        ),
+      },
       {
         label: selectOptions ? (
           <ul className="flex flex-col">
-            {selectOptions?.map(({ name, value, options }, i) => (
-              <li key={name}>
-                <Select
-                  name={name}
-                  options={options}
-                  value={value}
-                  placeholder={makePlaceholder(name, required)}
-                  onSelect={(id) => handleSelect(id || '')}
-                  clearable={!required}
-                />
-              </li>
-            ))}
+            {selectOptions?.map(
+              ({ name, value, options, groupedOptions }, i) => (
+                <li key={name}>
+                  {groupedOptions ? (
+                    <MissionCascader
+                      groups={groupedOptions}
+                      value={value}
+                      placeholder={makePlaceholder(name, required)}
+                      onSelect={(id) => handleSelect(id || '')}
+                      clearable={!required}
+                    />
+                  ) : (
+                    <Select
+                      name={name}
+                      options={options}
+                      value={value}
+                      placeholder={makePlaceholder(name, required)}
+                      onSelect={(id) => handleSelect(id || '')}
+                      clearable={!required}
+                    />
+                  )}
+                </li>
+              )
+            )}
           </ul>
         ) : (
           <section className="flex h-full w-full items-center">{input}</section>

--- a/packages/react-ui/src/Tables/CommandDetailTable.tsx
+++ b/packages/react-ui/src/Tables/CommandDetailTable.tsx
@@ -78,7 +78,7 @@ export const splitValues = (valueString: string) =>
 
 export const mapValues = (valueString: string) =>
   splitValues(valueString).reduce((acc, [k, v]) => {
-    acc[k] = v
+    if (k) acc[k] = v
     return acc
   }, {} as Record<string, string>)
 
@@ -133,8 +133,8 @@ export const scopedSelectOptions = (
         name,
         value: values[i],
         options: flatOptions,
-        groupedOptions,
-        pinnedNames,
+        ...(groupedOptions !== undefined && { groupedOptions }),
+        ...(pinnedNames !== undefined && { pinnedNames }),
       }
     })
   return options
@@ -227,7 +227,7 @@ const makeRow = (
         label: selectOptions ? (
           <ul className="flex flex-col">
             {selectOptions?.map(
-              ({ name, value, options, groupedOptions, pinnedNames }, i) => (
+              ({ name, value, options, groupedOptions, pinnedNames }) => (
                 <li key={name}>
                   {groupedOptions ? (
                     <MissionCascader

--- a/packages/react-ui/src/Tables/CommandDetailTable.tsx
+++ b/packages/react-ui/src/Tables/CommandDetailTable.tsx
@@ -105,9 +105,11 @@ export const scopedSelectOptions = (
           .filter((x) => x)
           .join(V_SEPARATOR)
 
+      const stripExt = (s: string) => s.replace(/\.(tl|xml|py)$/i, '')
+
       const flatOptions: SelectOption[] = options.map((option) => ({
         id: buildId(option),
-        name: groupBy ? option.split('/').pop() ?? option : option,
+        name: groupBy ? stripExt(option.split('/').pop() ?? option) : option,
       }))
 
       let groupedOptions: SelectOptionGroup[] | undefined
@@ -118,7 +120,7 @@ export const scopedSelectOptions = (
           if (!map.has(label)) map.set(label, [])
           map.get(label)!.push({
             id: buildId(option),
-            name: option.split('/').pop() ?? option,
+            name: stripExt(option.split('/').pop() ?? option),
           })
         })
         groupedOptions = Array.from(map.entries()).map(([label, opts]) => ({

--- a/packages/react-ui/src/Tables/CommandDetailTable.tsx
+++ b/packages/react-ui/src/Tables/CommandDetailTable.tsx
@@ -5,8 +5,8 @@ import { Select, SelectOption, SelectOptionGroup } from '../Fields/Select'
 import { MissionCascader } from '../Fields/MissionCascader'
 import { Input } from '../Fields/Input'
 
-const L_SEPARATOR = '____'
-const V_SEPARATOR = '::::'
+export const L_SEPARATOR = '____'
+export const V_SEPARATOR = '::::'
 
 export type ArgumentType =
   | 'ARG_COMMAND'
@@ -42,6 +42,8 @@ export interface OptionSet {
   options: string[]
   /** When provided, groups options under labelled headings inside a single dropdown. */
   groupBy?: (option: string) => string
+  /** Mission base names (without extension) to pin at the top as "Recently used". */
+  pinnedNames?: string[]
 }
 
 export interface HelpLink {
@@ -65,6 +67,7 @@ export interface ScopedOptionGroup {
   value?: string
   options: SelectOption[]
   groupedOptions?: SelectOptionGroup[]
+  pinnedNames?: string[]
 }
 
 export const explodeValues = (valueString: string) =>
@@ -96,7 +99,7 @@ export const scopedSelectOptions = (
   const values = scopedValues(valueString ?? '')
   const options = optionSets
     .filter((_, i) => i <= values.length)
-    .map(({ name, options, groupBy }, i) => {
+    .map(({ name, options, groupBy, pinnedNames }, i) => {
       const buildId = (option: string) =>
         [i ? values[i - 1] : '', [name, option].join(L_SEPARATOR)]
           .filter((x) => x)
@@ -124,7 +127,13 @@ export const scopedSelectOptions = (
         }))
       }
 
-      return { name, value: values[i], options: flatOptions, groupedOptions }
+      return {
+        name,
+        value: values[i],
+        options: flatOptions,
+        groupedOptions,
+        pinnedNames,
+      }
     })
   return options
 }
@@ -216,7 +225,7 @@ const makeRow = (
         label: selectOptions ? (
           <ul className="flex flex-col">
             {selectOptions?.map(
-              ({ name, value, options, groupedOptions }, i) => (
+              ({ name, value, options, groupedOptions, pinnedNames }, i) => (
                 <li key={name}>
                   {groupedOptions ? (
                     <MissionCascader
@@ -225,6 +234,7 @@ const makeRow = (
                       placeholder={makePlaceholder(name, required)}
                       onSelect={(id) => handleSelect(id || '')}
                       clearable={!required}
+                      pinnedNames={pinnedNames}
                     />
                   ) : (
                     <Select

--- a/packages/react-ui/src/Tables/CommandTable.tsx
+++ b/packages/react-ui/src/Tables/CommandTable.tsx
@@ -19,6 +19,7 @@ export interface Command {
   name: string
   description?: string
   vehicle?: string
+  advanced?: boolean
 }
 
 export const CommandTable: React.FC<CommandTableProps> = ({


### PR DESCRIPTION
## Summary

Closes #696. Comprehensive UX improvements to the **Build a Command** modal, focusing on mission variable selection and command discoverability.

### Mission variable picker
- New `MissionCascader` component: accordion-style folder/file picker with search, portal rendering for correct z-index, and priority-sorted folders (Standard Ops first, Deprecated/underscore last)
- Support for insert-scoped variables (`mission:Insert.Param` syntax) — fixes missing Science/module section parameters reported in #696 and validated by field report from user Chris
- Tiered variable picker: Variable Type → Mission (cascader) → Element (flat searchable list)
- Parameters alphabetized within the element dropdown
- Consistent mission picker applied to `ARG_MISSION` commands (e.g. `load`)

### Command selection UX
- **Standard only** toggle: hides `advanced=true` commands by default (shown by default, toggle to narrow)
- Search always runs against all commands regardless of the standard-only filter
- Default command list sorted alphabetically
- `quit` and `strobe` whitelisted to always appear in standard mode despite API `advanced` flag
- `failc` display alias for `failComponent` keyword (vehicle still receives `failComponent`)

### Modal polish
- Reset button added to modal footer (next to Cancel)
- Help links to [Mission Script Structure Guide](https://docs.mbari.org/tethysdash/mission/) and [LRAUV Missions](https://docs.mbari.org/lrauvmissions/missions/) in Build step
- `Input` field styling: consistent border, placeholder color, and min-height matching dropdowns
- Fix `buttonText` DOM prop warning in `Footer` by destructuring before spread

## Test plan
- [ ] Open Build a Command → set → Mission → verify Science folder missions appear in cascader
- [ ] Select `sci2_circle_hotspot` → verify `MedianFilterLen` appears in Element dropdown
- [ ] Verify insert-scoped variables show as `Mission:Insert.Param` in command text
- [ ] Toggle Standard only → verify `failComponent`/`burn`/`!` hidden; `quit`/`strobe` visible
- [ ] Search for `failc` → appears in results; command sent as `failComponent`
- [ ] Verify Reset button in footer clears all Build step selections
- [ ] Verify help links open correct docs pages