### PR TITLE
feat: add GPS surfacing dots, sticky track tooltip, and pre-waypoint marker (#744)

### DIFF
--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -127,7 +127,9 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
   }
 
   if (error) {
-    logger.warn(`Failed to load positions for platform ${platformId}:`, error)
+    // Downgraded to debug: external platform timeouts are expected and non-actionable.
+    // warn-level would pollute the console for platforms that are simply slow or offline.
+    logger.debug(`Failed to load positions for platform ${platformId}:`, error)
     return null
   }
 

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -134,9 +134,6 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
   const platformColor = color || 'cyan'
 
   if (!route || route.length === 0) {
-    logger.debug(
-      `No positions found for platform ${platformId} within the query window — nothing to render`
-    )
     return null
   }
 

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -127,9 +127,19 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
   }
 
   if (error) {
-    // Downgraded to debug: external platform timeouts are expected and non-actionable.
-    // warn-level would pollute the console for platforms that are simply slow or offline.
-    logger.debug(`Failed to load positions for platform ${platformId}:`, error)
+    const isTimeout =
+      error instanceof Error && error.message?.toLowerCase().includes('timeout')
+    if (isTimeout) {
+      // Timeout errors are expected for slow or offline external platforms
+      // and are not actionable by the developer — log at debug to reduce noise.
+      logger.debug(
+        `Failed to load positions for platform ${platformId}:`,
+        error
+      )
+    } else {
+      // Auth/config/5xx and other unexpected failures should remain visible.
+      logger.warn(`Failed to load positions for platform ${platformId}:`, error)
+    }
     return null
   }
 

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -581,41 +581,16 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           </Circle>
         </>
       )}
