### PR TITLE
feat: add Watchbill link to profile dropdown menu

### DIFF
--- a/apps/lrauv-dash2/components/Layout.tsx
+++ b/apps/lrauv-dash2/components/Layout.tsx
@@ -141,6 +141,17 @@ const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
                   onDismiss={dismissDropdown}
                   options={[
                     {
+                      label: 'Watchbill',
+                      onSelect: () => {
+                        window.open(
+                          'https://docs.google.com/spreadsheets/d/1kOTNsOcUKWlfK1YHQAq38arX9HLQINzlpuR-vL6bCrE/edit?gid=0#gid=0',
+                          '_blank',
+                          'noopener,noreferrer'
+                        )
+                        dismissDropdown()
+                      },
+                    },
+                    {
                       label: 'Notifications',
                       onSelect: () => {
                         setGlobalModalId({ id: 'emailNotifications' })

--- a/apps/lrauv-dash2/components/Layout.tsx
+++ b/apps/lrauv-dash2/components/Layout.tsx
@@ -34,6 +34,7 @@ import { useCookies } from 'react-cookie'
 import EmailNotificationsModal from './EmailNotificationsModal'
 import ScheduleEventDetailsModal from './ScheduleEventDetailsModal'
 import ServerHealthModal from './ServerHealthModal'
+import { WATCHBILL_URL } from '../lib/constants'
 
 const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
   const [showLogin, setLogin] = useState(false)
@@ -144,7 +145,7 @@ const Layout: React.FC<{ children?: React.ReactNode }> = ({ children }) => {
                       label: 'Watchbill',
                       onSelect: () => {
                         window.open(
-                          'https://docs.google.com/spreadsheets/d/1kOTNsOcUKWlfK1YHQAq38arX9HLQINzlpuR-vL6bCrE/edit?gid=0#gid=0',
+                          WATCHBILL_URL,
                           '_blank',
                           'noopener,noreferrer'
                         )

--- a/apps/lrauv-dash2/components/LrauvResourcesDropdown.tsx
+++ b/apps/lrauv-dash2/components/LrauvResourcesDropdown.tsx
@@ -7,6 +7,7 @@ import {
   faCalendar,
 } from '@fortawesome/free-regular-svg-icons'
 import { faLink } from '@fortawesome/free-solid-svg-icons'
+import { WATCHBILL_URL } from '../lib/constants'
 
 interface LrauvResourcesDropdownProps {
   isAdmin?: boolean
@@ -15,7 +16,7 @@ interface LrauvResourcesDropdownProps {
 const picLinks = [
   {
     label: 'Watchbill',
-    url: 'https://docs.google.com/spreadsheets/d/1kOTNsOcUKWlfK1YHQAq38arX9HLQINzlpuR-vL6bCrE/edit?gid=0#gid=0',
+    url: WATCHBILL_URL,
     tooltip: 'Sign up to pilot an LRAUV!\n(earn a team LRAUV hat)',
     icon: faFileExcel,
   },

--- a/apps/lrauv-dash2/lib/constants.ts
+++ b/apps/lrauv-dash2/lib/constants.ts
@@ -1,2 +1,7 @@
 /** Base URL for the ODSS API, used to resolve relative platform icon paths. */
 export const ODSS_BASE_URL = 'https://odss.mbari.org/odss'
+
+/** LRAUV Watchbill signup spreadsheet — single source of truth for the URL
+ *  so the profile dropdown and resources dropdown stay in sync. */
+export const WATCHBILL_URL =
+  'https://docs.google.com/spreadsheets/d/1kOTNsOcUKWlfK1YHQAq38arX9HLQINzlpuR-vL6bCrE/edit?gid=0#gid=0'


### PR DESCRIPTION
## Summary

Adds a **Watchbill** entry to the avatar/profile dropdown in the top nav so users can reach the LRAUV Watchbill signup without having to navigate into a specific vehicle page first.

- Opens the same Google Sheets Watchbill URL already present in the folder (`ResourcesDropdown`) — no new URL introduced
- Opens in a new tab (`noopener,noreferrer`)
- Positioned at the top of the dropdown, above Notifications and Logout

## Motivation

Christina Preston reported that finding the watch bill required clicking into a specific vehicle first. This makes it a one-click action from anywhere in the app.

Closes #753

## Test plan

- [ ] Click avatar → dropdown shows **Watchbill** as the first item
- [ ] Clicking Watchbill opens the Google Sheets signup in a new tab and closes the dropdown
- [ ] Notifications, Server Status (operator/admin), and Logout still work as before