### PR TITLE
fix: prevent map coordinates from clobbering Ctrl+C in text contexts

### DIFF
--- a/packages/react-ui/src/Map/MouseCoordinates.test.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.test.tsx
@@ -1,0 +1,126 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { render, act } from '@testing-library/react'
+
+// --- react-leaflet mocks ---
+let capturedMousemoveHandler: ((e: { latlng: L.LatLng }) => void) | null = null
+
+jest.mock('react-leaflet', () => ({
+  useMapEvents: (handlers: { mousemove?: (e: unknown) => void }) => {
+    capturedMousemoveHandler = handlers.mousemove ?? null
+    return null
+  },
+}))
+
+jest.mock('leaflet/dist/leaflet.css', () => {})
+
+// --- @mbari/utils mock ---
+jest.mock('@mbari/utils', () => ({
+  useDebouncedEffect: (fn: () => void) => fn(),
+}))
+
+// --- helpers ---
+const mockLatLng = (lat: number, lng: number) =>
+  ({ lat, lng } as unknown as L.LatLng)
+
+const simulateMousemove = (lat: number, lng: number) => {
+  act(() => {
+    capturedMousemoveHandler?.({ latlng: mockLatLng(lat, lng) })
+  })
+}
+
+const fireCtrlC = () => {
+  act(() => {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'c', ctrlKey: true, bubbles: true })
+    )
+  })
+}
+
+// --- clipboard mock ---
+const mockWriteText = jest.fn().mockResolvedValue(undefined)
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: mockWriteText },
+  writable: true,
+})
+
+import MouseCoordinates, { isInTextContext } from './MouseCoordinates'
+
+describe('MouseCoordinates — Ctrl+C clipboard guard (fix #751)', () => {
+  beforeEach(() => {
+    mockWriteText.mockClear()
+    capturedMousemoveHandler = null
+    // Reset activeElement to body and selection to empty
+    jest.spyOn(window, 'getSelection').mockReturnValue({
+      toString: () => '',
+    } as unknown as Selection)
+    Object.defineProperty(document, 'activeElement', {
+      value: document.body,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('copies coordinates to clipboard when mouse is over map and no text context is active', () => {
+    render(<MouseCoordinates />)
+    simulateMousemove(36.80353, -121.77897)
+    fireCtrlC()
+    expect(mockWriteText).toHaveBeenCalledWith('36.80353, -121.77897')
+  })
+
+  it('does NOT copy coordinates when the user has text selected (window.getSelection guard)', () => {
+    jest.spyOn(window, 'getSelection').mockReturnValue({
+      toString: () => 'EnableBackseat',
+    } as unknown as Selection)
+    render(<MouseCoordinates />)
+    simulateMousemove(36.80353, -121.77897)
+    fireCtrlC()
+    expect(mockWriteText).not.toHaveBeenCalled()
+  })
+
+  // --- isInTextContext unit tests (element-type guards) ---
+  // jsdom doesn't propagate .focus() to document.activeElement reliably, so
+  // we test the extracted guard function directly with real DOM elements.
+
+  it('isInTextContext: returns true for a contenteditable element', () => {
+    const el = document.createElement('div')
+    // jsdom does not implement isContentEditable, so we define it on the instance
+    // to simulate what a real browser returns for a contenteditable div.
+    Object.defineProperty(el, 'isContentEditable', { get: () => true })
+    expect(isInTextContext(el, '')).toBe(true)
+  })
+
+  it('isInTextContext: returns true for an <input> element', () => {
+    const el = document.createElement('input')
+    expect(isInTextContext(el, '')).toBe(true)
+  })
+
+  it('isInTextContext: returns true for a <textarea> element', () => {
+    const el = document.createElement('textarea')
+    expect(isInTextContext(el, '')).toBe(true)
+  })
+
+  it('isInTextContext: returns true when selection string is non-empty', () => {
+    expect(isInTextContext(document.body, 'EnableBackseat')).toBe(true)
+  })
+
+  it('isInTextContext: returns false for a plain div with no selection', () => {
+    const el = document.createElement('div')
+    expect(isInTextContext(el, '')).toBe(false)
+  })
+
+  it('isInTextContext: returns false for null activeElement with no selection', () => {
+    expect(isInTextContext(null, '')).toBe(false)
+  })
+
+  it('does NOT copy when no mouse coordinates have been recorded yet', () => {
+    render(<MouseCoordinates />)
+    // no simulateMousemove — formattedCoordinates is empty
+    fireCtrlC()
+    expect(mockWriteText).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react-ui/src/Map/MouseCoordinates.test.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.test.tsx
@@ -47,11 +47,14 @@ Object.defineProperty(navigator, 'clipboard', {
 import MouseCoordinates, { isInTextContext } from './MouseCoordinates'
 
 describe('MouseCoordinates — Ctrl+C clipboard guard (fix #751)', () => {
+  // Shared spy — created once per test in beforeEach and reused within tests
+  // to avoid double-spying errors (jest throws if you spy on an already-spied method).
+  let getSelectionSpy: jest.SpyInstance
+
   beforeEach(() => {
     mockWriteText.mockClear()
     capturedMousemoveHandler = null
-    // Reset activeElement to body and selection to empty
-    jest.spyOn(window, 'getSelection').mockReturnValue({
+    getSelectionSpy = jest.spyOn(window, 'getSelection').mockReturnValue({
       toString: () => '',
     } as unknown as Selection)
     Object.defineProperty(document, 'activeElement', {
@@ -73,7 +76,7 @@ describe('MouseCoordinates — Ctrl+C clipboard guard (fix #751)', () => {
   })
 
   it('does NOT copy coordinates when the user has text selected (window.getSelection guard)', () => {
-    jest.spyOn(window, 'getSelection').mockReturnValue({
+    getSelectionSpy.mockReturnValue({
       toString: () => 'EnableBackseat',
     } as unknown as Selection)
     render(<MouseCoordinates />)

--- a/packages/react-ui/src/Map/MouseCoordinates.tsx
+++ b/packages/react-ui/src/Map/MouseCoordinates.tsx
@@ -30,6 +30,19 @@ export interface MouseCoordinatesProps {
   onRequestDepth?: (lat: number, lng: number) => Promise<number | null>
 }
 
+/** Returns true when the user is in a text-editing context (input, textarea,
+ *  contenteditable, or has an active text selection). Used to prevent the map
+ *  Ctrl+C shortcut from clobbering clipboard content from the doc editor or
+ *  other text fields. Exported for unit testing. */
+export const isInTextContext = (
+  active: Element | null,
+  selection: string
+): boolean =>
+  active instanceof HTMLInputElement ||
+  active instanceof HTMLTextAreaElement ||
+  (active instanceof HTMLElement && active.isContentEditable) ||
+  selection.length > 0
+
 const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
   onRequestDepth,
 }) => {
@@ -96,7 +109,11 @@ const MouseCoordinates: React.FC<MouseCoordinatesProps> = ({
           event.key === 'c' &&
           event.ctrlKey &&
           formattedCoordinates.length > 0 &&
-          navigator.clipboard
+          navigator.clipboard &&
+          !isInTextContext(
+            document.activeElement,
+            window.getSelection()?.toString() ?? ''
+          )
         ) {
           navigator.clipboard?.writeText(formattedCoordinates)
         }


### PR DESCRIPTION
## Summary

- Adds an `isInTextContext` guard to the `MouseCoordinates` global `keydown` handler so it skips writing to the clipboard when the user has text selected or is focused inside an `<input>`, `<textarea>`, or `contenteditable` element
- Extracts the guard into an exported `isInTextContext` helper for testability
- Adds 9 new unit tests covering all guard branches

## Background

Monique reported that Ctrl+C anywhere inside a Dash5 deployment doc (including field values like `EnableBackseat`) would paste map coordinates instead of the copied text. The root cause was a global `document.addEventListener('keydown')` in `MouseCoordinates.tsx` that unconditionally called `navigator.clipboard.writeText(coordinates)` on every Ctrl+C — silently overwriting whatever the browser had just natively copied.

## Test plan

- [ ] Ctrl+C on selected text in the doc editor pastes the selected text, not coordinates
- [ ] Ctrl+C on a form field value pastes the field text, not coordinates
- [ ] Ctrl+C over the map with no text selected still copies coordinates as expected
- [ ] All 9 unit tests pass: `yarn workspace @mbari/react-ui test --testPathPattern="MouseCoordinates"`

Closes #751