### PR TITLE
feat: filter unit choices by selected mission parameter in Build a Command

### DIFF
--- a/apps/lrauv-dash2/components/CommandModal.test.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.test.tsx
@@ -24,7 +24,7 @@ describe('getFilteredUnitAbbreviations', () => {
     expect(result).toEqual(ALL_UNITS.map((u) => u.abbreviation))
   })
 
-  test('returns all abbreviations when unitsData is undefined', () => {
+  test('returns an empty array when unitsData is undefined', () => {
     const result = getFilteredUnitAbbreviations(undefined, 'meter')
     expect(result).toEqual([])
   })

--- a/apps/lrauv-dash2/components/CommandModal.test.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.test.tsx
@@ -1,0 +1,60 @@
+import { getFilteredUnitAbbreviations, UnitEntry } from './CommandModal'
+
+const TIME_UNITS: UnitEntry[] = [
+  { name: 'second', abbreviation: 's', baseUnit: undefined },
+  { name: 'millisecond', abbreviation: 'ms', baseUnit: 'second' },
+  { name: 'microsecond', abbreviation: 'us', baseUnit: 'second' },
+  { name: 'minute', abbreviation: 'min', baseUnit: 'second' },
+  { name: 'hour', abbreviation: 'h', baseUnit: 'second' },
+  { name: 'day', abbreviation: 'd', baseUnit: 'second' },
+]
+
+const LENGTH_UNITS: UnitEntry[] = [
+  { name: 'meter', abbreviation: 'm', baseUnit: undefined },
+  { name: 'centimeter', abbreviation: 'cm', baseUnit: 'meter' },
+  { name: 'kilometer', abbreviation: 'km', baseUnit: 'meter' },
+  { name: 'nautical_mile', abbreviation: 'nmi', baseUnit: 'meter' },
+]
+
+const ALL_UNITS = [...TIME_UNITS, ...LENGTH_UNITS]
+
+describe('getFilteredUnitAbbreviations', () => {
+  test('returns all abbreviations when selectedArgUnit is undefined', () => {
+    const result = getFilteredUnitAbbreviations(ALL_UNITS, undefined)
+    expect(result).toEqual(ALL_UNITS.map((u) => u.abbreviation))
+  })
+
+  test('returns all abbreviations when unitsData is undefined', () => {
+    const result = getFilteredUnitAbbreviations(undefined, 'meter')
+    expect(result).toEqual([])
+  })
+
+  test('filters to compatible length units when parameter unit is "meter"', () => {
+    const result = getFilteredUnitAbbreviations(ALL_UNITS, 'meter')
+    expect(result).toEqual(['m', 'cm', 'km', 'nmi'])
+    expect(result).not.toContain('s')
+    expect(result).not.toContain('h')
+  })
+
+  test('resolves canonical base unit and filters time units when parameter unit is "hour"', () => {
+    // hour.baseUnit = second, so canonical base = second
+    const result = getFilteredUnitAbbreviations(ALL_UNITS, 'hour')
+    expect(result).toContain('s')
+    expect(result).toContain('h')
+    expect(result).toContain('min')
+    expect(result).not.toContain('m')
+    expect(result).not.toContain('km')
+  })
+
+  test('sorts time units by abbreviation length so short forms appear first', () => {
+    const result = getFilteredUnitAbbreviations(ALL_UNITS, 'hour')
+    const lengths = result.map((a) => a.length)
+    expect(lengths).toEqual([...lengths].sort((a, b) => a - b))
+    expect(result[0]).toBe('s')
+  })
+
+  test('falls back to all abbreviations when no compatible units are found', () => {
+    const result = getFilteredUnitAbbreviations(ALL_UNITS, 'unknown_unit')
+    expect(result).toEqual(ALL_UNITS.map((u) => u.abbreviation))
+  })
+})

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -218,10 +218,14 @@ export const CommandModal: React.FC<CommandModalProps> = ({
 
   const filteredUnitAbbreviations = React.useMemo(() => {
     if (!selectedArgUnit) return allUnitAbbreviations
+    // Resolve the canonical base unit: e.g. "hour" → baseUnit "second",
+    // "meter_per_second" → no baseUnit so canonical base is itself.
+    const selectedUnitEntry = unitsData?.find((u) => u.name === selectedArgUnit)
+    const canonicalBase = selectedUnitEntry?.baseUnit ?? selectedArgUnit
     const compatible =
       unitsData
         ?.filter(
-          (u) => u.name === selectedArgUnit || u.baseUnit === selectedArgUnit
+          (u) => u.name === canonicalBase || u.baseUnit === canonicalBase
         )
         .map((u) => u.abbreviation) ?? []
     return compatible.length > 0 ? compatible : allUnitAbbreviations

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -192,6 +192,16 @@ export const CommandModal: React.FC<CommandModalProps> = ({
 
   const allUnitAbbreviations = unitsData?.map((u) => u.abbreviation) ?? []
 
+  // Display label map: abbreviation → human-readable name (e.g. h → hour, min → minute)
+  const unitLabels: Record<string, string> = React.useMemo(
+    () =>
+      (unitsData ?? []).reduce<Record<string, string>>((acc, u) => {
+        acc[u.abbreviation] = u.name.replace(/_/g, ' ')
+        return acc
+      }, {}),
+    [unitsData]
+  )
+
   // When a Mission element is selected, derive its unit from the script args and
   // filter the units dropdown to only show compatible options (same baseUnit).
   // Falls back to all units if no unit info is available for the selected parameter.
@@ -384,7 +394,13 @@ export const CommandModal: React.FC<CommandModalProps> = ({
       steps={steps}
       onSelectCommandId={setCurrentCommand}
       syntaxVariations={syntaxVariations ?? []}
-      units={[{ name: 'Units', options: filteredUnitAbbreviations }]}
+      units={[
+        {
+          name: 'Units',
+          options: filteredUnitAbbreviations,
+          optionLabels: unitLabels,
+        },
+      ]}
       universals={[{ name: 'Universal', options: universalData ?? [] }]}
       missions={missionTypeOptions}
       decimationTypes={[{ name: 'Decimation Type', options: decimationTypes }]}

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -217,11 +217,6 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   ]
   const moduleNames = makeModuleNames(variable)
 
-  const allUnitAbbreviations = React.useMemo(
-    () => unitsData?.map((u) => u.abbreviation) ?? [],
-    [unitsData]
-  )
-
   // Display label map: abbreviation → human-readable name (e.g. h → hour, min → minute)
   const unitLabels: Record<string, string> = React.useMemo(
     () =>

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -190,7 +190,10 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   ]
   const moduleNames = makeModuleNames(variable)
 
-  const allUnitAbbreviations = unitsData?.map((u) => u.abbreviation) ?? []
+  const allUnitAbbreviations = React.useMemo(
+    () => unitsData?.map((u) => u.abbreviation) ?? [],
+    [unitsData]
+  )
 
   // Display label map: abbreviation → human-readable name (e.g. h → hour, min → minute)
   const unitLabels: Record<string, string> = React.useMemo(

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -26,6 +26,33 @@ import { useRouter } from 'next/router'
 import toast from 'react-hot-toast'
 import useGlobalModalId from '../lib/useGlobalModalId'
 
+export interface UnitEntry {
+  name: string
+  abbreviation: string
+  baseUnit?: string
+}
+
+/** Pure helper — exported for testing. */
+export const getFilteredUnitAbbreviations = (
+  unitsData: UnitEntry[] | undefined,
+  selectedArgUnit: string | undefined
+): string[] => {
+  const all = unitsData?.map((u) => u.abbreviation) ?? []
+  if (!selectedArgUnit) return all
+  const selectedUnitEntry = unitsData?.find((u) => u.name === selectedArgUnit)
+  const canonicalBase = selectedUnitEntry?.baseUnit ?? selectedArgUnit
+  const compatible =
+    unitsData
+      ?.filter((u) => u.name === canonicalBase || u.baseUnit === canonicalBase)
+      .map((u) => u.abbreviation) ?? []
+  // Mirror ParameterField: sort time-based units by abbreviation length
+  // so short forms (s, h, d) appear before longer ones (min, ms, etc.)
+  if (canonicalBase === 'second') {
+    compatible.sort((a, b) => a.length - b.length)
+  }
+  return compatible.length > 0 ? compatible : all
+}
+
 export interface CommandModalProps {
   onClose: () => void
   className?: string
@@ -229,20 +256,10 @@ export const CommandModal: React.FC<CommandModalProps> = ({
     return undefined
   }, [variable, selectedMissionData])
 
-  const filteredUnitAbbreviations = React.useMemo(() => {
-    if (!selectedArgUnit) return allUnitAbbreviations
-    // Resolve the canonical base unit: e.g. "hour" → baseUnit "second",
-    // "meter_per_second" → no baseUnit so canonical base is itself.
-    const selectedUnitEntry = unitsData?.find((u) => u.name === selectedArgUnit)
-    const canonicalBase = selectedUnitEntry?.baseUnit ?? selectedArgUnit
-    const compatible =
-      unitsData
-        ?.filter(
-          (u) => u.name === canonicalBase || u.baseUnit === canonicalBase
-        )
-        .map((u) => u.abbreviation) ?? []
-    return compatible.length > 0 ? compatible : allUnitAbbreviations
-  }, [unitsData, selectedArgUnit, allUnitAbbreviations])
+  const filteredUnitAbbreviations = React.useMemo(
+    () => getFilteredUnitAbbreviations(unitsData, selectedArgUnit),
+    [unitsData, selectedArgUnit]
+  )
 
   // Display aliases: shown in UI but the original keyword is still sent to the vehicle
   const COMMAND_DISPLAY_ALIASES: Record<string, string> = {

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -190,7 +190,42 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   ]
   const moduleNames = makeModuleNames(variable)
 
-  const units = unitsData?.map((u) => u.abbreviation) ?? []
+  const allUnitAbbreviations = unitsData?.map((u) => u.abbreviation) ?? []
+
+  // When a Mission element is selected, derive its unit from the script args and
+  // filter the units dropdown to only show compatible options (same baseUnit).
+  // Falls back to all units if no unit info is available for the selected parameter.
+  const selectedArgUnit = React.useMemo(() => {
+    if (
+      variable['Variable Type'] !== 'Mission' ||
+      !variable.Element ||
+      !selectedMissionData
+    )
+      return undefined
+    const element = variable.Element
+    const rootArg = selectedMissionData.scriptArgs?.find(
+      (a) => a.name === element
+    )
+    if (rootArg?.unit) return rootArg.unit
+    for (const ins of selectedMissionData.inserts ?? []) {
+      const insArg = ins.scriptArgs?.find(
+        (a) => `${ins.id}.${a.name}` === element
+      )
+      if (insArg?.unit) return insArg.unit
+    }
+    return undefined
+  }, [variable, selectedMissionData])
+
+  const filteredUnitAbbreviations = React.useMemo(() => {
+    if (!selectedArgUnit) return allUnitAbbreviations
+    const compatible =
+      unitsData
+        ?.filter(
+          (u) => u.name === selectedArgUnit || u.baseUnit === selectedArgUnit
+        )
+        .map((u) => u.abbreviation) ?? []
+    return compatible.length > 0 ? compatible : allUnitAbbreviations
+  }, [unitsData, selectedArgUnit, allUnitAbbreviations])
 
   // Display aliases: shown in UI but the original keyword is still sent to the vehicle
   const COMMAND_DISPLAY_ALIASES: Record<string, string> = {
@@ -345,7 +380,7 @@ export const CommandModal: React.FC<CommandModalProps> = ({
       steps={steps}
       onSelectCommandId={setCurrentCommand}
       syntaxVariations={syntaxVariations ?? []}
-      units={[{ name: 'Units', options: units }]}
+      units={[{ name: 'Units', options: filteredUnitAbbreviations }]}
       universals={[{ name: 'Universal', options: universalData ?? [] }]}
       missions={missionTypeOptions}
       decimationTypes={[{ name: 'Decimation Type', options: decimationTypes }]}

--- a/packages/react-ui/src/Tables/CommandDetailTable.test.tsx
+++ b/packages/react-ui/src/Tables/CommandDetailTable.test.tsx
@@ -261,6 +261,51 @@ describe('scopedSelectOptions with pinnedNames', () => {
   })
 })
 
+describe('scopedSelectOptions with optionLabels', () => {
+  const unitOptionSet: OptionSet[] = [
+    {
+      name: 'Units',
+      options: ['h', 'min', 's'],
+      optionLabels: { h: 'hour', min: 'minute', s: 'second' },
+    },
+  ]
+
+  test('should use optionLabels as display name while preserving the raw value in the id', () => {
+    const [tier] = scopedSelectOptions('', unitOptionSet)
+    expect(tier.options).toEqual([
+      { id: 'Units____h', name: 'hour' },
+      { id: 'Units____min', name: 'minute' },
+      { id: 'Units____s', name: 'second' },
+    ])
+  })
+
+  test('should fall back to the raw option value when no label is provided for that key', () => {
+    const sets: OptionSet[] = [
+      {
+        name: 'Units',
+        options: ['h', 'kg'],
+        optionLabels: { h: 'hour' },
+      },
+    ]
+    const [tier] = scopedSelectOptions('', sets)
+    expect(tier.options.find((o) => o.id === 'Units____kg')?.name).toBe('kg')
+  })
+
+  test('should apply optionLabels inside groupedOptions when groupBy is also provided', () => {
+    const sets: OptionSet[] = [
+      {
+        name: 'Mission',
+        options: ['Science/sci2.tl'],
+        groupBy: (p) => p.split('/')[0] ?? 'Other',
+        optionLabels: { 'Science/sci2.tl': 'Sci2 — standard science' },
+      },
+    ]
+    const [tier] = scopedSelectOptions('', sets)
+    const sciGroup = tier.groupedOptions?.find((g) => g.label === 'Science')
+    expect(sciGroup?.options[0].name).toBe('Sci2 — standard science')
+  })
+})
+
 describe('mapValues', () => {
   test('should return an empty object for an empty string', () => {
     expect(mapValues('')).toEqual({})

--- a/packages/react-ui/src/Tables/CommandDetailTable.tsx
+++ b/packages/react-ui/src/Tables/CommandDetailTable.tsx
@@ -44,6 +44,8 @@ export interface OptionSet {
   groupBy?: (option: string) => string
   /** Mission base names (without extension) to pin at the top as "Recently used". */
   pinnedNames?: string[]
+  /** Optional display label overrides keyed by option value (e.g. { h: 'hour', min: 'minute' }). */
+  optionLabels?: Record<string, string>
 }
 
 export interface HelpLink {
@@ -99,7 +101,7 @@ export const scopedSelectOptions = (
   const values = scopedValues(valueString ?? '')
   const options = optionSets
     .filter((_, i) => i <= values.length)
-    .map(({ name, options, groupBy, pinnedNames }, i) => {
+    .map(({ name, options, groupBy, pinnedNames, optionLabels }, i) => {
       const buildId = (option: string) =>
         [i ? values[i - 1] : '', [name, option].join(L_SEPARATOR)]
           .filter((x) => x)
@@ -107,9 +109,13 @@ export const scopedSelectOptions = (
 
       const stripExt = (s: string) => s.replace(/\.(tl|xml|py)$/i, '')
 
+      const displayName = (option: string) =>
+        optionLabels?.[option] ??
+        (groupBy ? stripExt(option.split('/').pop() ?? option) : option)
+
       const flatOptions: SelectOption[] = options.map((option) => ({
         id: buildId(option),
-        name: groupBy ? stripExt(option.split('/').pop() ?? option) : option,
+        name: displayName(option),
       }))
 
       let groupedOptions: SelectOptionGroup[] | undefined

--- a/packages/react-ui/src/Tables/CommandDetailTable.tsx
+++ b/packages/react-ui/src/Tables/CommandDetailTable.tsx
@@ -126,7 +126,7 @@ export const scopedSelectOptions = (
           if (!map.has(label)) map.set(label, [])
           map.get(label)!.push({
             id: buildId(option),
-            name: stripExt(option.split('/').pop() ?? option),
+            name: displayName(option),
           })
         })
         groupedOptions = Array.from(map.entries()).map(([label, opts]) => ({


### PR DESCRIPTION
## Summary

Closes #707 — requested by Christina Preston.

When an operator selects a Mission element in the Build a Command modal, the unit dropdown now filters to only show units compatible with that parameter's declared unit. For example, selecting `MissionTimeout` (unit: `hour`) shows only time-based units (`s`, `min`, `h`, etc.) instead of the full list of ~200 units.

**How it works:**
- The `/commands/script` API already returns each parameter's unit (e.g. `meter`, `hour`, `meter_per_second`)
- The `/commands/units` API returns all units with a `baseUnit` field that groups compatible units
- When an element is selected, we filter to units where `name === selectedUnit` OR `baseUnit === selectedUnit`
- Falls back to the full unit list when: no element is selected, variable type is Universal or Component, or no matching units are found

**No new API calls** — all data was already being fetched.

## Test plan

- [ ] Open Build a Command → select `set` → choose Variable Type: **Mission**
- [ ] Select a mission (e.g. `Science/sci2.tl`) and an element (e.g. `MissionTimeout`)
- [ ] Confirm the unit dropdown shows only time-based units (not the full list)
- [ ] Select a distance parameter (e.g. `Lat1`) and confirm unit dropdown shows angle/degree units
- [ ] Switch Variable Type to **Universal** — confirm full unit list is restored
- [ ] Leave element unselected — confirm full unit list shows