### PR TITLE
fix: map projected route backtracking + center button stale zoom

### DIFF
--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -232,6 +232,10 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
     if (vehicleName !== latestVehicle.current) {
       setLatestGPS(undefined)
       setCenter(undefined)
+      // Also flush accumulated path so bounds/centering don't inherit stale
+      // points from the previous vehicle when the first fix for the new vehicle
+      // initializes latestGPS via the !latestGPS branch in handleGPSFix.
+      pathPoints.current = []
       latestVehicle.current = vehicleName
     }
   }, [vehicleName, setLatestGPS])

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -307,7 +307,9 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
         pathPoints.current = []
         setLatestGPS(gps)
       }
-      // Equal unixTime: same fix, no-op
+      // Always accumulate valid coordinates for bounds/centering regardless of
+      // whether latestGPS was updated above (equal unixTime is only a no-op for
+      // the latestGPS state update, not for pathPoints).
       if (Number.isFinite(gps?.latitude) && Number.isFinite(gps?.longitude)) {
         pathPoints.current.push([gps.latitude, gps.longitude])
         if (pathPoints.current.length > 1000) {

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -658,7 +658,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
           key={`deployment-map-${router.asPath}-${vehicleName ?? 'unknown'}`}
           ref={mapRef}
           className="h-full min-h-0 w-full"
-          maxZoom={17}
+          maxZoom={MAP_MAX_ZOOM}
           onMapReady={(map) => {
             logger.debug('Map is ready!')
             mapRef.current = map

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -74,6 +74,11 @@ const PlatformPaths = dynamic(
 )
 
 const logger = createLogger('DeploymentMap')
+
+const MAP_MAX_ZOOM = 17
+// Center-on-vehicle zoom: 3 levels below the tile ceiling so surrounding
+// geography is visible. Update MAP_MAX_ZOOM if the Map maxZoom prop changes.
+const CENTER_ZOOM = MAP_MAX_ZOOM - 3
 interface DeploymentMapProps {
   vehicleName?: string | null
   indicatorTime?: number | null
@@ -534,7 +539,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   const handleCoordinateRequest = useCallback(() => {
     if (latestGPS) {
       setCenter([latestGPS.latitude, latestGPS.longitude])
-      setCenterZoom(14)
+      setCenterZoom(CENTER_ZOOM)
       setBounds(undefined)
       setViewMode('center')
     } else {
@@ -542,7 +547,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       const lastPoint = pathPoints.current[pathPoints.current.length - 1]
       if (lastPoint) {
         setCenter(lastPoint)
-        setCenterZoom(14)
+        setCenterZoom(CENTER_ZOOM)
         setBounds(undefined)
         setViewMode('center')
       } else {

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -269,8 +269,6 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       }, 200)
     }
   }, [showVehicleColors])
-  // Store all vehicle locations to calculate center
-  const vehiclePosition = useRef<Array<[number, number]>>([])
   // Vehicle path points for bounds calculation
   const pathPoints = useRef<Array<[number, number]>>([])
 
@@ -295,24 +293,21 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       if (!latestGPS) {
         // First fix — initialize
         setLatestGPS(gps)
-      } else if (gps.isoTime > latestGPS.isoTime) {
+      } else if (gps.unixTime > latestGPS.unixTime) {
         // Newer fix arrived — update so the center button zooms to current position
         setLatestGPS(gps)
-      } else if (gps.isoTime < latestGPS.isoTime) {
+      } else if (gps.unixTime < latestGPS.unixTime) {
         // Incoming fix is older than what we have — vehicle or deployment changed;
-        // reset both accumulated arrays so bounds/centering don't use stale points.
-        vehiclePosition.current = []
+        // reset accumulated path so bounds/centering don't draw on stale points.
         pathPoints.current = []
         setLatestGPS(gps)
       }
-      // Equal isoTime: same fix, no-op
+      // Equal unixTime: same fix, no-op
       if (Number.isFinite(gps?.latitude) && Number.isFinite(gps?.longitude)) {
         pathPoints.current.push([gps.latitude, gps.longitude])
         if (pathPoints.current.length > 1000) {
           pathPoints.current = pathPoints.current.slice(-1000)
         }
-        const position: [number, number] = [gps.latitude, gps.longitude]
-        vehiclePosition.current.push(position)
       }
     },
     [latestGPS, setLatestGPS]

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -292,20 +292,25 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   // Handler for GPS fix updates
   const handleGPSFix = useCallback(
     (gps: VPosDetail) => {
-      // Reset the array if vehicle name changes
-      if ((latestGPS?.isoTime ?? 0) > gps.isoTime || !latestGPS) {
+      if (!latestGPS) {
+        // First fix — initialize
+        setLatestGPS(gps)
+      } else if (gps.isoTime > latestGPS.isoTime) {
+        // Newer fix arrived — update so the center button zooms to current position
+        setLatestGPS(gps)
+      } else if (gps.isoTime < latestGPS.isoTime) {
+        // Incoming fix is older than what we have — vehicle or deployment changed;
+        // reset accumulated positions and start fresh for the new vehicle.
         vehiclePosition.current = []
         setLatestGPS(gps)
       }
-      // Store position for path bounds calculation
+      // Equal isoTime: same fix, no-op
       if (gps?.latitude && gps?.longitude) {
         pathPoints.current.push([gps.latitude, gps.longitude])
       }
-      // Limit stored positions to prevent memory issues
       if (pathPoints.current.length > 1000) {
         pathPoints.current = pathPoints.current.slice(-1000)
       }
-      // Store position for centering
       const position: [number, number] = [gps.latitude, gps.longitude]
       vehiclePosition.current.push(position)
     },
@@ -527,11 +532,13 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
     setViewMode('bounds')
   }, [])
 
-  // Handler for centering the map on the latest GPS fix
+  // Handler for centering the map on the latest GPS fix.
+  // Zoom to maxZoom - 3 (14) so the user sees surrounding context rather than
+  // being pinned to the tile ceiling.
   const handleCoordinateRequest = useCallback(() => {
     if (latestGPS) {
       setCenter([latestGPS.latitude, latestGPS.longitude])
-      setCenterZoom(17)
+      setCenterZoom(14)
       setBounds(undefined)
       setViewMode('center')
     } else {
@@ -539,7 +546,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       const lastPoint = pathPoints.current[pathPoints.current.length - 1]
       if (lastPoint) {
         setCenter(lastPoint)
-        setCenterZoom(17)
+        setCenterZoom(14)
         setBounds(undefined)
         setViewMode('center')
       } else {

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -300,19 +300,20 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
         setLatestGPS(gps)
       } else if (gps.isoTime < latestGPS.isoTime) {
         // Incoming fix is older than what we have — vehicle or deployment changed;
-        // reset accumulated positions and start fresh for the new vehicle.
+        // reset both accumulated arrays so bounds/centering don't use stale points.
         vehiclePosition.current = []
+        pathPoints.current = []
         setLatestGPS(gps)
       }
       // Equal isoTime: same fix, no-op
-      if (gps?.latitude && gps?.longitude) {
+      if (Number.isFinite(gps?.latitude) && Number.isFinite(gps?.longitude)) {
         pathPoints.current.push([gps.latitude, gps.longitude])
+        if (pathPoints.current.length > 1000) {
+          pathPoints.current = pathPoints.current.slice(-1000)
+        }
+        const position: [number, number] = [gps.latitude, gps.longitude]
+        vehiclePosition.current.push(position)
       }
-      if (pathPoints.current.length > 1000) {
-        pathPoints.current = pathPoints.current.slice(-1000)
-      }
-      const position: [number, number] = [gps.latitude, gps.longitude]
-      vehiclePosition.current.push(position)
     },
     [latestGPS, setLatestGPS]
   )

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -298,7 +298,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
       // Walk cumulative segment distances to find the first waypoint whose
       // cumulative distance >= vehicleDist (i.e., still ahead of the vehicle).
       let cumDist = 0
-      startIdx = pts.length - 1 // fallback: past all but the final waypoint
+      startIdx = pts.length - 1 // fallback: show only the final waypoint if vehicle is past all others
       for (let i = 0; i < pts.length; i++) {
         if (cumDist >= vehicleDist) {
           startIdx = i

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -8,7 +8,7 @@ import {
 import { Polyline, useMap, Circle, Tooltip } from 'react-leaflet'
 import { LatLng, LeafletMouseEventHandlerFn } from 'leaflet'
 import { useRouter } from 'next/router'
-import { distance } from '@turf/turf'
+import { distance, nearestPointOnLine, lineString } from '@turf/turf'
 import { useSharedPath } from './SharedPathContextProvider'
 import { parseISO, getTime } from 'date-fns'
 import { formatElapsedTime } from '@mbari/utils'
@@ -277,21 +277,40 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         : []
 
     // The /wp endpoint returns all planned waypoints for the mission, including
-    // those the vehicle has already passed. Slice to the nearest waypoint so the
-    // projected route doesn't draw a backward segment toward an already-visited
-    // position before continuing forward.
-    // Use Turf distance (consistent with the rest of this file) rather than
-    // raw-degree Euclidean distance, which is inaccurate and latitude-dependent.
+    // those the vehicle has already passed. Find the first waypoint that is
+    // still ahead of the vehicle by projecting the vehicle's position onto the
+    // full route polyline and walking cumulative segment distances — this avoids
+    // a backward leg even when the vehicle has just passed a waypoint and the
+    // nearest vertex is still the one behind it.
     let startIdx = 0
-    if (latest?.latitude != null && latest?.longitude != null) {
-      let minDist = Infinity
-      pts.forEach((p, i) => {
-        const d = distance([latest.longitude, latest.latitude], [p.lon, p.lat])
-        if (d < minDist) {
-          minDist = d
+    if (
+      pts.length >= 2 &&
+      latest?.latitude != null &&
+      latest?.longitude != null
+    ) {
+      const routeLine = lineString(pts.map((p) => [p.lon, p.lat]))
+      const snapped = nearestPointOnLine(routeLine, [
+        latest.longitude,
+        latest.latitude,
+      ])
+      // Distance along the route to the vehicle's nearest projection point.
+      const vehicleDist = snapped.properties.location ?? 0
+      // Walk cumulative segment distances to find the first waypoint whose
+      // cumulative distance >= vehicleDist (i.e., still ahead of the vehicle).
+      let cumDist = 0
+      startIdx = pts.length - 1 // fallback: past all but the final waypoint
+      for (let i = 0; i < pts.length; i++) {
+        if (cumDist >= vehicleDist) {
           startIdx = i
+          break
         }
-      })
+        if (i < pts.length - 1) {
+          cumDist += distance(
+            [pts[i].lon, pts[i].lat],
+            [pts[i + 1].lon, pts[i + 1].lat]
+          )
+        }
+      }
     }
     const remainingPts = pts.slice(startIdx)
     if (remainingPts.length === 0) return null

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -280,11 +280,13 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     // those the vehicle has already passed. Slice to the nearest waypoint so the
     // projected route doesn't draw a backward segment toward an already-visited
     // position before continuing forward.
+    // Use Turf distance (consistent with the rest of this file) rather than
+    // raw-degree Euclidean distance, which is inaccurate and latitude-dependent.
     let startIdx = 0
     if (latest?.latitude != null && latest?.longitude != null) {
       let minDist = Infinity
       pts.forEach((p, i) => {
-        const d = Math.hypot(p.lat - latest.latitude, p.lon - latest.longitude)
+        const d = distance([latest.longitude, latest.latitude], [p.lon, p.lat])
         if (d < minDist) {
           minDist = d
           startIdx = i

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -275,7 +275,29 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
       latest?.latitude != null && latest?.longitude != null
         ? [[latest.latitude, latest.longitude] as [number, number]]
         : []
-    return [...start, ...pts.map((p) => [p.lat, p.lon] as [number, number])]
+
+    // The /wp endpoint returns all planned waypoints for the mission, including
+    // those the vehicle has already passed. Slice to the nearest waypoint so the
+    // projected route doesn't draw a backward segment toward an already-visited
+    // position before continuing forward.
+    let startIdx = 0
+    if (latest?.latitude != null && latest?.longitude != null) {
+      let minDist = Infinity
+      pts.forEach((p, i) => {
+        const d = Math.hypot(p.lat - latest.latitude, p.lon - latest.longitude)
+        if (d < minDist) {
+          minDist = d
+          startIdx = i
+        }
+      })
+    }
+    const remainingPts = pts.slice(startIdx)
+    if (remainingPts.length === 0) return null
+
+    return [
+      ...start,
+      ...remainingPts.map((p) => [p.lat, p.lon] as [number, number]),
+    ]
   }, [futureWaypoints?.points, vehiclePosition?.gpsFixes])
 
   const fitPositions = useMemo(() => {

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -315,10 +315,14 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     const remainingPts = pts.slice(startIdx)
     if (remainingPts.length === 0) return null
 
-    return [
+    const positions = [
       ...start,
       ...remainingPts.map((p) => [p.lat, p.lon] as [number, number]),
     ]
+    // Leaflet polylines require at least 2 points; guard to avoid runtime errors
+    // when there is no GPS fix yet and only one remaining waypoint.
+    if (positions.length < 2) return null
+    return positions
   }, [futureWaypoints?.points, vehiclePosition?.gpsFixes])
 
   const fitPositions = useMemo(() => {


### PR DESCRIPTION
## Summary

Three related map fixes on the deployment page, reported by Emme Wiederhold (2026-06-30):

### #735 — Projected route shows vehicle backtracking (`VehiclePath.tsx`)
The `GET /wp` endpoint returns **all** planned mission waypoints, including ones the vehicle has already passed. The previous code drew the dashed projected route as `[current position → past M1 → future M2 → ...]`, creating a visible backward jog before continuing forward.

**Fix:** Before building `futureRoute`, find the waypoint in `points` that is geographically closest to the vehicle's current GPS fix and slice from that index onward. Only the nearest upcoming target and subsequent waypoints are included in the projection.

### #736 — Center button zooms to wrong (old) position (`DeploymentMap.tsx`)
`handleGPSFix` had an inverted condition: `(latestGPS?.isoTime ?? 0) > gps.isoTime`. This fired only when the **stored** timestamp was newer than the incoming one, meaning `latestGPS` was set correctly on first load but **never updated** on subsequent data refreshes. The center-on-vehicle button always zoomed to the stale initial position.

**Fix:** Replaced with explicit three-way logic — update `latestGPS` when the incoming fix is newer, reset accumulated path positions when it's older (vehicle/deployment change), no-op when equal.

### Center button zoom level (`DeploymentMap.tsx`)
The center button was pinned to zoom `17` — the map's `maxZoom` ceiling — leaving no surrounding geographic context. Changed to `14` (maxZoom − 3).

## Issues closed
- Fixes #735
- Fixes #736

## Test plan
- [ ] AHI deployment map: dashed projected route goes forward from vehicle position to remaining waypoints only — no backward segment
- [ ] Center button zooms to vehicle's **current** (leading edge) position, not a prior one
- [ ] Center button lands at zoom 14 — enough context to see surrounding geography