-      {/* Current vehicle position — two separate pixel-based markers:
-          1. Small solid inner dot (no dashes, no star artifacts)
-          2. Hollow dashed outer ring for visibility when zoomed out
-          Keeping fill and dashes on separate elements avoids the star effect. */}
-      {latest && (
-        <>
-          <CircleMarker
-            center={{ lat: latest.latitude, lng: latest.longitude }}
-            radius={10}
-            color={color}
-            fillColor="transparent"
-            fillOpacity={0}
-            weight={2}
-            dashArray="4, 3"
-            interactive={false}
-          />
-          <CircleMarker
-            center={{ lat: latest.latitude, lng: latest.longitude }}
-            radius={4}
-            color={color}
-            fillColor={color}
-            fillOpacity={1}
-            weight={0}
-            interactive={false}
-          />
-        </>
-      )}
+      {/* Current vehicle position — solid pixel-based dot stays visible at all
+          zoom levels. Tooltip includes pre-waypoint info when future route exists. */}
       {latest && (
         <CircleMarker
           center={{ lat: latest.latitude, lng: latest.longitude }}
-          radius={12}
-          color="transparent"
-          fillColor="transparent"
-          fillOpacity={0}
-          weight={0}
+          radius={6}
+          color={color}
+          fillColor={color}
+          fillOpacity={1}
+          weight={1}
         >
           <Tooltip direction="right" offset={[10, 0]} opacity={0.9}>
             <div className="text-xs leading-snug">

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -205,16 +205,17 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   const lastHoveredFixTimeRef = useRef<number | null>(null)
   // Refs keep handleCoord/handleMouseOut deps-free so they never change
   // reference — preventing HitCircles from re-rendering on every poll/render.
-  const gpsFixesRef = useRef(vehiclePosition?.gpsFixes)
+  // displayedFixesRef is updated below (after displayedFixes is computed) so
+  // handleCoord always iterates the same deduplicated set used for rendering.
+  const displayedFixesRef = useRef<VPosDetail[]>([])
   const handleScrubRef = useRef(handleScrub)
-  gpsFixesRef.current = vehiclePosition?.gpsFixes
   handleScrubRef.current = handleScrub
 
   const handleCoord: LeafletMouseEventHandlerFn = useCallback((e) => {
     if (timeout.current) clearTimeout(timeout.current)
     let coord: VPosDetail | null = null
     let bestDist = Infinity
-    for (const fix of gpsFixesRef.current ?? []) {
+    for (const fix of displayedFixesRef.current) {
       const d = getDistance(fix, e.latlng)
       if (d < bestDist) {
         bestDist = d
@@ -359,6 +360,9 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
       return true
     })
   }, [gpsFixes])
+  // Keep the ref in sync so handleCoord always iterates the same deduplicated
+  // list that is used for rendering — consistent hover/scrub behaviour.
+  displayedFixesRef.current = displayedFixes
 
   // Deduplicated position count for the "Positions: N" tooltip label.
   // When dimTime is active, count only fixes at or before that threshold.

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -345,18 +345,15 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   // indicatorTime → set from timeline bar OR map hover → drives indicator dot
   const gpsFixes = vehiclePosition?.gpsFixes ?? null
 
-  // Limit surfacing dots to the 20 most recent fixes within the last 24h,
-  // matching Dash4's limitPositions=20 / timeWindowHoursForPositions=24 defaults.
-  // gpsFixes[0] is the most recent fix, so slicing from 0 keeps the latest.
+  // Show the 20 most recent GPS surfacing fixes regardless of age so dots
+  // are distributed across the full visible track. Dash4 additionally filters
+  // to a 24h window, but that hides dots on older portions of longer deployments
+  // creating a confusing "dots only on the recent segment" effect.
   const SURFACING_LIMIT = 20
-  const SURFACING_WINDOW_MS = 24 * 60 * 60 * 1000
-  const displayedFixes = useMemo(() => {
-    if (!gpsFixes) return []
-    const windowStart = Date.now() - SURFACING_WINDOW_MS
-    return gpsFixes
-      .filter((fix) => fix.unixTime >= windowStart)
-      .slice(0, SURFACING_LIMIT)
-  }, [gpsFixes])
+  const displayedFixes = useMemo(
+    () => (gpsFixes ? gpsFixes.slice(0, SURFACING_LIMIT) : []),
+    [gpsFixes]
+  )
 
   // Track-split: which fixes are in the "past" relative to dimTime
   const activePoints = useMemo(() => {
@@ -723,7 +720,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         <CircleMarker
           key={`${name}:surfacing:${fix.unixTime}`}
           center={{ lat: fix.latitude, lng: fix.longitude }}
-          radius={index === 0 ? 5 : 2}
+          radius={index === 0 ? 6 : 4}
           interactive={false}
           pathOptions={{
             color,

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -715,8 +715,8 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 Lat/Lon: {fix.latitude.toFixed(5)}, {fix.longitude.toFixed(5)}
               </div>
               <div>
-                {fix.isoTime.replace('T', ' ').replace('Z', '').trim()}
-                {fix.note ? ` ${fix.note}` : ''}
+                {fix.isoTime.replace('T', ' ').replace('Z', '').trim()} ~
+                {((Date.now() - fix.unixTime) / 60000).toFixed(2)}m
               </div>
             </div>
           </Tooltip>

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -360,6 +360,15 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
     })
   }, [gpsFixes])
 
+  // Deduplicated position count for the "Positions: N" tooltip label.
+  // When dimTime is active, count only fixes at or before that threshold.
+  // Uses displayedFixes (already deduped) as the source to avoid over-counting
+  // duplicate unixTime entries that exist in the raw gpsFixes array.
+  const displayedPositionCount = useMemo(() => {
+    if (!dimTime || dimTime <= 0) return displayedFixes.length
+    return displayedFixes.filter((fix) => fix.unixTime <= dimTime).length
+  }, [dimTime, displayedFixes])
+
   // Track-split: which fixes are in the "past" relative to dimTime
   const activePoints = useMemo(() => {
     if (!dimTime || dimTime <= 0 || !gpsFixes) return null
@@ -655,7 +664,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 </span>
               </div>
               <div className="text-gray-500 mt-0.5">
-                Positions: {activePoints?.length ?? displayedFixes.length}
+                Positions: {displayedPositionCount}
               </div>
             </div>
           </Tooltip>

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -670,7 +670,10 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 {mapHoverFix.longitude.toFixed(5)}
               </div>
               <div className="text-gray-600">
-                {mapHoverFix.isoTime.replace('T', ' ').replace('Z', ' UTC')}
+                {mapHoverFix.isoTime.replace('T', ' ').replace('Z', '').trim()}
+              </div>
+              <div className="text-[10px] italic text-gray-500">
+                -{formatElapsedTime(Date.now() - mapHoverFix.unixTime)}
               </div>
             </div>
           </Tooltip>

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -511,17 +511,19 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
               {latest && (
                 <>
                   <div className="mt-0.5">
-                    Latest position: {latest.latitude.toFixed(5)},{' '}
+                    Latest: {latest.latitude.toFixed(5)},{' '}
                     {latest.longitude.toFixed(5)}
                   </div>
                   <div>
                     {latest.isoTime.replace('T', ' ').replace('Z', ' UTC')}
-                    {timeSinceFixDisplay ? ` — ${timeSinceFixDisplay}` : ''}
+                  </div>
+                  <div>
+                    {formatElapsedTime(Date.now() - latest.unixTime)} ago
                   </div>
                 </>
               )}
               <div className="text-gray-500 mt-0.5">
-                Positions displayed: {gpsFixes?.length ?? 0}
+                Positions: {gpsFixes?.length ?? 0}
               </div>
             </div>
           </Tooltip>

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -507,29 +507,13 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             },
           }}
         >
-          {/* Sticky tooltip on the track line — follows cursor, shows summary */}
+          {/* Sticky tooltip on the track line — vehicle name + position count */}
           <Tooltip sticky opacity={0.88}>
-            <div className="text-xs leading-snug min-w-[170px]">
+            <div className="text-xs leading-snug">
               <div className="font-bold" style={{ color }}>
                 {name}
               </div>
-              {latest && (
-                <>
-                  <div className="mt-0.5">
-                    Latest: {latest.latitude.toFixed(5)},{' '}
-                    {latest.longitude.toFixed(5)}
-                  </div>
-                  <div>
-                    {latest.isoTime.replace('T', ' ').replace('Z', ' UTC')}
-                  </div>
-                  <div>
-                    {formatElapsedTime(Date.now() - latest.unixTime)} ago
-                  </div>
-                </>
-              )}
-              <div className="text-gray-500 mt-0.5">
-                Positions displayed: {displayedFixes.length}
-              </div>
+              <div>Positions: {displayedFixes.length}</div>
             </div>
           </Tooltip>
         </Polyline>
@@ -717,12 +701,26 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           key={`${name}:surfacing:${fix.unixTime}`}
           center={{ lat: fix.latitude, lng: fix.longitude }}
           radius={index === 0 ? 5 : 3}
-          interactive={false}
           color={color}
           fillColor={color}
           fillOpacity={index === 0 ? 1 : 0.7}
           weight={1}
-        />
+        >
+          <Tooltip direction="top" offset={[0, -4]} opacity={0.9}>
+            <div className="text-xs leading-snug">
+              <div className="font-bold" style={{ color }}>
+                {name}
+              </div>
+              <div>
+                Lat/Lon: {fix.latitude.toFixed(5)}, {fix.longitude.toFixed(5)}
+              </div>
+              <div>
+                {fix.isoTime.replace('T', ' ').replace('Z', '').trim()}
+                {fix.note ? ` ${fix.note}` : ''}
+              </div>
+            </div>
+          </Tooltip>
+        </CircleMarker>
       ))}
 
       {/* Memoized hit targets — isolated from VehiclePath re-renders to

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -568,7 +568,8 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         ))}
       {/* GPS surfacing dots along the full deployment track — rendered before the
           current position marker so the latest dot always appears on top when
-          positions overlap. Color props must be direct props on CircleMarker. */}
+          positions overlap. Non-interactive so HitCircles retain pointer priority
+          for scrub/hover. Per-fix details are shown via the mapHoverFix tooltip. */}
       {displayedFixes.map((fix, index) =>
         index === 0 ? null : (
           <CircleMarker
@@ -579,35 +580,8 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             fillColor={color}
             fillOpacity={0.7}
             weight={1}
-          >
-            <Tooltip direction="top" offset={[0, -4]} opacity={0.9}>
-              <div className="text-xs leading-snug">
-                <div className="flex items-center gap-1 font-bold text-black">
-                  <span
-                    style={{
-                      background: color,
-                      border: '1.5px solid rgba(0,0,0,0.4)',
-                      borderRadius: '50%',
-                      width: 8,
-                      height: 8,
-                      display: 'inline-block',
-                      flexShrink: 0,
-                    }}
-                  />
-                  {name}
-                </div>
-                <div>
-                  Lat/Lon: {fix.latitude.toFixed(5)}, {fix.longitude.toFixed(5)}
-                </div>
-                <div>
-                  {fix.isoTime.replace('T', ' ').replace('Z', '').trim()}{' '}
-                  <span className="text-[10px] italic text-gray-500">
-                    -{formatElapsedTime(Date.now() - fix.unixTime)}
-                  </span>
-                </div>
-              </div>
-            </Tooltip>
-          </CircleMarker>
+            interactive={false}
+          />
         )
       )}
       {/* Current vehicle position — solid filled dot with a contrasting white
@@ -631,51 +605,6 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             permanent
           >
             {name}
-          </Tooltip>
-        </CircleMarker>
-      )}
-      {/* Invisible hit target for the hover tooltip */}
-      {latest && (
-        <CircleMarker
-          center={{ lat: latest.latitude, lng: latest.longitude }}
-          radius={12}
-          color="transparent"
-          fillColor="transparent"
-          fillOpacity={0}
-          weight={0}
-        >
-          <Tooltip direction="right" offset={[10, 0]} opacity={0.9}>
-            <div className="text-xs leading-snug">
-              <div className="flex items-center gap-1 font-bold text-black">
-                <span
-                  style={{
-                    background: color,
-                    border: '1.5px solid rgba(0,0,0,0.4)',
-                    borderRadius: '50%',
-                    width: 8,
-                    height: 8,
-                    display: 'inline-block',
-                    flexShrink: 0,
-                  }}
-                />
-                {name}
-              </div>
-              {futureRoute && (
-                <div className="text-gray-500 italic">
-                  Position before waypoint trajectory
-                </div>
-              )}
-              <div className="mt-0.5">
-                Latest position: {latest.latitude.toFixed(5)},{' '}
-                {latest.longitude.toFixed(5)}
-              </div>
-              <div>
-                {latestTimeFix?.replace('T', ' ').replace('Z', '').trim()}{' '}
-                <span className="text-[10px] italic text-gray-500">
-                  -{formatElapsedTime(Date.now() - latest.unixTime)}
-                </span>
-              </div>
-            </div>
           </Tooltip>
         </CircleMarker>
       )}
@@ -744,7 +673,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 {mapHoverFix.longitude.toFixed(5)}
               </div>
               <div className="text-gray-600">
-                {mapHoverFix.isoTime.replace('T', ' ').replace('Z', '').trim()}{' '}
+                {mapHoverFix.isoTime.replace('T', ' ').replace('Z', ' UTC')}{' '}
                 <span className="text-[10px] italic text-gray-500">
                   -{formatElapsedTime(Date.now() - mapHoverFix.unixTime)}
                 </span>
@@ -788,6 +717,53 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         onCoord={handleCoord}
         onMouseOut={handleMouseOut}
       />
