### PR TITLE
fix: sort Deprecated/ missions to bottom of mission picker

### DIFF
--- a/apps/lrauv-dash2/components/CommandModal.test.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.test.tsx
@@ -1,4 +1,8 @@
-import { getFilteredUnitAbbreviations, UnitEntry } from './CommandModal'
+import {
+  getFilteredUnitAbbreviations,
+  UnitEntry,
+  sortMissionPaths,
+} from './CommandModal'
 
 const TIME_UNITS: UnitEntry[] = [
   { name: 'second', abbreviation: 's', baseUnit: undefined },
@@ -17,6 +21,48 @@ const LENGTH_UNITS: UnitEntry[] = [
 ]
 
 const ALL_UNITS = [...TIME_UNITS, ...LENGTH_UNITS]
+
+describe('sortMissionPaths', () => {
+  const paths = [
+    'Science/sci2.tl',
+    'Deprecated/Demo/old_mission.tl',
+    'Engineering/test.tl',
+    'Deprecated/BehaviorScripts/foo.xml',
+    'Transport/transit.tl',
+  ]
+
+  test('sorts Deprecated/ paths to the bottom', () => {
+    const sorted = [...paths].sort(sortMissionPaths)
+    const firstDeprecated = sorted.findIndex((p) =>
+      p.toLowerCase().startsWith('deprecated/')
+    )
+    const lastNonDeprecated = sorted.reduce(
+      (acc, p, i) => (!p.toLowerCase().startsWith('deprecated/') ? i : acc),
+      -1
+    )
+    expect(firstDeprecated).toBeGreaterThan(lastNonDeprecated)
+  })
+
+  test('keeps non-deprecated paths in alphabetical order', () => {
+    const sorted = [...paths].sort(sortMissionPaths)
+    const nonDeprecated = sorted.filter(
+      (p) => !p.toLowerCase().startsWith('deprecated/')
+    )
+    expect(nonDeprecated).toEqual(
+      [...nonDeprecated].sort((a, b) => a.localeCompare(b))
+    )
+  })
+
+  test('keeps deprecated paths in alphabetical order among themselves', () => {
+    const sorted = [...paths].sort(sortMissionPaths)
+    const deprecated = sorted.filter((p) =>
+      p.toLowerCase().startsWith('deprecated/')
+    )
+    expect(deprecated).toEqual(
+      [...deprecated].sort((a, b) => a.localeCompare(b))
+    )
+  })
+})
 
 describe('getFilteredUnitAbbreviations', () => {
   test('returns all abbreviations when selectedArgUnit is undefined', () => {

--- a/apps/lrauv-dash2/components/CommandModal.test.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.test.tsx
@@ -2,6 +2,7 @@ import {
   getFilteredUnitAbbreviations,
   UnitEntry,
   sortMissionPaths,
+  missionGroupLabel,
 } from './CommandModal'
 
 const TIME_UNITS: UnitEntry[] = [
@@ -21,6 +22,27 @@ const LENGTH_UNITS: UnitEntry[] = [
 ]
 
 const ALL_UNITS = [...TIME_UNITS, ...LENGTH_UNITS]
+
+describe('missionGroupLabel', () => {
+  test('returns the parent folder for normal paths', () => {
+    expect(missionGroupLabel('Science/sci2.tl')).toBe('Science')
+    expect(missionGroupLabel('Engineering/test.tl')).toBe('Engineering')
+  })
+
+  test('collapses all Deprecated/* sub-paths into a single "Deprecated" label', () => {
+    expect(missionGroupLabel('Deprecated/Demo/old.tl')).toBe('Deprecated')
+    expect(missionGroupLabel('Deprecated/BehaviorScripts/foo.xml')).toBe(
+      'Deprecated'
+    )
+    expect(missionGroupLabel('deprecated/Engineering/bar.tl')).toBe(
+      'Deprecated'
+    )
+  })
+
+  test('returns Standard Ops for paths with no folder', () => {
+    expect(missionGroupLabel('mission.tl')).toBe('Standard Ops')
+  })
+})
 
 describe('sortMissionPaths', () => {
   const paths = [

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -26,7 +26,7 @@ import { useRouter } from 'next/router'
 import toast from 'react-hot-toast'
 import useGlobalModalId from '../lib/useGlobalModalId'
 
-/** Pure helper — exported for testing. Returns the group label for a mission path, collapsing all Deprecated/* into a single "Deprecated" group so MissionCascader.groupPriority can deprioritize it correctly. */
+/** Pure helper — exported for testing. Returns the group label for a mission path, collapsing all Deprecated/* sub-paths into the single label "Deprecated" so the mission picker renders them as one deprioritized group at the bottom. */
 export const missionGroupLabel = (path: string): string => {
   if (path.toLowerCase().startsWith('deprecated/')) return 'Deprecated'
   const slash = path.lastIndexOf('/')

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -26,6 +26,14 @@ import { useRouter } from 'next/router'
 import toast from 'react-hot-toast'
 import useGlobalModalId from '../lib/useGlobalModalId'
 
+/** Pure helper — exported for testing. Sorts mission paths alphabetically with Deprecated/ pinned last. */
+export const sortMissionPaths = (a: string, b: string): number => {
+  const aDeprecated = a.toLowerCase().startsWith('deprecated/')
+  const bDeprecated = b.toLowerCase().startsWith('deprecated/')
+  if (aDeprecated !== bDeprecated) return aDeprecated ? 1 : -1
+  return a.localeCompare(b)
+}
+
 export interface UnitEntry {
   name: string
   abbreviation: string
@@ -321,7 +329,9 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   const serviceTypes = commandData?.serviceTypes ?? []
 
   // Flat sorted mission paths for both ARG_VARIABLE and ARG_MISSION pickers.
-  const allMissionPaths = (missionData?.list?.map((m) => m.path) ?? []).sort()
+  const allMissionPaths = (missionData?.list?.map((m) => m.path) ?? []).sort(
+    sortMissionPaths
+  )
 
   // Groups paths by folder prefix for the grouped dropdown headers.
   const missionGroupBy = (path: string) => {

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -336,8 +336,9 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   const serviceTypes = commandData?.serviceTypes ?? []
 
   // Flat sorted mission paths for both ARG_VARIABLE and ARG_MISSION pickers.
-  const allMissionPaths = (missionData?.list?.map((m) => m.path) ?? []).sort(
-    sortMissionPaths
+  const allMissionPaths = React.useMemo(
+    () => (missionData?.list?.map((m) => m.path) ?? []).sort(sortMissionPaths),
+    [missionData]
   )
 
   // Groups paths by folder prefix for the grouped dropdown headers.

--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -26,6 +26,13 @@ import { useRouter } from 'next/router'
 import toast from 'react-hot-toast'
 import useGlobalModalId from '../lib/useGlobalModalId'
 
+/** Pure helper — exported for testing. Returns the group label for a mission path, collapsing all Deprecated/* into a single "Deprecated" group so MissionCascader.groupPriority can deprioritize it correctly. */
+export const missionGroupLabel = (path: string): string => {
+  if (path.toLowerCase().startsWith('deprecated/')) return 'Deprecated'
+  const slash = path.lastIndexOf('/')
+  return slash >= 0 ? path.slice(0, slash) : 'Standard Ops'
+}
+
 /** Pure helper — exported for testing. Sorts mission paths alphabetically with Deprecated/ pinned last. */
 export const sortMissionPaths = (a: string, b: string): number => {
   const aDeprecated = a.toLowerCase().startsWith('deprecated/')
@@ -334,10 +341,7 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   )
 
   // Groups paths by folder prefix for the grouped dropdown headers.
-  const missionGroupBy = (path: string) => {
-    const slash = path.lastIndexOf('/')
-    return slash >= 0 ? path.slice(0, slash) : 'Standard Ops'
-  }
+  const missionGroupBy = missionGroupLabel
 
   // Extract unique mission base names from recent commands (set/load) for pinning.
   const recentMissionNames = React.useMemo(() => {


### PR DESCRIPTION
## Summary

Closes #710 — requested by Christina Preston.

Missions in the `Deprecated/` folder are now sorted to the bottom of the mission picker in Build a Command. All other folders (`Science`, `Engineering`, `Transport`, etc.) retain their alphabetical order. Deprecated missions within the `Deprecated/` group also stay alphabetically sorted among themselves.

## How it works

A single sort comparator (`sortMissionPaths`) is applied to `allMissionPaths` in `CommandModal.tsx`. Since the `groupBy` function builds groups from the mission array in insertion order, deprecated missions naturally land at the bottom of the grouped dropdown.

## Test plan

- [ ] Open Build a Command → select a mission-based command → open the mission picker
- [ ] Confirm `Deprecated/` appears at the bottom of the grouped list
- [ ] Confirm `Science`, `Engineering`, `Transport` etc. are still in alphabetical order above it
- [ ] Confirm "Recently used" and "Standard Ops" still pin to the top