### PR TITLE
fix: remove stale Mission Script Guide link and clarify variable description

### DIFF
--- a/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
+++ b/packages/react-ui/src/Modals/CommandModalSteps/BuildTemplatedCommandStep.tsx
@@ -162,12 +162,8 @@ const argumentAsParameter = (
       return {
         argType: arg.argType,
         name: 'variable',
-        description: 'Mission-level vs insert parameter syntax',
+        description: 'Mission-level and insert parameter syntax',
         helpLinks: [
-          {
-            label: 'Syntax guide',
-            url: 'https://docs.mbari.org/tethysdash/mission/',
-          },
           {
             label: 'LRAUV missions',
             url: 'https://docs.mbari.org/lrauvmissions/missions/',
@@ -411,14 +407,6 @@ export const BuildTemplatedCommandStep: React.FC<
               {selectedCommandName}
             </span>
           </span>
-          <a
-            href="https://docs.mbari.org/tethysdash/mission/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-blue-500 hover:text-blue-700 hover:underline"
-          >
-            Mission Script Structure Guide
-          </a>
         </li>
         <li className="my-4 flex w-full items-center">
           <p className="mr-2 flex-shrink-0">Choose a syntax</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,23 +15,6 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@azure/msal-browser@^5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-browser/-/msal-browser-5.12.0.tgz#b3977a3390ab8fefddfed155d8a61603cdd69c96"
-  integrity sha512-eNf2aqx1C6I0yT1GEu5ukblFrmaBXGfe1bivpmlfqvK7giPZvoXLa404C8EfeHVsy6EIryfQuPRzuW1fPxWlHg==
-  dependencies:
-    "@azure/msal-common" "16.7.0"
-
-"@azure/msal-common@16.7.0":
-  version "16.7.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-16.7.0.tgz#ee3f3eb1c86961bc559e0db2a2bd3d147f8001dd"
-  integrity sha512-Jb8Y7pX6KM42SIT7KWP6YbY3+vLbwB5b5m+tpiiOzMU1QeyelQzs9lO8jv1e7/Uj9r7tg7VjPvW4T0KB1jF3UQ==
-
-"@azure/msal-react@^5.4.3":
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/@azure/msal-react/-/msal-react-5.4.3.tgz#4b9a0da41e706c7387639f15edbc4e2d97d64e8c"
-  integrity sha512-hBc/Gpk5/A8uK9tyHvNMYlJEU+vYeYBpg9IlSfmAm4CGiOCgYx7U1fnwOq1QWBj9+/jHqv93ZJ5mg6eBpPzNfg==
-
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz"


### PR DESCRIPTION
## Summary

- Removes the outdated "Mission Script Structure Guide" link from the Build Command step header in the command builder modal (`docs.mbari.org/tethysdash/mission/` is no longer current)
- Updates the `ARG_VARIABLE` field description from "Mission-level vs insert parameter syntax" to "Mission-level and insert parameter syntax" for clearer readability
- Cleans up stale `@azure/msal-browser`, `@azure/msal-common`, and `@azure/msal-react` entries from `yarn.lock`

## Test plan

- [ ] Open the command builder modal and navigate to the Build Command step — confirm the Mission Script Structure Guide link is gone
- [ ] Select a command with a variable argument — confirm the field description reads "Mission-level and insert parameter syntax"