+      {/* Invisible hit target for the latest-position tooltip — rendered AFTER
+          HitCircles so it sits on top and its tooltip is reliably reachable.
+          Shows "Position before waypoint trajectory" when a future route exists. */}
+      {latest && (
+        <CircleMarker
+          center={{ lat: latest.latitude, lng: latest.longitude }}
+          radius={12}
+          color="transparent"
+          fillColor="transparent"
+          fillOpacity={0}
+          weight={0}
+        >
+          <Tooltip direction="right" offset={[10, 0]} opacity={0.9}>
+            <div className="text-xs leading-snug">
+              <div className="flex items-center gap-1 font-bold text-black">
+                <span
+                  style={{
+                    background: color,
+                    border: '1.5px solid rgba(0,0,0,0.4)',
+                    borderRadius: '50%',
+                    width: 8,
+                    height: 8,
+                    display: 'inline-block',
+                    flexShrink: 0,
+                  }}
+                />
+                {name}
+              </div>
+              {futureRoute && (
+                <div className="text-gray-500 italic">
+                  Position before waypoint trajectory
+                </div>
+              )}
+              <div className="mt-0.5">
+                Latest position: {latest.latitude.toFixed(5)},{' '}
+                {latest.longitude.toFixed(5)}
+              </div>
+              <div>
+                {latestTimeFix?.replace('T', ' ').replace('Z', ' UTC')}{' '}
+                <span className="text-[10px] italic text-gray-500">
+                  -{formatElapsedTime(Date.now() - latest.unixTime)}
+                </span>
+              </div>
+            </div>
+          </Tooltip>
+        </CircleMarker>
+      )}
     </>
   ) : null
 }

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -50,8 +50,6 @@ const VehiclePoint: React.FC<{
 // Memoized hit-circle layer so it never re-renders when VehiclePath state
 // (mapHoverFix, indicatorTime, etc.) changes — prevents React-Leaflet from
 // re-mounting the circles and emitting spurious mouseout/mouseover events.
-// Also carries the sticky summary tooltip so it appears even when the cursor
-// is over a hit circle (which intercepts pointer events before the Polyline).
 const HitCircles = React.memo(
   ({
     name,
@@ -553,7 +551,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           <CircleMarker
             key={`${name}:surfacing:${fix.eventId ?? fix.unixTime}`}
             center={{ lat: fix.latitude, lng: fix.longitude }}
-            radius={3}
+            radius={2}
             color={color}
             fillColor={color}
             fillOpacity={0.7}
@@ -569,7 +567,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         <CircleMarker
           data-vehicle-point={`${name}-latest`}
           center={{ lat: latest.latitude, lng: latest.longitude }}
-          radius={7}
+          radius={6}
           color="white"
           fillColor={color}
           fillOpacity={1}
@@ -731,8 +729,8 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 </div>
               )}
               <div className="mt-0.5">
-                Latest position: {latest.latitude.toFixed(5)},{' '}
-                {latest.longitude.toFixed(5)}
+                {futureRoute ? 'Lat/Lon:' : 'Latest position:'}{' '}
+                {latest.latitude.toFixed(5)}, {latest.longitude.toFixed(5)}
               </div>
               <div>
                 {latestTimeFix?.replace('T', ' ').replace('Z', ' UTC')}{' '}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -581,7 +581,9 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           </Circle>
         </>
       )}
-      {/* Solid dot at the latest GPS fix — always visible, tooltip on hover only */}
+      {/* Solid dot at the latest GPS fix — always visible, tooltip on hover only.
+          When a future route exists, also shows "Position before waypoint trajectory"
+          so both pieces of info come from a single tooltip with no overlap. */}
       {latest && (
         <Circle
           pathOptions={{ color }}
@@ -592,18 +594,35 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           radius={60}
         >
           <Tooltip direction="right" offset={[10, 0]} opacity={0.9}>
-            <div>
-              <div className="text-purple text-bold">{name}</div>
-              <div>
-                Latest position: {latest.latitude.toFixed(5)},{' '}
+            <div className="text-xs leading-snug">
+              <div className="flex items-center gap-1 font-bold text-black">
+                <span
+                  style={{
+                    background: color,
+                    border: '1.5px solid rgba(0,0,0,0.4)',
+                    borderRadius: '50%',
+                    width: 8,
+                    height: 8,
+                    display: 'inline-block',
+                    flexShrink: 0,
+                  }}
+                />
+                {name}
+              </div>
+              {futureRoute && (
+                <div className="text-gray-500 italic">
+                  Position before waypoint trajectory
+                </div>
+              )}
+              <div className="mt-0.5">
+                Lat/Lon: {latest.latitude.toFixed(5)},{' '}
                 {latest.longitude.toFixed(5)}
               </div>
               <div>
-                {latest.isoTime.split('T')[0] +
-                  ' ' +
-                  latest.isoTime.split('T')[1].split('Z')[0]}
-                {' - '}
-                {timeSinceFixDisplay}
+                {latest.isoTime.replace('T', ' ').replace('Z', '').trim()}{' '}
+                <span className="text-[10px] italic text-gray-500">
+                  -{formatElapsedTime(Date.now() - latest.unixTime)}
+                </span>
               </div>
             </div>
           </Tooltip>
@@ -764,44 +783,6 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         onCoord={handleCoord}
         onMouseOut={handleMouseOut}
       />
-
-      {/* "Position before waypoint trajectory" — invisible hit target so the
-          tooltip is reachable without adding a visual circle on top of the
-          existing vehicle position indicator (which would cause a star artifact). */}
-      {futureRoute && latest && (
-        <CircleMarker
-          center={{ lat: latest.latitude, lng: latest.longitude }}
-          radius={12}
-          color="transparent"
-          fillColor="transparent"
-          fillOpacity={0}
-          weight={0}
-        >
-          <Tooltip direction="top" offset={[0, -10]} opacity={0.9}>
-            <div className="text-xs leading-snug">
-              <div className="flex items-center gap-1 font-bold text-black">
-                <span
-                  style={{
-                    background: color,
-                    border: '1.5px solid rgba(0,0,0,0.4)',
-                    borderRadius: '50%',
-                    width: 8,
-                    height: 8,
-                    display: 'inline-block',
-                    flexShrink: 0,
-                  }}
-                />
-                {name}
-              </div>
-              <div>Position before waypoint trajectory</div>
-              <div>
-                Lat/Lon: {latest.latitude.toFixed(5)},{' '}
-                {latest.longitude.toFixed(5)}
-              </div>
-            </div>
-          </Tooltip>
-        </CircleMarker>
-      )}
     </>
   ) : null
 }

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -510,7 +510,14 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           {/* Sticky tooltip on the track line — vehicle name + position count */}
           <Tooltip sticky opacity={0.88}>
             <div className="text-xs leading-snug">
-              <div className="font-bold" style={{ color }}>
+              <div
+                className="font-bold"
+                style={{
+                  color,
+                  textShadow:
+                    '0 0 2px rgba(0,0,0,0.6), 0 0 4px rgba(0,0,0,0.3)',
+                }}
+              >
                 {name}
               </div>
               <div>Positions: {displayedFixes.length}</div>
@@ -708,15 +715,22 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         >
           <Tooltip direction="top" offset={[0, -4]} opacity={0.9}>
             <div className="text-xs leading-snug">
-              <div className="font-bold" style={{ color }}>
+              <div
+                className="font-bold"
+                style={{
+                  color,
+                  textShadow:
+                    '0 0 2px rgba(0,0,0,0.6), 0 0 4px rgba(0,0,0,0.3)',
+                }}
+              >
                 {name}
               </div>
               <div>
                 Lat/Lon: {fix.latitude.toFixed(5)}, {fix.longitude.toFixed(5)}
               </div>
-              <div>
-                {fix.isoTime.replace('T', ' ').replace('Z', '').trim()} ~
-                {((Date.now() - fix.unixTime) / 60000).toFixed(2)}m
+              <div>{fix.isoTime.replace('T', ' ').replace('Z', '').trim()}</div>
+              <div className="text-[10px] italic text-gray-500">
+                -{formatElapsedTime(Date.now() - fix.unixTime)}
               </div>
             </div>
           </Tooltip>
@@ -747,7 +761,14 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         >
           <Tooltip direction="right" offset={[6, 0]} opacity={0.9}>
             <div className="text-xs leading-snug">
-              <div className="font-bold" style={{ color }}>
+              <div
+                className="font-bold"
+                style={{
+                  color,
+                  textShadow:
+                    '0 0 2px rgba(0,0,0,0.6), 0 0 4px rgba(0,0,0,0.3)',
+                }}
+              >
                 {name}
               </div>
               <div>Position before waypoint trajectory</div>

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -515,7 +515,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 style={{
                   color,
                   textShadow:
-                    '0 0 2px rgba(0,0,0,0.6), 0 0 4px rgba(0,0,0,0.3)',
+                    '0 0 1px #000, 0 0 2px #000, 0 0 3px rgba(0,0,0,0.6)',
                 }}
               >
                 {name}
