### PR TITLE
fix: logset tooltip clipped in narrow science sidebar (#718)

### DIFF
--- a/apps/lrauv-dash2/components/ScienceDataSection.tsx
+++ b/apps/lrauv-dash2/components/ScienceDataSection.tsx
@@ -1,9 +1,5 @@
-import {
-  SelectField,
-  AbsoluteOverlay,
-  AccordionCells,
-  ToolTip,
-} from '@mbari/react-ui'
+import { SelectField, AbsoluteOverlay, AccordionCells } from '@mbari/react-ui'
+import Tippy from '@tippyjs/react'
 import useGlobalModalId from '../lib/useGlobalModalId'
 import dynamic from 'next/dynamic'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -131,7 +127,6 @@ const ScienceDataSection: React.FC<{
     'scienceSection.alignAxes',
     false
   )
-  const [logsetTooltip, setLogsetTooltip] = useState(false)
 
   const isExtended = timeWindow !== 'latest'
 
@@ -323,24 +318,21 @@ const ScienceDataSection: React.FC<{
           />
         </div>
         {!isExtended && logsetOptions.length > 0 && (
-          <div
-            className="relative my-auto"
-            onMouseEnter={() => setLogsetTooltip(true)}
-            onMouseLeave={() => setLogsetTooltip(false)}
+          <Tippy
+            content="Select a logset to scope the charts to that time window"
+            placement="bottom"
+            theme="mapBtnTT"
           >
-            <SelectField
-              name="logset"
-              placeholder="Logset"
-              value={selectedLogsetId ?? ''}
-              options={logsetOptions}
-              onSelect={setSelectedLogsetId}
-            />
-            <ToolTip
-              label="Select a logset to scope the charts to that time window"
-              direction="below"
-              active={logsetTooltip}
-            />
-          </div>
+            <div className="my-auto">
+              <SelectField
+                name="logset"
+                placeholder="Logset"
+                value={selectedLogsetId ?? ''}
+                options={logsetOptions}
+                onSelect={setSelectedLogsetId}
+              />
+            </div>
+          </Tippy>
         )}
         <button
           title={


### PR DESCRIPTION
## Summary

Fixes #718.

The logset dropdown tooltip in the Science & Vehicle Data section was clipped when the sidebar was narrow. The `ToolTip` component renders as an `absolute`-positioned element inside its `relative` parent — it cannot escape ancestor `overflow: hidden` containers, so the tooltip text was cut off at the sidebar boundary.

## Fix

Replaced the custom `ToolTip` + hover-state pair with `Tippy` (already a project dependency via `@tippyjs/react`). Tippy renders via a portal at the document root, completely outside any clipping context, so the tooltip displays fully at any sidebar width.

Also removed the now-unused `logsetTooltip` useState hook.

## Test plan
- [ ] Open a deployment → Science & Vehicle Data section
- [ ] Narrow the right sidebar to a moderate/narrow width
- [ ] Hover the Logset dropdown selector
- [ ] Confirm the tooltip "Select a logset to scope the charts to that time window" renders fully without clipping