### PR TITLE
fix: bring overview VehicleCell to parity with full vehicle page widget (#732)

### DIFF
--- a/apps/lrauv-dash2/components/VehicleDiagram.tsx
+++ b/apps/lrauv-dash2/components/VehicleDiagram.tsx
@@ -18,6 +18,7 @@ import {
 import clsx from 'clsx'
 import { DateTime } from 'luxon'
 import { decodeHtmlEntities, formatCompactDuration } from '@mbari/utils'
+import { deriveVehiclePropsStatus } from '../lib/deriveVehiclePropsStatus'
 import { useTethysApiContext } from 'api-client'
 
 const DepthSparkline = dynamic(
@@ -202,12 +203,7 @@ const VehicleDiagram: React.FC<{
     colorMissionDefault: vehicle?.color_missiondefault,
     textVolts: vehicle?.text_volts,
     colorVolts: vehicle?.color_volts,
-    status:
-      missionText.indexOf('PLUGGED') >= 0
-        ? 'pluggedIn'
-        : missionText.indexOf('RECOVERED') >= 0
-        ? 'recovered'
-        : 'onMission',
+    status: deriveVehiclePropsStatus({ missionText }),
     colorLeak: vehicle?.color_leak,
     textLeakAgo: vehicle?.text_leakago,
     textLeak: vehicle?.text_leak,

--- a/apps/lrauv-dash2/components/VehicleList.test.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.test.tsx
@@ -50,10 +50,20 @@ describe('VehicleList', () => {
 })
 
 describe('deriveStatusLabel', () => {
-  test('returns "Recovered" when recoverEvent is present', () => {
+  test('returns "Recovered" when recoverEvent has a valid eventId', () => {
     expect(
       deriveStatusLabel({ recoverEvent: { eventId: 123 }, missionText: '' })
     ).toBe('Recovered')
+  })
+
+  test('does not treat an empty recoverEvent object as recovered', () => {
+    expect(
+      deriveStatusLabel({
+        recoverEvent: { eventId: undefined },
+        missionText: '',
+        mission: 'sci2.xml',
+      })
+    ).toBe('Running sci2.xml')
   })
 
   test('returns "Recovered" when text_mission contains RECOVERED', () => {
@@ -88,9 +98,16 @@ describe('deriveStatusLabel', () => {
     ).toBe('Running sci2.xml')
   })
 
-  test('falls back to "Running mission" when mission name is absent', () => {
+  test('falls back to "Running mission" when mission name is null', () => {
     expect(
       deriveStatusLabel({ recoverEvent: null, missionText: '', mission: null })
+    ).toBe('Running mission')
+  })
+
+  test('falls back to "Running mission" when mission is an empty string', () => {
+    // .replace(/started mission/i, '') on "started mission" produces ""
+    expect(
+      deriveStatusLabel({ recoverEvent: null, missionText: '', mission: '' })
     ).toBe('Running mission')
   })
 })

--- a/apps/lrauv-dash2/components/VehicleList.test.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.test.tsx
@@ -78,6 +78,16 @@ describe('deriveStatusLabel', () => {
     ).toBe('Running sci2.xml')
   })
 
+  test('trims leading whitespace from mission name (from .replace result)', () => {
+    expect(
+      deriveStatusLabel({
+        recoverEvent: null,
+        missionText: 'some active mission',
+        mission: ' sci2.xml',
+      })
+    ).toBe('Running sci2.xml')
+  })
+
   test('falls back to "Running mission" when mission name is absent', () => {
     expect(
       deriveStatusLabel({ recoverEvent: null, missionText: '', mission: null })

--- a/apps/lrauv-dash2/components/VehicleList.test.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom'
 import React from 'react'
 import { render } from '@testing-library/react'
-import VehicleList from './VehicleList'
+import VehicleList, { deriveStatusLabel } from './VehicleList'
 import { QueryClient } from 'react-query'
 import { rest } from 'msw'
 import { setupServer } from 'msw/node'
@@ -46,5 +46,41 @@ describe('VehicleList', () => {
         </MockProviders>
       )
     ).not.toThrow()
+  })
+})
+
+describe('deriveStatusLabel', () => {
+  test('returns "Recovered" when recoverEvent is present', () => {
+    expect(
+      deriveStatusLabel({ recoverEvent: { eventId: 123 }, missionText: '' })
+    ).toBe('Recovered')
+  })
+
+  test('returns "Recovered" when text_mission contains RECOVERED', () => {
+    expect(
+      deriveStatusLabel({ recoverEvent: null, missionText: 'RECOVERED' })
+    ).toBe('Recovered')
+  })
+
+  test('returns "Plugged in" when text_mission contains PLUGGED', () => {
+    expect(
+      deriveStatusLabel({ recoverEvent: null, missionText: 'PLUGGED IN' })
+    ).toBe('Plugged in')
+  })
+
+  test('returns running mission label for an active mission', () => {
+    expect(
+      deriveStatusLabel({
+        recoverEvent: null,
+        missionText: 'some active mission',
+        mission: 'sci2.xml',
+      })
+    ).toBe('Running sci2.xml')
+  })
+
+  test('falls back to "Running mission" when mission name is absent', () => {
+    expect(
+      deriveStatusLabel({ recoverEvent: null, missionText: '', mission: null })
+    ).toBe('Running mission')
   })
 })

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -46,9 +46,14 @@ export const deriveStatusLabel = ({
   missionText?: string | null
   mission?: string | null
 }): string => {
-  if (recoverEvent?.eventId || missionText?.includes('RECOVERED'))
-    return 'Recovered'
-  if (missionText?.includes('PLUGGED')) return 'Plugged in'
+  // Delegate to the shared helper so recovered/plugged precedence stays
+  // consistent with the diagram status — avoids duplicating the logic here.
+  const status = deriveVehiclePropsStatus({
+    recoverEventId: recoverEvent?.eventId,
+    missionText,
+  })
+  if (status === 'recovered') return 'Recovered'
+  if (status === 'pluggedIn') return 'Plugged in'
   return `Running ${mission?.trim() || 'mission'}`
 }
 

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -59,7 +59,7 @@ const ConnectedVehicleCellComponent: React.FC<{
     {
       vehicle: name,
     },
-    { staleTime: 5 * 60 * 1000 }
+    { staleTime: 5 * 60 * 1000, refetchInterval: 30 * 1000 }
   )
 
   const defaultFrom = useMemo(() => Date.now() - 24 * 60 * 60 * 1000, [])
@@ -70,6 +70,7 @@ const ConnectedVehicleCellComponent: React.FC<{
     },
     {
       enabled: !!lastDeployment?.lastEvent,
+      refetchInterval: 30 * 1000,
     }
   )
 
@@ -253,9 +254,11 @@ const ConnectedVehicleCellComponent: React.FC<{
         textVolts: vehicle.text_volts,
         colorVolts: vehicle.color_volts,
         status: (lastDeployment?.recoverEvent ||
-        (vehicle?.text_mission?.indexOf('PLUGGED') ?? -1) >= 0
+        vehicle?.text_mission?.includes('RECOVERED')
+          ? 'recovered'
+          : vehicle?.text_mission?.includes('PLUGGED')
           ? 'pluggedIn'
-          : 'onMission') as 'pluggedIn' | 'onMission',
+          : 'onMission') as 'pluggedIn' | 'onMission' | 'recovered',
         textLeak: vehicle.text_leak,
         textLeakAgo: vehicle.text_leakago,
         colorLeak: vehicle.color_leak,
@@ -278,6 +281,14 @@ const ConnectedVehicleCellComponent: React.FC<{
         textVersion: vehicle.text_version,
         svgCurrent: vehicle.svg_current,
         colorDuration: vehicle.color_duration,
+        textLM: vehicle.text_LM,
+        textHM: vehicle.text_HM,
+        textRoiAgo: vehicle.text_roiago,
+        colorWhitebeam: vehicle.color_whitebeam,
+        colorWhiteled: vehicle.color_whiteled,
+        colorRedbeam: vehicle.color_redbeam,
+        colorRedled: vehicle.color_redled,
+        textArriveLabel: vehicle.text_waypoint,
       }
     : undefined
 

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -353,10 +353,14 @@ const ConnectedVehicleCellComponent: React.FC<{
       undefined
     : undefined
 
-  const timeSpanSinceRecovery =
-    DateTime.fromMillis(
-      lastDeployment?.recoverEvent?.unixTime ?? 0
-    ).toRelative() ?? ''
+  // Only produce a recovery-time string when we actually have a timestamp.
+  // derivedStatus can be 'recovered' from vehicle.text_mission before
+  // lastDeployment.recoverEvent loads; falling back to epoch (0) would render
+  // "Recovered 56 years ago", so we leave it undefined until the event arrives.
+  const timeSpanSinceRecovery = lastDeployment?.recoverEvent?.unixTime
+    ? DateTime.fromMillis(lastDeployment.recoverEvent.unixTime).toRelative() ??
+      ''
+    : undefined
 
   const { setGlobalModalId } = useGlobalModalId()
   const onColorChange = (_: string, _v: string) => {

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -88,6 +88,9 @@ const ConnectedVehicleCellComponent: React.FC<{
     {
       vehicle: name,
       from: lastDeployment?.lastEvent ?? defaultFrom,
+      // Only the most recent GPS fix is used (gpsFixes[0]); limit to 1 so
+      // polling at 30s doesn't repeatedly download the full deployment track.
+      limit: 1,
     },
     {
       enabled: !!lastDeployment?.lastEvent,

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -196,7 +196,7 @@ const ConnectedVehicleCellComponent: React.FC<{
   const formattedNextComm = nextCommsText ?? vehicle?.text_nextcomm
 
   // Compute once; reused for vehicleProps.status and the recovered boolean.
-  const provedStatus = deriveVehiclePropsStatus({
+  const derivedStatus = deriveVehiclePropsStatus({
     recoverEventId: lastDeployment?.recoverEvent?.eventId,
     missionText: vehicle?.text_mission,
   })
@@ -280,7 +280,7 @@ const ConnectedVehicleCellComponent: React.FC<{
         colorMissionDefault: vehicle.color_missiondefault,
         textVolts: vehicle.text_volts,
         colorVolts: vehicle.color_volts,
-        status: provedStatus,
+        status: derivedStatus,
         textLeak: vehicle.text_leak,
         textLeakAgo: vehicle.text_leakago,
         colorLeak: vehicle.color_leak,
@@ -322,7 +322,7 @@ const ConnectedVehicleCellComponent: React.FC<{
   const endDate = DateTime.fromMillis(lastDeployment?.endEvent?.unixTime ?? 0)
 
   const ended = lastDeployment?.endEvent?.eventId && true
-  const recovered = provedStatus === 'recovered'
+  const recovered = derivedStatus === 'recovered'
   const active = lastDeployment?.active
 
   // Prefer launchEvent (vehicle in water) over startEvent (deployment record

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -41,13 +41,14 @@ export const deriveStatusLabel = ({
   missionText,
   mission,
 }: {
-  recoverEvent?: object | null
+  recoverEvent?: { eventId?: number | string | null } | null
   missionText?: string | null
   mission?: string | null
 }): string => {
-  if (recoverEvent || missionText?.includes('RECOVERED')) return 'Recovered'
+  if (recoverEvent?.eventId || missionText?.includes('RECOVERED'))
+    return 'Recovered'
   if (missionText?.includes('PLUGGED')) return 'Plugged in'
-  return `Running ${mission?.trim() ?? 'mission'}`
+  return `Running ${mission?.trim() || 'mission'}`
 }
 
 const ConnectedVehicleCellComponent: React.FC<{
@@ -314,7 +315,9 @@ const ConnectedVehicleCellComponent: React.FC<{
   const endDate = DateTime.fromMillis(lastDeployment?.endEvent?.unixTime ?? 0)
 
   const ended = lastDeployment?.endEvent?.eventId && true
-  const recovered = Boolean(lastDeployment?.recoverEvent?.eventId)
+  const recovered =
+    Boolean(lastDeployment?.recoverEvent?.eventId) ||
+    Boolean(vehicle?.text_mission?.includes('RECOVERED'))
   const active = lastDeployment?.active
 
   // Prefer launchEvent (vehicle in water) over startEvent (deployment record

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -190,6 +190,12 @@ const ConnectedVehicleCellComponent: React.FC<{
   )
   const formattedNextComm = nextCommsText ?? vehicle?.text_nextcomm
 
+  // Compute once; reused for vehicleProps.status and the recovered boolean.
+  const provedStatus = deriveVehiclePropsStatus({
+    recoverEventId: lastDeployment?.recoverEvent?.eventId,
+    missionText: vehicle?.text_mission,
+  })
+
   const vehicleProps = vehicle
     ? {
         textAmpAgo: vehicle.text_ampago,
@@ -269,10 +275,7 @@ const ConnectedVehicleCellComponent: React.FC<{
         colorMissionDefault: vehicle.color_missiondefault,
         textVolts: vehicle.text_volts,
         colorVolts: vehicle.color_volts,
-        status: deriveVehiclePropsStatus({
-          recoverEventId: lastDeployment?.recoverEvent?.eventId,
-          missionText: vehicle?.text_mission,
-        }),
+        status: provedStatus,
         textLeak: vehicle.text_leak,
         textLeakAgo: vehicle.text_leakago,
         colorLeak: vehicle.color_leak,
@@ -314,11 +317,7 @@ const ConnectedVehicleCellComponent: React.FC<{
   const endDate = DateTime.fromMillis(lastDeployment?.endEvent?.unixTime ?? 0)
 
   const ended = lastDeployment?.endEvent?.eventId && true
-  const recovered =
-    deriveVehiclePropsStatus({
-      recoverEventId: lastDeployment?.recoverEvent?.eventId,
-      missionText: vehicle?.text_mission,
-    }) === 'recovered'
+  const recovered = provedStatus === 'recovered'
   const active = lastDeployment?.active
 
   // Prefer launchEvent (vehicle in water) over startEvent (deployment record

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -31,6 +31,7 @@ import { useLastCommsTime } from '../lib/useLastCommsTime'
 import { useNeedCommsTime } from '../lib/useNeedCommsTime'
 import { useTick } from '../lib/useTick'
 import { useVehicleStatus } from '../lib/useVehicleStatus'
+import { deriveVehiclePropsStatus } from '../lib/deriveVehiclePropsStatus'
 
 const parsePos = (pos: string | number) => parseFloat(`${pos}`).toFixed(3)
 const calcPosition = (lat?: number | string, long?: number | string) =>
@@ -268,12 +269,10 @@ const ConnectedVehicleCellComponent: React.FC<{
         colorMissionDefault: vehicle.color_missiondefault,
         textVolts: vehicle.text_volts,
         colorVolts: vehicle.color_volts,
-        status: (lastDeployment?.recoverEvent?.eventId ||
-        vehicle?.text_mission?.includes('RECOVERED')
-          ? 'recovered'
-          : vehicle?.text_mission?.includes('PLUGGED')
-          ? 'pluggedIn'
-          : 'onMission') as 'pluggedIn' | 'onMission' | 'recovered',
+        status: deriveVehiclePropsStatus({
+          recoverEventId: lastDeployment?.recoverEvent?.eventId,
+          missionText: vehicle?.text_mission,
+        }),
         textLeak: vehicle.text_leak,
         textLeakAgo: vehicle.text_leakago,
         colorLeak: vehicle.color_leak,
@@ -316,8 +315,10 @@ const ConnectedVehicleCellComponent: React.FC<{
 
   const ended = lastDeployment?.endEvent?.eventId && true
   const recovered =
-    Boolean(lastDeployment?.recoverEvent?.eventId) ||
-    Boolean(vehicle?.text_mission?.includes('RECOVERED'))
+    deriveVehiclePropsStatus({
+      recoverEventId: lastDeployment?.recoverEvent?.eventId,
+      missionText: vehicle?.text_mission,
+    }) === 'recovered'
   const active = lastDeployment?.active
 
   // Prefer launchEvent (vehicle in water) over startEvent (deployment record

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -36,6 +36,20 @@ const parsePos = (pos: string | number) => parseFloat(`${pos}`).toFixed(3)
 const calcPosition = (lat?: number | string, long?: number | string) =>
   lat && long ? [parsePos(lat), parsePos(long)].join(', ') : undefined
 
+export const deriveStatusLabel = ({
+  recoverEvent,
+  missionText,
+  mission,
+}: {
+  recoverEvent?: object | null
+  missionText?: string | null
+  mission?: string | null
+}): string => {
+  if (recoverEvent || missionText?.includes('RECOVERED')) return 'Recovered'
+  if (missionText?.includes('PLUGGED')) return 'Plugged in'
+  return `Running ${mission ?? 'mission'}`
+}
+
 const ConnectedVehicleCellComponent: React.FC<{
   name: string
   color: string
@@ -292,9 +306,11 @@ const ConnectedVehicleCellComponent: React.FC<{
       }
     : undefined
 
-  const status = lastDeployment?.recoverEvent
-    ? 'Plugged in'
-    : `Running ${mission ?? 'mission'}`
+  const status = deriveStatusLabel({
+    recoverEvent: lastDeployment?.recoverEvent,
+    missionText: vehicle?.text_mission,
+    mission,
+  })
   const endDate = DateTime.fromMillis(lastDeployment?.endEvent?.unixTime ?? 0)
 
   const ended = lastDeployment?.endEvent?.eventId && true

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -47,7 +47,7 @@ export const deriveStatusLabel = ({
 }): string => {
   if (recoverEvent || missionText?.includes('RECOVERED')) return 'Recovered'
   if (missionText?.includes('PLUGGED')) return 'Plugged in'
-  return `Running ${mission ?? 'mission'}`
+  return `Running ${mission?.trim() ?? 'mission'}`
 }
 
 const ConnectedVehicleCellComponent: React.FC<{

--- a/apps/lrauv-dash2/components/VehicleList.tsx
+++ b/apps/lrauv-dash2/components/VehicleList.tsx
@@ -268,7 +268,7 @@ const ConnectedVehicleCellComponent: React.FC<{
         colorMissionDefault: vehicle.color_missiondefault,
         textVolts: vehicle.text_volts,
         colorVolts: vehicle.color_volts,
-        status: (lastDeployment?.recoverEvent ||
+        status: (lastDeployment?.recoverEvent?.eventId ||
         vehicle?.text_mission?.includes('RECOVERED')
           ? 'recovered'
           : vehicle?.text_mission?.includes('PLUGGED')

--- a/apps/lrauv-dash2/lib/deriveVehiclePropsStatus.test.ts
+++ b/apps/lrauv-dash2/lib/deriveVehiclePropsStatus.test.ts
@@ -1,0 +1,81 @@
+import { deriveVehiclePropsStatus } from './deriveVehiclePropsStatus'
+
+describe('deriveVehiclePropsStatus', () => {
+  describe('recovered precedence', () => {
+    test('returns "recovered" when recoverEventId is present', () => {
+      expect(
+        deriveVehiclePropsStatus({ recoverEventId: 42, missionText: '' })
+      ).toBe('recovered')
+    })
+
+    test('returns "recovered" when missionText contains RECOVERED', () => {
+      expect(
+        deriveVehiclePropsStatus({
+          recoverEventId: null,
+          missionText: 'RECOVERED',
+        })
+      ).toBe('recovered')
+    })
+
+    test('RECOVERED beats PLUGGED in missionText', () => {
+      expect(
+        deriveVehiclePropsStatus({
+          recoverEventId: null,
+          missionText: 'RECOVERED PLUGGED',
+        })
+      ).toBe('recovered')
+    })
+
+    test('recoverEventId beats PLUGGED in missionText', () => {
+      expect(
+        deriveVehiclePropsStatus({
+          recoverEventId: 1,
+          missionText: 'PLUGGED',
+        })
+      ).toBe('recovered')
+    })
+  })
+
+  describe('pluggedIn', () => {
+    test('returns "pluggedIn" when missionText contains PLUGGED and no recovery', () => {
+      expect(
+        deriveVehiclePropsStatus({
+          recoverEventId: null,
+          missionText: 'PLUGGED IN',
+        })
+      ).toBe('pluggedIn')
+    })
+
+    test('does not treat empty recoverEvent (no eventId) as recovered', () => {
+      expect(
+        deriveVehiclePropsStatus({
+          recoverEventId: undefined,
+          missionText: 'PLUGGED',
+        })
+      ).toBe('pluggedIn')
+    })
+  })
+
+  describe('onMission', () => {
+    test('returns "onMission" when no recovery or plugged indicators', () => {
+      expect(
+        deriveVehiclePropsStatus({
+          recoverEventId: null,
+          missionText: 'started sci2.xml',
+        })
+      ).toBe('onMission')
+    })
+
+    test('returns "onMission" when missionText is empty', () => {
+      expect(
+        deriveVehiclePropsStatus({ recoverEventId: null, missionText: '' })
+      ).toBe('onMission')
+    })
+
+    test('returns "onMission" when missionText is null', () => {
+      expect(
+        deriveVehiclePropsStatus({ recoverEventId: null, missionText: null })
+      ).toBe('onMission')
+    })
+  })
+})

--- a/apps/lrauv-dash2/lib/deriveVehiclePropsStatus.test.ts
+++ b/apps/lrauv-dash2/lib/deriveVehiclePropsStatus.test.ts
@@ -8,6 +8,12 @@ describe('deriveVehiclePropsStatus', () => {
       ).toBe('recovered')
     })
 
+    test('treats recoverEventId of 0 as a valid (recovered) id', () => {
+      expect(
+        deriveVehiclePropsStatus({ recoverEventId: 0, missionText: '' })
+      ).toBe('recovered')
+    })
+
     test('returns "recovered" when missionText contains RECOVERED', () => {
       expect(
         deriveVehiclePropsStatus({

--- a/apps/lrauv-dash2/lib/deriveVehiclePropsStatus.ts
+++ b/apps/lrauv-dash2/lib/deriveVehiclePropsStatus.ts
@@ -13,7 +13,13 @@ export const deriveVehiclePropsStatus = ({
   recoverEventId?: number | string | null
   missionText?: string | null
 }): 'recovered' | 'pluggedIn' | 'onMission' => {
-  if (recoverEventId || missionText?.includes('RECOVERED')) return 'recovered'
+  // Explicit null/undefined/empty-string check so a valid numeric id of 0
+  // is not mistakenly treated as absent (truthiness would coerce 0 to false).
+  if (
+    (recoverEventId != null && recoverEventId !== '') ||
+    missionText?.includes('RECOVERED')
+  )
+    return 'recovered'
   if (missionText?.includes('PLUGGED')) return 'pluggedIn'
   return 'onMission'
 }

--- a/apps/lrauv-dash2/lib/deriveVehiclePropsStatus.ts
+++ b/apps/lrauv-dash2/lib/deriveVehiclePropsStatus.ts
@@ -1,0 +1,19 @@
+/**
+ * Derives the VehicleProps diagram status from deployment and mission data.
+ * RECOVERED takes precedence over PLUGGED so a recovered-and-plugged vehicle
+ * always renders in the terminal recovered state.
+ *
+ * Used by both VehicleList (overview) and VehicleDiagram (full page) to keep
+ * the two views consistent.
+ */
+export const deriveVehiclePropsStatus = ({
+  recoverEventId,
+  missionText,
+}: {
+  recoverEventId?: number | string | null
+  missionText?: string | null
+}): 'recovered' | 'pluggedIn' | 'onMission' => {
+  if (recoverEventId || missionText?.includes('RECOVERED')) return 'recovered'
+  if (missionText?.includes('PLUGGED')) return 'pluggedIn'
+  return 'onMission'
+}

--- a/apps/lrauv-dash2/lib/useLastCommsTime.ts
+++ b/apps/lrauv-dash2/lib/useLastCommsTime.ts
@@ -29,25 +29,24 @@ export const useLastCommsTime = (
 ): LastCommsTimeResult => {
   const { axiosInstance } = useTethysApiContext()
 
-  // Deployment start minus one day, used as the stable query-key anchor.
+  // deploymentFrom (deployment start − 1 day) anchors the stable query key.
+  // The actual rolling window is computed inside the fetch function at fetch
+  // time so that Date.now() doesn't change the cache key on every render.
   const COMMS_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000
   const deploymentFrom = getAdjustedUnixTime({
     unixTime: startTimeMillis,
     offsetDays: -1,
   })
 
-  // Keep the query key stable (keyed by deploymentFrom, not Date.now()).
-  // The rolling window is computed inside the fetch function so it is always
-  // evaluated at fetch time — avoiding cache churn on every render.
   const { data: eventsData } = useQuery(
     ['event', 'lastCommsTime', vehicleName, deploymentFrom],
     () => {
       // Use a rolling 7-day lookback rather than the full deployment window.
       // Since we can't filter by event state (sat=0 / cell=2) server-side, we
-      // rely on the time window being narrow enough that limit:100 reliably
-      // covers both sat and cell events. If comms of either type haven't
-      // occurred in 7 days the vehicle is overdue; the caller falls back to
-      // vehicle.text_nextcomm (refreshed by useVehicleInfo polling).
+      // rely on the time window being narrow enough that limit:500 reliably
+      // covers both sat and cell events even in high-volume deployments. If
+      // comms of either type haven't occurred in 7 days the vehicle is overdue;
+      // the caller falls back to vehicle.text_nextcomm (from useVehicleInfo).
       const recentFrom = Math.max(
         deploymentFrom,
         Date.now() - COMMS_LOOKBACK_MS

--- a/apps/lrauv-dash2/lib/useLastCommsTime.ts
+++ b/apps/lrauv-dash2/lib/useLastCommsTime.ts
@@ -1,5 +1,10 @@
-import { useEvents } from '@mbari/api-client'
+import {
+  getEvents,
+  GetEventsParams,
+  useTethysApiContext,
+} from '@mbari/api-client'
 import { getAdjustedUnixTime } from '@mbari/utils'
+import { useQuery } from 'react-query'
 
 export type CommsType = 'sat' | 'cell' | null
 
@@ -22,23 +27,32 @@ export const useLastCommsTime = (
   vehicleName: string,
   startTimeMillis: number
 ): LastCommsTimeResult => {
+  const { axiosInstance } = useTethysApiContext()
   const adjustedStartTime = getAdjustedUnixTime({
     unixTime: startTimeMillis,
     offsetDays: -1,
   })
-  const { data: eventsData } = useEvents(
-    {
-      vehicles: [vehicleName as string],
-      eventTypes: ['sbdReceive'],
-      from: adjustedStartTime,
-      // Fetch only the most recent events in descending order so a small limit
-      // is sufficient and polling does not trigger a backfill/pagination loop.
-      limit: 20,
-      ascending: 'n',
-    },
+
+  // Use a single-page fetch (no recursive backfill) so that polling at 30s
+  // does not generate unbounded paginated requests for long deployments.
+  // Fetching in descending order with a small limit gives us the most recent
+  // sbdReceive events in one request — all we need for last-comms times.
+  const params: GetEventsParams = {
+    vehicles: [vehicleName],
+    eventTypes: ['sbdReceive'],
+    from: adjustedStartTime,
+    limit: 20,
+    ascending: 'n',
+  }
+
+  const { data: eventsData } = useQuery(
+    ['event', 'lastCommsTime', vehicleName, adjustedStartTime],
+    () => getEvents(params, { instance: axiosInstance }),
     {
       staleTime: 60 * 1000,
       refetchInterval: 30 * 1000,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
       // startTimeMillis defaults to 0 when the deployment hasn't loaded yet.
       // Subtracting 1 day produces from=-86400000, which TethysDash rejects
       // with a 400. Disable the query until a real start time is available.

--- a/apps/lrauv-dash2/lib/useLastCommsTime.ts
+++ b/apps/lrauv-dash2/lib/useLastCommsTime.ts
@@ -28,26 +28,31 @@ export const useLastCommsTime = (
   startTimeMillis: number
 ): LastCommsTimeResult => {
   const { axiosInstance } = useTethysApiContext()
-  const adjustedStartTime = getAdjustedUnixTime({
+
+  // Use a rolling 7-day lookback rather than the full deployment window.
+  // Since we can't filter by event state (sat=0 / cell=2) server-side, we
+  // rely on the time window being narrow enough that limit:100 reliably covers
+  // both sat and cell events. If comms of either type haven't occurred in 7
+  // days the vehicle is well overdue; the NextComm display will then fall
+  // back to vehicle.text_nextcomm (refreshed by useVehicleInfo polling).
+  const COMMS_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000
+  const deploymentFrom = getAdjustedUnixTime({
     unixTime: startTimeMillis,
     offsetDays: -1,
   })
+  // Don't search earlier than deployment start, but cap at 7 days ago.
+  const recentFrom = Math.max(deploymentFrom, Date.now() - COMMS_LOOKBACK_MS)
 
-  // Use a single-page fetch (no recursive backfill) so that polling at 30s
-  // does not generate unbounded paginated requests for long deployments.
-  // Fetching in descending order (most recent first) with a generous limit
-  // ensures we capture at least one sat (state===0) and cell (state===2)
-  // event even when one type dominates — without paging.
   const params: GetEventsParams = {
     vehicles: [vehicleName],
     eventTypes: ['sbdReceive'],
-    from: adjustedStartTime,
+    from: recentFrom,
     limit: 100,
     ascending: 'n',
   }
 
   const { data: eventsData } = useQuery(
-    ['event', 'lastCommsTime', vehicleName, adjustedStartTime],
+    ['event', 'lastCommsTime', vehicleName, recentFrom],
     () => getEvents(params, { instance: axiosInstance }),
     {
       staleTime: 60 * 1000,

--- a/apps/lrauv-dash2/lib/useLastCommsTime.ts
+++ b/apps/lrauv-dash2/lib/useLastCommsTime.ts
@@ -31,7 +31,10 @@ export const useLastCommsTime = (
       vehicles: [vehicleName as string],
       eventTypes: ['sbdReceive'],
       from: adjustedStartTime,
-      limit: 500,
+      // Fetch only the most recent events in descending order so a small limit
+      // is sufficient and polling does not trigger a backfill/pagination loop.
+      limit: 20,
+      ascending: 'n',
     },
     {
       staleTime: 60 * 1000,

--- a/apps/lrauv-dash2/lib/useLastCommsTime.ts
+++ b/apps/lrauv-dash2/lib/useLastCommsTime.ts
@@ -56,7 +56,10 @@ export const useLastCommsTime = (
         vehicles: [vehicleName],
         eventTypes: ['sbdReceive'],
         from: recentFrom,
-        limit: 100,
+        // 500 events in a 7-day window gives a large safety margin so both
+        // sat (state=0) and cell (state=2) types are captured even if one
+        // type dominates — without reintroducing a full deployment-range fetch.
+        limit: 500,
         ascending: 'n',
       }
       return getEvents(params, { instance: axiosInstance })

--- a/apps/lrauv-dash2/lib/useLastCommsTime.ts
+++ b/apps/lrauv-dash2/lib/useLastCommsTime.ts
@@ -35,6 +35,7 @@ export const useLastCommsTime = (
     },
     {
       staleTime: 60 * 1000,
+      refetchInterval: 30 * 1000,
       // startTimeMillis defaults to 0 when the deployment hasn't loaded yet.
       // Subtracting 1 day produces from=-86400000, which TethysDash rejects
       // with a 400. Disable the query until a real start time is available.

--- a/apps/lrauv-dash2/lib/useLastCommsTime.ts
+++ b/apps/lrauv-dash2/lib/useLastCommsTime.ts
@@ -29,31 +29,38 @@ export const useLastCommsTime = (
 ): LastCommsTimeResult => {
   const { axiosInstance } = useTethysApiContext()
 
-  // Use a rolling 7-day lookback rather than the full deployment window.
-  // Since we can't filter by event state (sat=0 / cell=2) server-side, we
-  // rely on the time window being narrow enough that limit:100 reliably covers
-  // both sat and cell events. If comms of either type haven't occurred in 7
-  // days the vehicle is well overdue; the NextComm display will then fall
-  // back to vehicle.text_nextcomm (refreshed by useVehicleInfo polling).
+  // Deployment start minus one day, used as the stable query-key anchor.
   const COMMS_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000
   const deploymentFrom = getAdjustedUnixTime({
     unixTime: startTimeMillis,
     offsetDays: -1,
   })
-  // Don't search earlier than deployment start, but cap at 7 days ago.
-  const recentFrom = Math.max(deploymentFrom, Date.now() - COMMS_LOOKBACK_MS)
 
-  const params: GetEventsParams = {
-    vehicles: [vehicleName],
-    eventTypes: ['sbdReceive'],
-    from: recentFrom,
-    limit: 100,
-    ascending: 'n',
-  }
-
+  // Keep the query key stable (keyed by deploymentFrom, not Date.now()).
+  // The rolling window is computed inside the fetch function so it is always
+  // evaluated at fetch time — avoiding cache churn on every render.
   const { data: eventsData } = useQuery(
-    ['event', 'lastCommsTime', vehicleName, recentFrom],
-    () => getEvents(params, { instance: axiosInstance }),
+    ['event', 'lastCommsTime', vehicleName, deploymentFrom],
+    () => {
+      // Use a rolling 7-day lookback rather than the full deployment window.
+      // Since we can't filter by event state (sat=0 / cell=2) server-side, we
+      // rely on the time window being narrow enough that limit:100 reliably
+      // covers both sat and cell events. If comms of either type haven't
+      // occurred in 7 days the vehicle is overdue; the caller falls back to
+      // vehicle.text_nextcomm (refreshed by useVehicleInfo polling).
+      const recentFrom = Math.max(
+        deploymentFrom,
+        Date.now() - COMMS_LOOKBACK_MS
+      )
+      const params: GetEventsParams = {
+        vehicles: [vehicleName],
+        eventTypes: ['sbdReceive'],
+        from: recentFrom,
+        limit: 100,
+        ascending: 'n',
+      }
+      return getEvents(params, { instance: axiosInstance })
+    },
     {
       staleTime: 60 * 1000,
       refetchInterval: 30 * 1000,

--- a/apps/lrauv-dash2/lib/useLastCommsTime.ts
+++ b/apps/lrauv-dash2/lib/useLastCommsTime.ts
@@ -35,13 +35,14 @@ export const useLastCommsTime = (
 
   // Use a single-page fetch (no recursive backfill) so that polling at 30s
   // does not generate unbounded paginated requests for long deployments.
-  // Fetching in descending order with a small limit gives us the most recent
-  // sbdReceive events in one request — all we need for last-comms times.
+  // Fetching in descending order (most recent first) with a generous limit
+  // ensures we capture at least one sat (state===0) and cell (state===2)
+  // event even when one type dominates — without paging.
   const params: GetEventsParams = {
     vehicles: [vehicleName],
     eventTypes: ['sbdReceive'],
     from: adjustedStartTime,
-    limit: 20,
+    limit: 100,
     ascending: 'n',
   }
 

--- a/apps/lrauv-dash2/lib/useLastCommsTime.ts
+++ b/apps/lrauv-dash2/lib/useLastCommsTime.ts
@@ -47,9 +47,12 @@ export const useLastCommsTime = (
       // covers both sat and cell events even in high-volume deployments. If
       // comms of either type haven't occurred in 7 days the vehicle is overdue;
       // the caller falls back to vehicle.text_nextcomm (from useVehicleInfo).
-      const recentFrom = Math.max(
-        deploymentFrom,
-        Date.now() - COMMS_LOOKBACK_MS
+      // Clamp to Date.now() so a future-dated deployment start (the API can
+      // return launch events scheduled in the future) never produces a from
+      // value in the future, which would cause the query to return no events.
+      const recentFrom = Math.min(
+        Date.now(),
+        Math.max(deploymentFrom, Date.now() - COMMS_LOOKBACK_MS)
       )
       const params: GetEventsParams = {
         vehicles: [vehicleName],


### PR DESCRIPTION
## Summary

Closes #732.

The overview page vehicle widget (`ConnectedVehicleCell` / `VehicleCell`) was missing several props that the full vehicle page (`VehicleDiagram` / `FullWidthVehicleDiagram`) already wired up. This caused the overview widget to show an older/simpler view of vehicle state.

**Props gap fixed — added to `ConnectedVehicleCell` in `VehicleList.tsx`:**
- `textLM` / `textHM` / `textRoiAgo` — planktivore LM:HM tail values (`PlanktivoreIndicator` was silently skipped without these)
- `colorWhitebeam` / `colorWhiteled` / `colorRedbeam` / `colorRedled` — planktivore LED colors
- `textArriveLabel` — was always defaulting to `"Arrive Station"` instead of using `text_waypoint` from the widget JSON

**Status fix:**
- Overview status derivation was missing the `'recovered'` case — recovered vehicles were incorrectly shown as `'pluggedIn'`

**Auto-refresh / stale data fix (`useLastCommsTime.ts` + `VehicleList.tsx`):**
- Added `refetchInterval: 30s` to `useLastCommsTime` — satellite/cell comms event data was never polled, causing stale NextComm text on the overview widget without a page reload
- Added `refetchInterval: 30s` to `useLastDeployment` and `useVehiclePos` — position data now stays live on the overview page

## Root cause

`VehicleDiagram.tsx` (full page) and `ConnectedVehicleCell` in `VehicleList.tsx` (overview) both build a `vehicleProps` object, but the overview one was never updated when planktivore payload props were added to the full page. The polling gaps were an independent oversight.

## Test plan

- [ ] Open overview page — confirm LM/HM values appear in the planktivore tail section for applicable vehicles (e.g. ahi)
- [ ] Confirm `textArriveLabel` shows the correct waypoint label (not hardcoded "Arrive Station") where `text_waypoint` differs
- [ ] Let overview page sit for ~2 minutes without interaction — confirm NextComm text updates without a page reload
- [ ] Confirm recovered vehicles show the correct visual state on the overview page