@@ -723,7 +723,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 style={{
                   color,
                   textShadow:
-                    '0 0 2px rgba(0,0,0,0.6), 0 0 4px rgba(0,0,0,0.3)',
+                    '0 0 1px #000, 0 0 2px #000, 0 0 3px rgba(0,0,0,0.6)',
                 }}
               >
                 {name}
@@ -771,7 +771,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 style={{
                   color,
                   textShadow:
-                    '0 0 2px rgba(0,0,0,0.6), 0 0 4px rgba(0,0,0,0.3)',
+                    '0 0 1px #000, 0 0 2px #000, 0 0 3px rgba(0,0,0,0.6)',
                 }}
               >
                 {name}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -553,21 +553,23 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             radius={20}
           />
         ))}
+      {/* Current vehicle position — pixel-based so both elements stay at fixed
+          screen sizes at every zoom level, preventing the star collision artifact:
+          - outer ring: 16px hollow dashed ring (always clearly outside the dot)
+          - inner dot:  4px solid fill (always clearly inside the ring)
+          The vehicle name label uses the existing permanent tooltip on the ring. */}
       {latest && (
         <>
-          {/* DEPLOYMENT AND OVERVIEW PAGE */}
-          {/* Circle = large dotted indicator circle. */}
-          <Circle
+          <CircleMarker
             data-vehicle-point={`${name}-latest`}
             center={{ lat: latest.latitude, lng: latest.longitude }}
-            pathOptions={{
-              color,
-              fillColor: color,
-              fillOpacity: 0.1,
-              weight: 1,
-              dashArray: '4, 4',
-            }}
-            radius={200}
+            radius={16}
+            color={color}
+            fillColor={color}
+            fillOpacity={0.08}
+            weight={1.5}
+            dashArray="5, 4"
+            interactive={false}
           >
             <Tooltip
               className="text-bold text-purple"
@@ -578,19 +580,27 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             >
               {name}
             </Tooltip>
-          </Circle>
+          </CircleMarker>
+          <CircleMarker
+            center={{ lat: latest.latitude, lng: latest.longitude }}
+            radius={4}
+            color={color}
+            fillColor={color}
+            fillOpacity={1}
+            weight={0}
+            interactive={false}
+          />
         </>
       )}
-      {/* Current vehicle position — solid pixel-based dot stays visible at all
-          zoom levels. Tooltip includes pre-waypoint info when future route exists. */}
+      {/* Tooltip hit target for current position — invisible, sits on top */}
       {latest && (
         <CircleMarker
           center={{ lat: latest.latitude, lng: latest.longitude }}
-          radius={6}
-          color={color}
-          fillColor={color}
-          fillOpacity={1}
-          weight={1}
+          radius={16}
+          color="transparent"
+          fillColor="transparent"
+          fillOpacity={0}
+          weight={0}
         >
           <Tooltip direction="right" offset={[10, 0]} opacity={0.9}>
             <div className="text-xs leading-snug">

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -765,18 +765,19 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         onMouseOut={handleMouseOut}
       />
 
-      {/* "Position before waypoint trajectory" — interactive marker rendered
-          on top of hit circles so its tooltip is reachable on hover */}
+      {/* "Position before waypoint trajectory" — invisible hit target so the
+          tooltip is reachable without adding a visual circle on top of the
+          existing vehicle position indicator (which would cause a star artifact). */}
       {futureRoute && latest && (
         <CircleMarker
           center={{ lat: latest.latitude, lng: latest.longitude }}
-          radius={5}
-          color={color}
-          fillColor={color}
-          fillOpacity={0.5}
-          weight={2}
+          radius={12}
+          color="transparent"
+          fillColor="transparent"
+          fillOpacity={0}
+          weight={0}
         >
-          <Tooltip direction="right" offset={[6, 0]} opacity={0.9}>
+          <Tooltip direction="top" offset={[0, -10]} opacity={0.9}>
             <div className="text-xs leading-snug">
               <div className="flex items-center gap-1 font-bold text-black">
                 <span

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -708,21 +708,20 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             opacity={0.5}
           />
         ))}
-      {/* GPS surfacing dots — 20 most recent fixes within last 24h, matching
-          Dash4's limitPositions/timeWindowHoursForPositions defaults.
+      {/* GPS surfacing dots along the full deployment track.
+          Color props must be direct props on CircleMarker (not pathOptions)
+          for react-leaflet to apply them correctly.
           interactive=false so HitCircles keep hover/scrub control. */}
       {displayedFixes.map((fix, index) => (
         <CircleMarker
           key={`${name}:surfacing:${fix.unixTime}`}
           center={{ lat: fix.latitude, lng: fix.longitude }}
-          radius={index === 0 ? 6 : 4}
+          radius={index === 0 ? 5 : 3}
           interactive={false}
-          pathOptions={{
-            color,
-            fillColor: color,
-            fillOpacity: index === 0 ? 1 : 0.65,
-            weight: 1,
-          }}
+          color={color}
+          fillColor={color}
+          fillOpacity={index === 0 ? 1 : 0.7}
+          weight={1}
         />
       ))}
 
@@ -743,12 +742,10 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         <CircleMarker
           center={{ lat: latest.latitude, lng: latest.longitude }}
           radius={5}
-          pathOptions={{
-            color,
-            fillColor: color,
-            fillOpacity: 0.5,
-            weight: 2,
-          }}
+          color={color}
+          fillColor={color}
+          fillOpacity={0.5}
+          weight={2}
         >
           <Tooltip direction="right" offset={[6, 0]} opacity={0.9}>
             <div className="text-xs leading-snug">

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -553,18 +553,19 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             radius={20}
           />
         ))}
-      {/* Current vehicle position — hollow ring with thick stroke. At close zoom
-          it reads as a ring; as you zoom out the stroke fills the center and it
-          naturally merges into a solid dot. Matches Dash4's visual behavior. */}
+      {/* Current vehicle position — solid filled dot with a contrasting white
+          border ring. The fill anchors the center point at all zoom levels;
+          the white stroke acts as the visible ring separator from the track.
+          Matches Dash4's l-circle-marker approach (radius=6, solid). */}
       {latest && (
         <CircleMarker
           data-vehicle-point={`${name}-latest`}
           center={{ lat: latest.latitude, lng: latest.longitude }}
-          radius={8}
-          color={color}
+          radius={7}
+          color="white"
           fillColor={color}
-          fillOpacity={0}
-          weight={4}
+          fillOpacity={1}
+          weight={2}
         >
           <Tooltip
             className="text-bold text-purple"

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -553,18 +553,18 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             radius={20}
           />
         ))}
-      {/* Current vehicle position — single solid pixel-based dot with vehicle
-          name label. No outer ring: rings at any radius cause visual clutter
-          or star artifacts at different zoom levels. */}
+      {/* Current vehicle position — hollow ring with thick stroke. At close zoom
+          it reads as a ring; as you zoom out the stroke fills the center and it
+          naturally merges into a solid dot. Matches Dash4's visual behavior. */}
       {latest && (
         <CircleMarker
           data-vehicle-point={`${name}-latest`}
           center={{ lat: latest.latitude, lng: latest.longitude }}
-          radius={6}
+          radius={8}
           color={color}
           fillColor={color}
-          fillOpacity={1}
-          weight={1}
+          fillOpacity={0}
+          weight={4}
         >
           <Tooltip
             className="text-bold text-purple"

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -510,14 +510,18 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           {/* Sticky tooltip on the track line — vehicle name + position count */}
           <Tooltip sticky opacity={0.88}>
             <div className="text-xs leading-snug">
-              <div
-                className="font-bold"
-                style={{
-                  color,
-                  textShadow:
-                    '0 0 1px #000, 0 0 2px #000, 0 0 3px rgba(0,0,0,0.6)',
-                }}
-              >
+              <div className="flex items-center gap-1 font-bold text-black">
+                <span
+                  style={{
+                    background: color,
+                    border: '1.5px solid rgba(0,0,0,0.4)',
+                    borderRadius: '50%',
+                    width: 8,
+                    height: 8,
+                    display: 'inline-block',
+                    flexShrink: 0,
+                  }}
+                />
                 {name}
               </div>
               <div>Positions: {displayedFixes.length}</div>
@@ -718,14 +722,18 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         >
           <Tooltip direction="top" offset={[0, -4]} opacity={0.9}>
             <div className="text-xs leading-snug">
-              <div
-                className="font-bold"
-                style={{
-                  color,
-                  textShadow:
-                    '0 0 1px #000, 0 0 2px #000, 0 0 3px rgba(0,0,0,0.6)',
-                }}
-              >
+              <div className="flex items-center gap-1 font-bold text-black">
+                <span
+                  style={{
+                    background: color,
+                    border: '1.5px solid rgba(0,0,0,0.4)',
+                    borderRadius: '50%',
+                    width: 8,
+                    height: 8,
+                    display: 'inline-block',
+                    flexShrink: 0,
+                  }}
+                />
                 {name}
               </div>
               <div>
@@ -766,14 +774,18 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         >
           <Tooltip direction="right" offset={[6, 0]} opacity={0.9}>
             <div className="text-xs leading-snug">
-              <div
-                className="font-bold"
-                style={{
-                  color,
-                  textShadow:
-                    '0 0 1px #000, 0 0 2px #000, 0 0 3px rgba(0,0,0,0.6)',
-                }}
-              >
+              <div className="flex items-center gap-1 font-bold text-black">
+                <span
+                  style={{
+                    background: color,
+                    border: '1.5px solid rgba(0,0,0,0.4)',
+                    borderRadius: '50%',
+                    width: 8,
+                    height: 8,
+                    display: 'inline-block',
+                    flexShrink: 0,
+                  }}
+                />
                 {name}
               </div>
               <div>Position before waypoint trajectory</div>

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -563,9 +563,52 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             radius={20}
           />
         ))}
+      {/* GPS surfacing dots along the full deployment track — rendered before the
+          current position marker so the latest dot always appears on top when
+          positions overlap. Color props must be direct props on CircleMarker. */}
+      {displayedFixes.map((fix, index) =>
+        index === 0 ? null : (
+          <CircleMarker
+            key={`${name}:surfacing:${fix.eventId ?? fix.unixTime}`}
+            center={{ lat: fix.latitude, lng: fix.longitude }}
+            radius={3}
+            color={color}
+            fillColor={color}
+            fillOpacity={0.7}
+            weight={1}
+          >
+            <Tooltip direction="top" offset={[0, -4]} opacity={0.9}>
+              <div className="text-xs leading-snug">
+                <div className="flex items-center gap-1 font-bold text-black">
+                  <span
+                    style={{
+                      background: color,
+                      border: '1.5px solid rgba(0,0,0,0.4)',
+                      borderRadius: '50%',
+                      width: 8,
+                      height: 8,
+                      display: 'inline-block',
+                      flexShrink: 0,
+                    }}
+                  />
+                  {name}
+                </div>
+                <div>
+                  Lat/Lon: {fix.latitude.toFixed(5)}, {fix.longitude.toFixed(5)}
+                </div>
+                <div>
+                  {fix.isoTime.replace('T', ' ').replace('Z', '').trim()}{' '}
+                  <span className="text-[10px] italic text-gray-500">
+                    -{formatElapsedTime(Date.now() - fix.unixTime)}
+                  </span>
+                </div>
+              </div>
+            </Tooltip>
+          </CircleMarker>
+        )
+      )}
       {/* Current vehicle position — solid filled dot with a contrasting white
-          border ring. The fill anchors the center point at all zoom levels;
-          the white stroke acts as the visible ring separator from the track.
+          border ring. Rendered after surfacing dots so it always appears on top.
           Matches Dash4's l-circle-marker approach (radius=6, solid). */}
       {latest && (
         <CircleMarker
@@ -730,53 +773,6 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             opacity={0.5}
           />
         ))}
-      {/* GPS surfacing dots along the full deployment track.
-          Color props must be direct props on CircleMarker (not pathOptions)
-          for react-leaflet to apply them correctly.
-          interactive=false so HitCircles keep hover/scrub control. */}
-      {displayedFixes.map((fix, index) =>
-        // Skip index 0 — the existing vehicle position indicator (60m Circle)
-        // already marks the current location. Rendering on top causes a star artifact.
-        index === 0 ? null : (
-          <CircleMarker
-            key={`${name}:surfacing:${fix.eventId ?? fix.unixTime}`}
-            center={{ lat: fix.latitude, lng: fix.longitude }}
-            radius={3}
-            color={color}
-            fillColor={color}
-            fillOpacity={0.7}
-            weight={1}
-          >
-            <Tooltip direction="top" offset={[0, -4]} opacity={0.9}>
-              <div className="text-xs leading-snug">
-                <div className="flex items-center gap-1 font-bold text-black">
-                  <span
-                    style={{
-                      background: color,
-                      border: '1.5px solid rgba(0,0,0,0.4)',
-                      borderRadius: '50%',
-                      width: 8,
-                      height: 8,
-                      display: 'inline-block',
-                      flexShrink: 0,
-                    }}
-                  />
-                  {name}
-                </div>
-                <div>
-                  Lat/Lon: {fix.latitude.toFixed(5)}, {fix.longitude.toFixed(5)}
-                </div>
-                <div>
-                  {fix.isoTime.replace('T', ' ').replace('Z', '').trim()}{' '}
-                  <span className="text-[10px] italic text-gray-500">
-                    -{formatElapsedTime(Date.now() - fix.unixTime)}
-                  </span>
-                </div>
-              </div>
-            </Tooltip>
-          </CircleMarker>
-        )
-      )}
 
       {/* Memoized hit targets — isolated from VehiclePath re-renders to
           prevent spurious mouseout/mouseover events causing tooltip flicker. */}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -58,7 +58,6 @@ const HitCircles = React.memo(
     grouped,
     route,
     color,
-    positionCount,
     onCoord,
     onMouseOut,
   }: {
@@ -66,7 +65,6 @@ const HitCircles = React.memo(
     grouped?: boolean
     route: [number, number][]
     color: string
-    positionCount: number
     onCoord: LeafletMouseEventHandlerFn
     onMouseOut: LeafletMouseEventHandlerFn
   }) => (
@@ -83,27 +81,7 @@ const HitCircles = React.memo(
           color={color}
           opacity={0}
           eventHandlers={{ mouseover: onCoord, mouseout: onMouseOut }}
-        >
-          <Tooltip sticky opacity={0.88}>
-            <div className="text-xs leading-snug">
-              <div className="flex items-center gap-1 font-bold text-black">
-                <span
-                  style={{
-                    background: color,
-                    border: '1.5px solid rgba(0,0,0,0.4)',
-                    borderRadius: '50%',
-                    width: 8,
-                    height: 8,
-                    display: 'inline-block',
-                    flexShrink: 0,
-                  }}
-                />
-                {name}
-              </div>
-              <div>Positions: {positionCount}</div>
-            </div>
-          </Tooltip>
-        </Circle>
+        />
       ))}
     </>
   )
@@ -678,6 +656,9 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                   -{formatElapsedTime(Date.now() - mapHoverFix.unixTime)}
                 </span>
               </div>
+              <div className="text-gray-500 mt-0.5">
+                Positions: {activePoints?.length ?? displayedFixes.length}
+              </div>
             </div>
           </Tooltip>
         </Circle>
@@ -713,7 +694,6 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         grouped={grouped}
         route={route}
         color={color}
-        positionCount={activePoints?.length ?? displayedFixes.length}
         onCoord={handleCoord}
         onMouseOut={handleMouseOut}
       />

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -710,45 +710,49 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           Color props must be direct props on CircleMarker (not pathOptions)
           for react-leaflet to apply them correctly.
           interactive=false so HitCircles keep hover/scrub control. */}
-      {displayedFixes.map((fix, index) => (
-        <CircleMarker
-          key={`${name}:surfacing:${fix.unixTime}`}
-          center={{ lat: fix.latitude, lng: fix.longitude }}
-          radius={index === 0 ? 5 : 3}
-          color={color}
-          fillColor={color}
-          fillOpacity={index === 0 ? 1 : 0.7}
-          weight={1}
-        >
-          <Tooltip direction="top" offset={[0, -4]} opacity={0.9}>
-            <div className="text-xs leading-snug">
-              <div className="flex items-center gap-1 font-bold text-black">
-                <span
-                  style={{
-                    background: color,
-                    border: '1.5px solid rgba(0,0,0,0.4)',
-                    borderRadius: '50%',
-                    width: 8,
-                    height: 8,
-                    display: 'inline-block',
-                    flexShrink: 0,
-                  }}
-                />
-                {name}
+      {displayedFixes.map((fix, index) =>
+        // Skip index 0 — the existing vehicle position indicator (60m Circle)
+        // already marks the current location. Rendering on top causes a star artifact.
+        index === 0 ? null : (
+          <CircleMarker
+            key={`${name}:surfacing:${fix.unixTime}`}
+            center={{ lat: fix.latitude, lng: fix.longitude }}
+            radius={3}
+            color={color}
+            fillColor={color}
+            fillOpacity={0.7}
+            weight={1}
+          >
+            <Tooltip direction="top" offset={[0, -4]} opacity={0.9}>
+              <div className="text-xs leading-snug">
+                <div className="flex items-center gap-1 font-bold text-black">
+                  <span
+                    style={{
+                      background: color,
+                      border: '1.5px solid rgba(0,0,0,0.4)',
+                      borderRadius: '50%',
+                      width: 8,
+                      height: 8,
+                      display: 'inline-block',
+                      flexShrink: 0,
+                    }}
+                  />
+                  {name}
+                </div>
+                <div>
+                  Lat/Lon: {fix.latitude.toFixed(5)}, {fix.longitude.toFixed(5)}
+                </div>
+                <div>
+                  {fix.isoTime.replace('T', ' ').replace('Z', '').trim()}{' '}
+                  <span className="text-[10px] italic text-gray-500">
+                    -{formatElapsedTime(Date.now() - fix.unixTime)}
+                  </span>
+                </div>
               </div>
-              <div>
-                Lat/Lon: {fix.latitude.toFixed(5)}, {fix.longitude.toFixed(5)}
-              </div>
-              <div>
-                {fix.isoTime.replace('T', ' ').replace('Z', '').trim()}{' '}
-                <span className="text-[10px] italic text-gray-500">
-                  -{formatElapsedTime(Date.now() - fix.unixTime)}
-                </span>
-              </div>
-            </div>
-          </Tooltip>
-        </CircleMarker>
-      ))}
+            </Tooltip>
+          </CircleMarker>
+        )
+      )}
 
       {/* Memoized hit targets — isolated from VehiclePath re-renders to
           prevent spurious mouseout/mouseover events causing tooltip flicker. */}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -670,10 +670,10 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 {mapHoverFix.longitude.toFixed(5)}
               </div>
               <div className="text-gray-600">
-                {mapHoverFix.isoTime.replace('T', ' ').replace('Z', '').trim()}
-              </div>
-              <div className="text-[10px] italic text-gray-500">
-                -{formatElapsedTime(Date.now() - mapHoverFix.unixTime)}
+                {mapHoverFix.isoTime.replace('T', ' ').replace('Z', '').trim()}{' '}
+                <span className="text-[10px] italic text-gray-500">
+                  -{formatElapsedTime(Date.now() - mapHoverFix.unixTime)}
+                </span>
               </div>
             </div>
           </Tooltip>
@@ -731,9 +731,11 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
               <div>
                 Lat/Lon: {fix.latitude.toFixed(5)}, {fix.longitude.toFixed(5)}
               </div>
-              <div>{fix.isoTime.replace('T', ' ').replace('Z', '').trim()}</div>
-              <div className="text-[10px] italic text-gray-500">
-                -{formatElapsedTime(Date.now() - fix.unixTime)}
+              <div>
+                {fix.isoTime.replace('T', ' ').replace('Z', '').trim()}{' '}
+                <span className="text-[10px] italic text-gray-500">
+                  -{formatElapsedTime(Date.now() - fix.unixTime)}
+                </span>
               </div>
             </div>
           </Tooltip>

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -581,19 +581,41 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           </Circle>
         </>
       )}
-      {/* Current vehicle position — pixel-based dashed ring stays visible at all
-          zoom levels (CircleMarker radius is in screen pixels, not meters).
-          The solid fill dot sits inside the ring. When a future route exists,
-          the tooltip also notes "Position before waypoint trajectory". */}
+      {/* Current vehicle position — two separate pixel-based markers:
+          1. Small solid inner dot (no dashes, no star artifacts)
+          2. Hollow dashed outer ring for visibility when zoomed out
+          Keeping fill and dashes on separate elements avoids the star effect. */}
+      {latest && (
+        <>
+          <CircleMarker
+            center={{ lat: latest.latitude, lng: latest.longitude }}
+            radius={10}
+            color={color}
+            fillColor="transparent"
+            fillOpacity={0}
+            weight={2}
+            dashArray="4, 3"
+            interactive={false}
+          />
+          <CircleMarker
+            center={{ lat: latest.latitude, lng: latest.longitude }}
+            radius={4}
+            color={color}
+            fillColor={color}
+            fillOpacity={1}
+            weight={0}
+            interactive={false}
+          />
+        </>
+      )}
       {latest && (
         <CircleMarker
           center={{ lat: latest.latitude, lng: latest.longitude }}
-          radius={10}
-          color={color}
-          fillColor={color}
-          fillOpacity={1}
-          weight={2}
-          dashArray="4, 3"
+          radius={12}
+          color="transparent"
+          fillColor="transparent"
+          fillOpacity={0}
+          weight={0}
         >
           <Tooltip direction="right" offset={[10, 0]} opacity={0.9}>
             <div className="text-xs leading-snug">

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -553,50 +553,35 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             radius={20}
           />
         ))}
-      {/* Current vehicle position — pixel-based so both elements stay at fixed
-          screen sizes at every zoom level, preventing the star collision artifact:
-          - outer ring: 16px hollow dashed ring (always clearly outside the dot)
-          - inner dot:  4px solid fill (always clearly inside the ring)
-          The vehicle name label uses the existing permanent tooltip on the ring. */}
+      {/* Current vehicle position — single solid pixel-based dot with vehicle
+          name label. No outer ring: rings at any radius cause visual clutter
+          or star artifacts at different zoom levels. */}
       {latest && (
-        <>
-          <CircleMarker
-            data-vehicle-point={`${name}-latest`}
-            center={{ lat: latest.latitude, lng: latest.longitude }}
-            radius={16}
-            color={color}
-            fillColor={color}
-            fillOpacity={0.08}
-            weight={1.5}
-            dashArray="5, 4"
-            interactive={false}
+        <CircleMarker
+          data-vehicle-point={`${name}-latest`}
+          center={{ lat: latest.latitude, lng: latest.longitude }}
+          radius={6}
+          color={color}
+          fillColor={color}
+          fillOpacity={1}
+          weight={1}
+        >
+          <Tooltip
+            className="text-bold text-purple"
+            direction="right"
+            offset={[10, 0]}
+            opacity={0.4}
+            permanent
           >
-            <Tooltip
-              className="text-bold text-purple"
-              direction="right"
-              offset={[10, 0]}
-              opacity={0.4}
-              permanent
-            >
-              {name}
-            </Tooltip>
-          </CircleMarker>
-          <CircleMarker
-            center={{ lat: latest.latitude, lng: latest.longitude }}
-            radius={4}
-            color={color}
-            fillColor={color}
-            fillOpacity={1}
-            weight={0}
-            interactive={false}
-          />
-        </>
+            {name}
+          </Tooltip>
+        </CircleMarker>
       )}
-      {/* Tooltip hit target for current position — invisible, sits on top */}
+      {/* Invisible hit target for the hover tooltip */}
       {latest && (
         <CircleMarker
           center={{ lat: latest.latitude, lng: latest.longitude }}
-          radius={16}
+          radius={12}
           color="transparent"
           fillColor="transparent"
           fillOpacity={0}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -348,7 +348,17 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   // Show all GPS surfacing fixes so dots appear across the full deployment
   // track, not just the most recent segment. gpsFixes is already bounded by
   // the deployment window query, so the array is not unbounded.
-  const displayedFixes = gpsFixes ?? []
+  // Deduplicate by unixTime — the API occasionally returns duplicate fixes
+  // with the same timestamp, which causes React duplicate-key warnings.
+  const displayedFixes = useMemo(() => {
+    if (!gpsFixes) return []
+    const seen = new Set<number>()
+    return gpsFixes.filter((fix) => {
+      if (seen.has(fix.unixTime)) return false
+      seen.add(fix.unixTime)
+      return true
+    })
+  }, [gpsFixes])
 
   // Track-split: which fixes are in the "past" relative to dimTime
   const activePoints = useMemo(() => {
@@ -729,7 +739,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         // already marks the current location. Rendering on top causes a star artifact.
         index === 0 ? null : (
           <CircleMarker
-            key={`${name}:surfacing:${fix.unixTime}`}
+            key={`${name}:surfacing:${fix.eventId ?? fix.unixTime}`}
             center={{ lat: fix.latitude, lng: fix.longitude }}
             radius={3}
             color={color}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -345,6 +345,19 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   // indicatorTime → set from timeline bar OR map hover → drives indicator dot
   const gpsFixes = vehiclePosition?.gpsFixes ?? null
 
+  // Limit surfacing dots to the 20 most recent fixes within the last 24h,
+  // matching Dash4's limitPositions=20 / timeWindowHoursForPositions=24 defaults.
+  // gpsFixes[0] is the most recent fix, so slicing from 0 keeps the latest.
+  const SURFACING_LIMIT = 20
+  const SURFACING_WINDOW_MS = 24 * 60 * 60 * 1000
+  const displayedFixes = useMemo(() => {
+    if (!gpsFixes) return []
+    const windowStart = Date.now() - SURFACING_WINDOW_MS
+    return gpsFixes
+      .filter((fix) => fix.unixTime >= windowStart)
+      .slice(0, SURFACING_LIMIT)
+  }, [gpsFixes])
+
   // Track-split: which fixes are in the "past" relative to dimTime
   const activePoints = useMemo(() => {
     if (!dimTime || dimTime <= 0 || !gpsFixes) return null
@@ -523,7 +536,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 </>
               )}
               <div className="text-gray-500 mt-0.5">
-                Positions: {gpsFixes?.length ?? 0}
+                Positions displayed: {displayedFixes.length}
               </div>
             </div>
           </Tooltip>
@@ -703,24 +716,23 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             opacity={0.5}
           />
         ))}
-      {/* GPS surfacing dots — small visual markers at every recorded GPS fix.
-          These show where the vehicle surfaced throughout the deployment.
-          interactive=false so HitCircles (below) keep hover/scrub control. */}
-      {gpsFixes &&
-        gpsFixes.map((fix, index) => (
-          <CircleMarker
-            key={`${name}:surfacing:${fix.unixTime}`}
-            center={{ lat: fix.latitude, lng: fix.longitude }}
-            radius={index === 0 ? 5 : 2}
-            interactive={false}
-            pathOptions={{
-              color,
-              fillColor: color,
-              fillOpacity: index === 0 ? 1 : 0.65,
-              weight: 1,
-            }}
-          />
-        ))}
+      {/* GPS surfacing dots — 20 most recent fixes within last 24h, matching
+          Dash4's limitPositions/timeWindowHoursForPositions defaults.
+          interactive=false so HitCircles keep hover/scrub control. */}
+      {displayedFixes.map((fix, index) => (
+        <CircleMarker
+          key={`${name}:surfacing:${fix.unixTime}`}
+          center={{ lat: fix.latitude, lng: fix.longitude }}
+          radius={index === 0 ? 5 : 2}
+          interactive={false}
+          pathOptions={{
+            color,
+            fillColor: color,
+            fillOpacity: index === 0 ? 1 : 0.65,
+            weight: 1,
+          }}
+        />
+      ))}
 
       {/* Memoized hit targets — isolated from VehiclePath re-renders to
           prevent spurious mouseout/mouseover events causing tooltip flicker. */}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -581,17 +581,19 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
           </Circle>
         </>
       )}
-      {/* Solid dot at the latest GPS fix — always visible, tooltip on hover only.
-          When a future route exists, also shows "Position before waypoint trajectory"
-          so both pieces of info come from a single tooltip with no overlap. */}
+      {/* Current vehicle position — pixel-based dashed ring stays visible at all
+          zoom levels (CircleMarker radius is in screen pixels, not meters).
+          The solid fill dot sits inside the ring. When a future route exists,
+          the tooltip also notes "Position before waypoint trajectory". */}
       {latest && (
-        <Circle
-          pathOptions={{ color }}
+        <CircleMarker
           center={{ lat: latest.latitude, lng: latest.longitude }}
+          radius={10}
+          color={color}
           fillColor={color}
           fillOpacity={1}
-          color={color}
-          radius={60}
+          weight={2}
+          dashArray="4, 3"
         >
           <Tooltip direction="right" offset={[10, 0]} opacity={0.9}>
             <div className="text-xs leading-snug">
@@ -626,7 +628,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
               </div>
             </div>
           </Tooltip>
-        </Circle>
+        </CircleMarker>
       )}
       {/* Scrub indicator dot — shown for any scrub source (depth chart, timeline)
           unless the map-hover highlight is already visible at that position */}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -5,7 +5,7 @@ import {
   VPosDetail,
   useWaypointsInfo,
 } from '@mbari/api-client'
-import { Polyline, useMap, Circle, Tooltip } from 'react-leaflet'
+import { Polyline, useMap, Circle, CircleMarker, Tooltip } from 'react-leaflet'
 import { LatLng, LeafletMouseEventHandlerFn } from 'leaflet'
 import { useRouter } from 'next/router'
 import { distance, nearestPointOnLine, lineString } from '@turf/turf'
@@ -501,7 +501,31 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
               setLineStyle({ color, weight: 3 })
             },
           }}
-        />
+        >
+          {/* Sticky tooltip on the track line — follows cursor, shows summary */}
+          <Tooltip sticky opacity={0.88}>
+            <div className="text-xs leading-snug min-w-[170px]">
+              <div className="font-bold" style={{ color }}>
+                {name}
+              </div>
+              {latest && (
+                <>
+                  <div className="mt-0.5">
+                    Latest position: {latest.latitude.toFixed(5)},{' '}
+                    {latest.longitude.toFixed(5)}
+                  </div>
+                  <div>
+                    {latest.isoTime.replace('T', ' ').replace('Z', ' UTC')}
+                    {timeSinceFixDisplay ? ` — ${timeSinceFixDisplay}` : ''}
+                  </div>
+                </>
+              )}
+              <div className="text-gray-500 mt-0.5">
+                Positions displayed: {gpsFixes?.length ?? 0}
+              </div>
+            </div>
+          </Tooltip>
+        </Polyline>
       )}
       {/* dashed future waypoint trajectory */}
       {futureRoute && (
@@ -677,6 +701,25 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             opacity={0.5}
           />
         ))}
+      {/* GPS surfacing dots — small visual markers at every recorded GPS fix.
+          These show where the vehicle surfaced throughout the deployment.
+          interactive=false so HitCircles (below) keep hover/scrub control. */}
+      {gpsFixes &&
+        gpsFixes.map((fix, index) => (
+          <CircleMarker
+            key={`${name}:surfacing:${fix.unixTime}`}
+            center={{ lat: fix.latitude, lng: fix.longitude }}
+            radius={index === 0 ? 5 : 2}
+            interactive={false}
+            pathOptions={{
+              color,
+              fillColor: color,
+              fillOpacity: index === 0 ? 1 : 0.65,
+              weight: 1,
+            }}
+          />
+        ))}
+
       {/* Memoized hit targets — isolated from VehiclePath re-renders to
           prevent spurious mouseout/mouseover events causing tooltip flicker. */}
       <HitCircles
@@ -687,6 +730,34 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         onCoord={handleCoord}
         onMouseOut={handleMouseOut}
       />
+
+      {/* "Position before waypoint trajectory" — interactive marker rendered
+          on top of hit circles so its tooltip is reachable on hover */}
+      {futureRoute && latest && (
+        <CircleMarker
+          center={{ lat: latest.latitude, lng: latest.longitude }}
+          radius={5}
+          pathOptions={{
+            color,
+            fillColor: color,
+            fillOpacity: 0.5,
+            weight: 2,
+          }}
+        >
+          <Tooltip direction="right" offset={[6, 0]} opacity={0.9}>
+            <div className="text-xs leading-snug">
+              <div className="font-bold" style={{ color }}>
+                {name}
+              </div>
+              <div>Position before waypoint trajectory</div>
+              <div>
+                Lat/Lon: {latest.latitude.toFixed(5)},{' '}
+                {latest.longitude.toFixed(5)}
+              </div>
+            </div>
+          </Tooltip>
+        </CircleMarker>
+      )}
     </>
   ) : null
 }

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -50,12 +50,15 @@ const VehiclePoint: React.FC<{
 // Memoized hit-circle layer so it never re-renders when VehiclePath state
 // (mapHoverFix, indicatorTime, etc.) changes — prevents React-Leaflet from
 // re-mounting the circles and emitting spurious mouseout/mouseover events.
+// Also carries the sticky summary tooltip so it appears even when the cursor
+// is over a hit circle (which intercepts pointer events before the Polyline).
 const HitCircles = React.memo(
   ({
     name,
     grouped,
     route,
     color,
+    positionCount,
     onCoord,
     onMouseOut,
   }: {
@@ -63,6 +66,7 @@ const HitCircles = React.memo(
     grouped?: boolean
     route: [number, number][]
     color: string
+    positionCount: number
     onCoord: LeafletMouseEventHandlerFn
     onMouseOut: LeafletMouseEventHandlerFn
   }) => (
@@ -79,7 +83,27 @@ const HitCircles = React.memo(
           color={color}
           opacity={0}
           eventHandlers={{ mouseover: onCoord, mouseout: onMouseOut }}
-        />
+        >
+          <Tooltip sticky opacity={0.88}>
+            <div className="text-xs leading-snug">
+              <div className="flex items-center gap-1 font-bold text-black">
+                <span
+                  style={{
+                    background: color,
+                    border: '1.5px solid rgba(0,0,0,0.4)',
+                    borderRadius: '50%',
+                    width: 8,
+                    height: 8,
+                    display: 'inline-block',
+                    flexShrink: 0,
+                  }}
+                />
+                {name}
+              </div>
+              <div>Positions: {positionCount}</div>
+            </div>
+          </Tooltip>
+        </Circle>
       ))}
     </>
   )
@@ -516,28 +540,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
               setLineStyle({ color, weight: 3 })
             },
           }}
-        >
-          {/* Sticky tooltip on the track line — vehicle name + position count */}
-          <Tooltip sticky opacity={0.88}>
-            <div className="text-xs leading-snug">
-              <div className="flex items-center gap-1 font-bold text-black">
-                <span
-                  style={{
-                    background: color,
-                    border: '1.5px solid rgba(0,0,0,0.4)',
-                    borderRadius: '50%',
-                    width: 8,
-                    height: 8,
-                    display: 'inline-block',
-                    flexShrink: 0,
-                  }}
-                />
-                {name}
-              </div>
-              <div>Positions: {displayedFixes.length}</div>
-            </div>
-          </Tooltip>
-        </Polyline>
+        />
       )}
       {/* dashed future waypoint trajectory */}
       {futureRoute && (
@@ -667,7 +670,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 {latest.longitude.toFixed(5)}
               </div>
               <div>
-                {latest.isoTime.replace('T', ' ').replace('Z', '').trim()}{' '}
+                {latestTimeFix?.replace('T', ' ').replace('Z', '').trim()}{' '}
                 <span className="text-[10px] italic text-gray-500">
                   -{formatElapsedTime(Date.now() - latest.unixTime)}
                 </span>
@@ -781,6 +784,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
         grouped={grouped}
         route={route}
         color={color}
+        positionCount={activePoints?.length ?? displayedFixes.length}
         onCoord={handleCoord}
         onMouseOut={handleMouseOut}
       />

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -610,7 +610,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
                 </div>
               )}
               <div className="mt-0.5">
-                Lat/Lon: {latest.latitude.toFixed(5)},{' '}
+                Latest position: {latest.latitude.toFixed(5)},{' '}
                 {latest.longitude.toFixed(5)}
               </div>
               <div>

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -345,15 +345,10 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
   // indicatorTime → set from timeline bar OR map hover → drives indicator dot
   const gpsFixes = vehiclePosition?.gpsFixes ?? null
 
-  // Show the 20 most recent GPS surfacing fixes regardless of age so dots
-  // are distributed across the full visible track. Dash4 additionally filters
-  // to a 24h window, but that hides dots on older portions of longer deployments
-  // creating a confusing "dots only on the recent segment" effect.
-  const SURFACING_LIMIT = 20
-  const displayedFixes = useMemo(
-    () => (gpsFixes ? gpsFixes.slice(0, SURFACING_LIMIT) : []),
-    [gpsFixes]
-  )
+  // Show all GPS surfacing fixes so dots appear across the full deployment
+  // track, not just the most recent segment. gpsFixes is already bounded by
+  // the deployment window query, so the array is not unbounded.
+  const displayedFixes = gpsFixes ?? []
 
   // Track-split: which fixes are in the "past" relative to dimTime
   const activePoints = useMemo(() => {


### PR DESCRIPTION
Closes #744. Aligns Dash5's map track display with Dash4 by adding GPS surfacing markers, a track hover tooltip, and a pre-waypoint position indicator.

## Changes

**GPS surfacing dots**
- Render a non-interactive `CircleMarker` (radius 2px, matching Dash4) at every GPS fix along the full deployment track so surfacing history is visible at all zoom levels
- Skip the index-0 fix (current position has its own dedicated marker)
- Deduplicate fixes by `unixTime` to prevent React duplicate-key warnings
- Historical dots rendered before the current position marker so the latest always appears on top

**Current vehicle position marker**
- Replaced the meter-based `Circle` with a pixel-based `CircleMarker` (radius 6px, solid fill, white border ring, matching Dash4)
- Stays a consistent, visible size at every zoom level

**Track hover tooltip (mapHoverFix)**
- When the cursor enters a HitCircle (200 m invisible hit target at each GPS fix), the nearest fix is highlighted with a tooltip showing vehicle name, lat/lon, UTC date/time, elapsed time, and `Positions: N`
- A single tooltip fires per hover — no cursor-following sticky Polyline tooltip is used because HitCircles intercept pointer events before the Polyline and a Polyline sticky tooltip would cause overlapping tooltips (per user feedback)
- `Positions: N` is derived from the deduplicated `displayedFixes` (not raw `gpsFixes`) so duplicate unixTime entries are never over-counted; when `dimTime` is active the count reflects only the rendered past-segment fixes

**Latest position tooltip**
- An invisible `CircleMarker` (radius 12px) rendered after `HitCircles` (on top in z-order) shows a hover tooltip with vehicle name, optional "Position before waypoint trajectory" label, lat/lon, UTC date/time, and elapsed time
- Label reads "Lat/Lon:" when pre-waypoint text is present, "Latest position:" otherwise

**Noise reduction**
- `[PlatformPath] No positions found` debug log removed (expected behavior)
- `[PlatformPath] Failed to load positions` — only genuine timeout errors are downgraded to `debug`; auth/config/5xx errors retain `warn` level

## Test plan
- [ ] Hover GPS fix dots along the track → single tooltip with vehicle name, lat/lon, UTC time, elapsed, and positions count
- [ ] Hover current position → "Latest position:" tooltip; shows "Position before waypoint trajectory" when future route exists
- [ ] Zoom in/out — current position dot stays consistent size (radius 6px), no star artifact
- [ ] Timeline scrub active (dimTime) — "Positions: N" reflects only rendered past-segment fixes
- [ ] Multiple vehicles — each tooltip shows correct colored dot + black name
- [ ] Console clean: no duplicate-key warnings, no PlatformPath noise for timeouts