### PR TITLE
feat: make ship current-position marker more prominent on map

### DIFF
--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -163,14 +163,16 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
 
   return (
     <>
-      {/* Custom icon at latest position, shown for fixed/infrequently-updated platforms */}
+      {/* Custom icon at latest position, shown for fixed/infrequently-updated platforms.
+          Tooltip is permanent so the name label is always visible, matching the
+          behaviour of the prominent CircleMarker used for no-icon platforms. */}
       {platformIcon && route.length > 0 && (
         <Marker position={[route[0][0], route[0][1]]} icon={platformIcon}>
-          <Tooltip opacity={0.9}>
+          <Tooltip permanent opacity={0.75}>
             <div className="text-italic">
-              <div className="text-bold">{displayName}</div>
+              <span className="text-bold">{displayName}</span>
               {displayAbbrev && (
-                <div className="text-gray-500">({displayAbbrev})</div>
+                <span className="text-gray-500"> ({displayAbbrev})</span>
               )}
             </div>
           </Tooltip>

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -42,6 +42,7 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
 }) => {
   const [hovered, setHovered] = useState(false)
   const [currentPosHovered, setCurrentPosHovered] = useState(false)
+  const [iconHovered, setIconHovered] = useState(false)
   // Track icon load failure so we can show the fallback CircleMarker when
   // the ODSS image is blocked or unavailable. Reset whenever iconUrl changes
   // so a new valid URL gets a fresh attempt.
@@ -165,15 +166,35 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
   return (
     <>
       {/* Custom icon at latest position, shown for fixed/infrequently-updated platforms.
-          Tooltip is permanent so the name label is always visible, matching the
-          behaviour of the prominent CircleMarker used for no-icon platforms. */}
+          Permanent name label always visible; coords + timestamp appear on hover,
+          matching the CircleMarker behaviour for no-icon platforms. */}
       {platformIcon && route.length > 0 && (
-        <Marker position={[route[0][0], route[0][1]]} icon={platformIcon}>
+        <Marker
+          position={[route[0][0], route[0][1]]}
+          icon={platformIcon}
+          eventHandlers={{
+            mouseover: () => setIconHovered(true),
+            mouseout: () => setIconHovered(false),
+          }}
+        >
           <Tooltip permanent opacity={0.75}>
             <div className="text-italic">
               <span className="text-bold">{displayName}</span>
               {displayAbbrev && (
                 <span className="text-gray-500"> ({displayAbbrev})</span>
+              )}
+              {iconHovered && (
+                <>
+                  <br />
+                  <span className="text-xs text-gray-400">
+                    {route[0][0].toFixed(5)}, {route[0][1].toFixed(5)}
+                  </span>
+                  {displayPositions[0] && (
+                    <div className="text-xs text-gray-400">
+                      {new Date(displayPositions[0].timeMs).toLocaleString()}
+                    </div>
+                  )}
+                </>
               )}
             </div>
           </Tooltip>

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -63,9 +63,13 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
 
   const [hovered, setHovered] = useState(false)
   // Track icon load failure so we can show the fallback CircleMarker when
-  // the ODSS image is blocked or unavailable (Copilot review suggestion).
+  // the ODSS image is blocked or unavailable. Reset whenever iconUrl changes
+  // so a new valid URL gets a fresh attempt.
   const [iconFailed, setIconFailed] = useState(false)
   const handleIconError = useCallback(() => setIconFailed(true), [])
+  useEffect(() => {
+    setIconFailed(false)
+  }, [iconUrl])
 
   const nowMs = useTick(refreshIntervalMs)
 
@@ -128,7 +132,7 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
   // - the icon object is memoized to avoid unnecessary Leaflet icon churn
   // Must be declared before any early returns to satisfy Rules of Hooks.
   const platformIcon = useMemo(() => {
-    if (!iconUrl) return null
+    if (!iconUrl || iconFailed) return null
 
     const container = document.createElement('div')
     container.style.cssText = 'width:44px;height:44px;overflow:hidden;'
@@ -151,7 +155,7 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
       iconAnchor: [22, 22],
       tooltipAnchor: [22, 0],
     })
-  }, [iconUrl, displayName])
+  }, [iconUrl, iconFailed, displayName, handleIconError])
 
   if (isLoading) {
     return null

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect, useCallback } from 'react'
+import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react'
 import { Marker, Polyline, Tooltip, CircleMarker, useMap } from 'react-leaflet'
 import L from 'leaflet'
 import { usePlatformPositions } from '@mbari/api-client'
@@ -47,15 +47,19 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
 }) => {
   const map = useMap()
 
-  // Create the platforms pane once so ship elements receive pointer events
-  // before the vehicle hit-circle layer (overlayPane, z-index 400).
-  useEffect(() => {
+  // Create the platforms pane synchronously (before JSX returns) so that the
+  // pane exists by the time react-leaflet mounts Polyline/CircleMarker into it.
+  // useEffect is too late — Leaflet crashes with "Cannot read appendChild of
+  // undefined" if the pane doesn't exist when the layer first mounts.
+  const paneInitializedRef = useRef(false)
+  if (!paneInitializedRef.current) {
     if (!map.getPane(PLATFORM_PANE)) {
       map.createPane(PLATFORM_PANE)
       const pane = map.getPane(PLATFORM_PANE)
       if (pane) pane.style.zIndex = String(PLATFORM_PANE_Z)
     }
-  }, [map])
+    paneInitializedRef.current = true
+  }
 
   const [hovered, setHovered] = useState(false)
   // Track icon load failure so we can show the fallback CircleMarker when

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from 'react'
+import React, { useMemo, useState, useEffect, useCallback } from 'react'
 import { Marker, Polyline, Tooltip, CircleMarker, useMap } from 'react-leaflet'
 import L from 'leaflet'
 import { usePlatformPositions } from '@mbari/api-client'
@@ -58,6 +58,10 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
   }, [map])
 
   const [hovered, setHovered] = useState(false)
+  // Track icon load failure so we can show the fallback CircleMarker when
+  // the ODSS image is blocked or unavailable (Copilot review suggestion).
+  const [iconFailed, setIconFailed] = useState(false)
+  const handleIconError = useCallback(() => setIconFailed(true), [])
 
   const nowMs = useTick(refreshIntervalMs)
 
@@ -132,6 +136,7 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
       'width:44px;height:44px;object-fit:contain;border:none;background:transparent;'
     img.onerror = () => {
       img.style.display = 'none'
+      handleIconError()
     }
     container.appendChild(img)
 
@@ -216,8 +221,9 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
 
           {/* Prominent current-position marker — solid filled circle with white
               outline so it reads clearly against both the track line and the
-              basemap. Single permanent tooltip carries name + position details. */}
-          {!platformIcon && (
+              basemap. Also shown as fallback when the custom icon image fails
+              to load (e.g. ODSS blocks the request). */}
+          {(!platformIcon || iconFailed) && (
             <CircleMarker
               center={[route[0][0], route[0][1]]}
               pane={PLATFORM_PANE}

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -197,7 +197,7 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
 
           {/* Prominent current-position marker — solid filled circle with white
               outline so it reads clearly against both the track line and the
-              basemap. Carries the permanent name label and the hover tooltip. */}
+              basemap. Single permanent tooltip carries name + position details. */}
           {!platformIcon && (
             <CircleMarker
               center={[route[0][0], route[0][1]]}
@@ -215,23 +215,16 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
                   {displayAbbrev ? (
                     <span className="text-gray-500"> ({displayAbbrev})</span>
                   ) : null}
-                </div>
-              </Tooltip>
-              <Tooltip opacity={0.9}>
-                <div className="text-italic">
-                  <div className="text-bold">{displayName}</div>
-                  {displayAbbrev && (
-                    <div className="text-gray-500">({displayAbbrev})</div>
+                  <br />
+                  <span className="text-xs text-gray-400">
+                    {route[0][0].toFixed(5)}, {route[0][1].toFixed(5)}
+                  </span>
+                  {displayPositions[0] && (
+                    <div className="text-xs text-gray-400">
+                      {new Date(displayPositions[0].timeMs).toLocaleString()}
+                    </div>
                   )}
                 </div>
-                <span>Latest position:</span> {route[0][0].toFixed(5)},{' '}
-                {route[0][1].toFixed(5)}
-                <br />
-                {displayPositions[0] && (
-                  <div className="text-sm text-gray-400">
-                    {new Date(displayPositions[0].timeMs).toLocaleString()}
-                  </div>
-                )}
               </Tooltip>
             </CircleMarker>
           )}

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react'
-import { Marker, Polyline, Tooltip, CircleMarker, useMap } from 'react-leaflet'
+import React, { useMemo, useState, useEffect, useCallback } from 'react'
+import { Marker, Polyline, Tooltip, CircleMarker, Pane } from 'react-leaflet'
 import L from 'leaflet'
 import { usePlatformPositions } from '@mbari/api-client'
 import { createLogger } from '@mbari/utils'
@@ -8,6 +8,8 @@ import { useTick } from '../lib/useTick'
 // Dedicated Leaflet pane for ship/platform tracks — sits above the vehicle
 // hit-circle layer (overlayPane z-index 400) so ship elements always win
 // pointer-event priority when a ship track overlaps a vehicle surfacing fix.
+// Declared as a <Pane /> component (declarative) rather than map.createPane()
+// (imperative side-effect in render) to follow react-leaflet best practice.
 const PLATFORM_PANE = 'platformsPane'
 const PLATFORM_PANE_Z = 450
 
@@ -45,22 +47,6 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
   limitPositions = 20,
   refreshIntervalMs = 5 * 60_000,
 }) => {
-  const map = useMap()
-
-  // Create the platforms pane synchronously (before JSX returns) so that the
-  // pane exists by the time react-leaflet mounts Polyline/CircleMarker into it.
-  // useEffect is too late — Leaflet crashes with "Cannot read appendChild of
-  // undefined" if the pane doesn't exist when the layer first mounts.
-  const paneInitializedRef = useRef(false)
-  if (!paneInitializedRef.current) {
-    if (!map.getPane(PLATFORM_PANE)) {
-      map.createPane(PLATFORM_PANE)
-      const pane = map.getPane(PLATFORM_PANE)
-      if (pane) pane.style.zIndex = String(PLATFORM_PANE_Z)
-    }
-    paneInitializedRef.current = true
-  }
-
   const [hovered, setHovered] = useState(false)
   // Track icon load failure so we can show the fallback CircleMarker when
   // the ODSS image is blocked or unavailable. Reset whenever iconUrl changes
@@ -184,6 +170,9 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
 
   return (
     <>
+      {/* Declare the platforms pane declaratively so react-leaflet owns the
+          lifecycle — avoids imperative map.createPane() side-effects in render. */}
+      <Pane name={PLATFORM_PANE} style={{ zIndex: PLATFORM_PANE_Z }} />
       {/* Custom icon at latest position, shown for fixed/infrequently-updated platforms */}
       {platformIcon && route.length > 0 && (
         <Marker position={[route[0][0], route[0][1]]} icon={platformIcon}>
@@ -231,7 +220,8 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
               outline so it reads clearly against both the track line and the
               basemap. Also shown as fallback when the custom icon image fails
               to load (e.g. ODSS blocks the request). */}
-          {(!platformIcon || iconFailed) && (
+          {/* platformIcon is already null when iconFailed — !platformIcon covers both cases */}
+          {!platformIcon && (
             <CircleMarker
               center={[route[0][0], route[0][1]]}
               pane={PLATFORM_PANE}

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -1,9 +1,15 @@
-import React, { useMemo, useState } from 'react'
-import { Marker, Polyline, Tooltip, CircleMarker } from 'react-leaflet'
+import React, { useMemo, useState, useEffect } from 'react'
+import { Marker, Polyline, Tooltip, CircleMarker, useMap } from 'react-leaflet'
 import L from 'leaflet'
 import { usePlatformPositions } from '@mbari/api-client'
 import { createLogger } from '@mbari/utils'
 import { useTick } from '../lib/useTick'
+
+// Dedicated Leaflet pane for ship/platform tracks — sits above the vehicle
+// hit-circle layer (overlayPane z-index 400) so ship elements always win
+// pointer-event priority when a ship track overlaps a vehicle surfacing fix.
+const PLATFORM_PANE = 'platformsPane'
+const PLATFORM_PANE_Z = 450
 
 const logger = createLogger('PlatformPath')
 
@@ -39,6 +45,18 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
   limitPositions = 20,
   refreshIntervalMs = 5 * 60_000,
 }) => {
+  const map = useMap()
+
+  // Create the platforms pane once so ship elements receive pointer events
+  // before the vehicle hit-circle layer (overlayPane, z-index 400).
+  useEffect(() => {
+    if (!map.getPane(PLATFORM_PANE)) {
+      map.createPane(PLATFORM_PANE)
+      const pane = map.getPane(PLATFORM_PANE)
+      if (pane) pane.style.zIndex = String(PLATFORM_PANE_Z)
+    }
+  }, [map])
+
   const [hovered, setHovered] = useState(false)
 
   const nowMs = useTick(refreshIntervalMs)
@@ -169,6 +187,7 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
       {route.length > 0 && (
         <>
           <Polyline
+            pane={PLATFORM_PANE}
             pathOptions={{
               color: platformColor,
               weight: 3,
@@ -201,6 +220,7 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
           {!platformIcon && (
             <CircleMarker
               center={[route[0][0], route[0][1]]}
+              pane={PLATFORM_PANE}
               radius={8}
               pathOptions={{
                 color: 'white',
@@ -241,6 +261,7 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
               <CircleMarker
                 key={`${platformId}-${index}`}
                 center={[position[0], position[1]]}
+                pane={PLATFORM_PANE}
                 radius={2}
                 pathOptions={{
                   color: platformColor,

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useEffect, useCallback } from 'react'
-import { Marker, Polyline, Tooltip, CircleMarker, Pane } from 'react-leaflet'
+import { Marker, Polyline, Tooltip, CircleMarker } from 'react-leaflet'
 import L from 'leaflet'
 import { usePlatformPositions } from '@mbari/api-client'
 import { createLogger } from '@mbari/utils'
@@ -8,10 +8,10 @@ import { useTick } from '../lib/useTick'
 // Dedicated Leaflet pane for ship/platform tracks — sits above the vehicle
 // hit-circle layer (overlayPane z-index 400) so ship elements always win
 // pointer-event priority when a ship track overlaps a vehicle surfacing fix.
-// Declared as a <Pane /> component (declarative) rather than map.createPane()
-// (imperative side-effect in render) to follow react-leaflet best practice.
-const PLATFORM_PANE = 'platformsPane'
-const PLATFORM_PANE_Z = 450
+// The <Pane /> must be rendered exactly ONCE (in PlatformPaths.tsx, the parent)
+// to avoid "A pane with this name already exists" when multiple ships are shown.
+export const PLATFORM_PANE = 'platformsPane'
+export const PLATFORM_PANE_Z = 450
 
 const logger = createLogger('PlatformPath')
 
@@ -170,9 +170,6 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
 
   return (
     <>
-      {/* Declare the platforms pane declaratively so react-leaflet owns the
-          lifecycle — avoids imperative map.createPane() side-effects in render. */}
-      <Pane name={PLATFORM_PANE} style={{ zIndex: PLATFORM_PANE_Z }} />
       {/* Custom icon at latest position, shown for fixed/infrequently-updated platforms */}
       {platformIcon && route.length > 0 && (
         <Marker position={[route[0][0], route[0][1]]} icon={platformIcon}>

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -195,33 +195,52 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
             </Tooltip>
           </Polyline>
 
-          {/* Name-label dot at latest position — always rendered so the position
-              remains visible even if the custom icon image fails to load */}
-          <CircleMarker
-            center={[route[0][0], route[0][1]]}
-            radius={1}
-            pathOptions={{
-              color: platformColor,
-              fillColor: platformColor,
-              fillOpacity: 1,
-              weight: 0,
-            }}
-          >
-            <Tooltip permanent opacity={0.6}>
-              <div className="text-italic">
-                <span className="text-bold">{displayName}</span>
-                {displayAbbrev ? (
-                  <span className="text-gray-500"> ({displayAbbrev})</span>
-                ) : null}
-              </div>
-            </Tooltip>
-          </CircleMarker>
+          {/* Prominent current-position marker — solid filled circle with white
+              outline so it reads clearly against both the track line and the
+              basemap. Carries the permanent name label and the hover tooltip. */}
+          {!platformIcon && (
+            <CircleMarker
+              center={[route[0][0], route[0][1]]}
+              radius={8}
+              pathOptions={{
+                color: 'white',
+                fillColor: platformColor,
+                fillOpacity: 0.9,
+                weight: 2,
+              }}
+            >
+              <Tooltip permanent opacity={0.75}>
+                <div className="text-italic">
+                  <span className="text-bold">{displayName}</span>
+                  {displayAbbrev ? (
+                    <span className="text-gray-500"> ({displayAbbrev})</span>
+                  ) : null}
+                </div>
+              </Tooltip>
+              <Tooltip opacity={0.9}>
+                <div className="text-italic">
+                  <div className="text-bold">{displayName}</div>
+                  {displayAbbrev && (
+                    <div className="text-gray-500">({displayAbbrev})</div>
+                  )}
+                </div>
+                <span>Latest position:</span> {route[0][0].toFixed(5)},{' '}
+                {route[0][1].toFixed(5)}
+                <br />
+                {displayPositions[0] && (
+                  <div className="text-sm text-gray-400">
+                    {new Date(displayPositions[0].timeMs).toLocaleString()}
+                  </div>
+                )}
+              </Tooltip>
+            </CircleMarker>
+          )}
 
-          {/* One circle marker per fix with hover tooltip.
-              Skip the latest-position dot when a custom icon already marks it. */}
+          {/* Historical fix dots — small, semi-transparent, hover-only tooltip.
+              Skip index 0 (latest) since the prominent marker above covers it
+              for no-icon platforms; skip it too when a custom icon marks it. */}
           {route.map((position, index) => {
-            const isLatest = index === 0
-            if (isLatest && platformIcon) return null
+            if (index === 0) return null
             const pos = displayPositions[index]
             const timestamp = pos ? new Date(pos.timeMs).toLocaleString() : ''
 
@@ -229,13 +248,13 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
               <CircleMarker
                 key={`${platformId}-${index}`}
                 center={[position[0], position[1]]}
-                radius={isLatest ? 6 : 2}
+                radius={2}
                 pathOptions={{
                   color: platformColor,
                   fillColor: platformColor,
-                  fillOpacity: 0.2,
-                  weight: 3,
-                  opacity: 1,
+                  fillOpacity: 0.5,
+                  weight: 1,
+                  opacity: 0.7,
                 }}
               >
                 <Tooltip opacity={0.9}>
@@ -245,8 +264,8 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
                       <div className="text-gray-500">({displayAbbrev})</div>
                     )}
                   </div>
-                  <span>{isLatest ? 'Latest position:' : 'Lat/Lon:'}</span>{' '}
-                  {position[0].toFixed(5)}, {position[1].toFixed(5)}
+                  <span>Lat/Lon:</span> {position[0].toFixed(5)},{' '}
+                  {position[1].toFixed(5)}
                   <br />
                   {timestamp && (
                     <div className="text-sm text-gray-400">{timestamp}</div>

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -105,13 +105,13 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
     if (!iconUrl) return null
 
     const container = document.createElement('div')
-    container.style.cssText = 'width:32px;height:32px;overflow:hidden;'
+    container.style.cssText = 'width:44px;height:44px;overflow:hidden;'
 
     const img = document.createElement('img')
     img.src = iconUrl
     img.alt = displayName
     img.style.cssText =
-      'width:32px;height:32px;object-fit:contain;border:none;background:transparent;'
+      'width:44px;height:44px;object-fit:contain;border:none;background:transparent;'
     img.onerror = () => {
       img.style.display = 'none'
     }
@@ -120,9 +120,9 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
     return L.divIcon({
       className: '',
       html: container,
-      iconSize: [32, 32],
-      iconAnchor: [16, 16],
-      tooltipAnchor: [16, 0],
+      iconSize: [44, 44],
+      iconAnchor: [22, 22],
+      tooltipAnchor: [22, 0],
     })
   }, [iconUrl, displayName])
 

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -41,6 +41,7 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
   refreshIntervalMs = 5 * 60_000,
 }) => {
   const [hovered, setHovered] = useState(false)
+  const [currentPosHovered, setCurrentPosHovered] = useState(false)
   // Track icon load failure so we can show the fallback CircleMarker when
   // the ODSS image is blocked or unavailable. Reset whenever iconUrl changes
   // so a new valid URL gets a fresh attempt.
@@ -224,21 +225,33 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
                 fillOpacity: 0.9,
                 weight: 2,
               }}
+              eventHandlers={{
+                mouseover: () => setCurrentPosHovered(true),
+                mouseout: () => setCurrentPosHovered(false),
+              }}
             >
+              {/* Permanent tooltip shows name label only — coords/timestamp
+                  are added on hover to avoid clutter with multiple platforms. */}
               <Tooltip permanent opacity={0.75}>
                 <div className="text-italic">
                   <span className="text-bold">{displayName}</span>
                   {displayAbbrev ? (
                     <span className="text-gray-500"> ({displayAbbrev})</span>
                   ) : null}
-                  <br />
-                  <span className="text-xs text-gray-400">
-                    {route[0][0].toFixed(5)}, {route[0][1].toFixed(5)}
-                  </span>
-                  {displayPositions[0] && (
-                    <div className="text-xs text-gray-400">
-                      {new Date(displayPositions[0].timeMs).toLocaleString()}
-                    </div>
+                  {currentPosHovered && (
+                    <>
+                      <br />
+                      <span className="text-xs text-gray-400">
+                        {route[0][0].toFixed(5)}, {route[0][1].toFixed(5)}
+                      </span>
+                      {displayPositions[0] && (
+                        <div className="text-xs text-gray-400">
+                          {new Date(
+                            displayPositions[0].timeMs
+                          ).toLocaleString()}
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
               </Tooltip>

--- a/apps/lrauv-dash2/components/PlatformPath.tsx
+++ b/apps/lrauv-dash2/components/PlatformPath.tsx
@@ -4,14 +4,7 @@ import L from 'leaflet'
 import { usePlatformPositions } from '@mbari/api-client'
 import { createLogger } from '@mbari/utils'
 import { useTick } from '../lib/useTick'
-
-// Dedicated Leaflet pane for ship/platform tracks — sits above the vehicle
-// hit-circle layer (overlayPane z-index 400) so ship elements always win
-// pointer-event priority when a ship track overlaps a vehicle surfacing fix.
-// The <Pane /> must be rendered exactly ONCE (in PlatformPaths.tsx, the parent)
-// to avoid "A pane with this name already exists" when multiple ships are shown.
-export const PLATFORM_PANE = 'platformsPane'
-export const PLATFORM_PANE_Z = 450
+import { PLATFORM_PANE } from '../lib/constants'
 
 const logger = createLogger('PlatformPath')
 
@@ -251,8 +244,8 @@ export const PlatformPath: React.FC<PlatformPathProps> = ({
           )}
 
           {/* Historical fix dots — small, semi-transparent, hover-only tooltip.
-              Skip index 0 (latest) since the prominent marker above covers it
-              for no-icon platforms; skip it too when a custom icon marks it. */}
+              Index 0 (latest position) is always skipped here; it is covered
+              by the prominent CircleMarker above (no-icon) or the Marker icon. */}
           {route.map((position, index) => {
             if (index === 0) return null
             const pos = displayPositions[index]

--- a/apps/lrauv-dash2/components/PlatformPaths.tsx
+++ b/apps/lrauv-dash2/components/PlatformPaths.tsx
@@ -3,8 +3,7 @@ import dynamic from 'next/dynamic'
 import { Pane } from 'react-leaflet'
 import { useSelectedPlatforms } from './SelectedPlatformContext'
 import { usePlatformList } from '../lib/usePlatformList'
-import { ODSS_BASE_URL } from '../lib/constants'
-import { PLATFORM_PANE, PLATFORM_PANE_Z } from './PlatformPath'
+import { ODSS_BASE_URL, PLATFORM_PANE, PLATFORM_PANE_Z } from '../lib/constants'
 
 const PlatformPath = dynamic(
   () => import('./PlatformPath').then((mod) => ({ default: mod.PlatformPath })),

--- a/apps/lrauv-dash2/components/PlatformPaths.tsx
+++ b/apps/lrauv-dash2/components/PlatformPaths.tsx
@@ -23,9 +23,9 @@ export const PlatformPaths: React.FC = () => {
 
   return (
     <>
-      {/* Single pane declaration for all ship/platform layers — must be here
-          (not in PlatformPath) to avoid duplicate-pane errors when multiple
-          ships are selected simultaneously. */}
+      {/* Single pane declaration for ship/platform polylines and circle markers
+          (icon Markers stay in the default markerPane) — declared here once to
+          avoid duplicate-pane errors when multiple ships are selected. */}
       <Pane name={PLATFORM_PANE} style={{ zIndex: PLATFORM_PANE_Z }} />
       {selectedPlatformIds.map((platformId) => {
         const platform = platformMap[platformId]

--- a/apps/lrauv-dash2/components/PlatformPaths.tsx
+++ b/apps/lrauv-dash2/components/PlatformPaths.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import dynamic from 'next/dynamic'
+import { Pane } from 'react-leaflet'
 import { useSelectedPlatforms } from './SelectedPlatformContext'
 import { usePlatformList } from '../lib/usePlatformList'
 import { ODSS_BASE_URL } from '../lib/constants'
+import { PLATFORM_PANE, PLATFORM_PANE_Z } from './PlatformPath'
 
 const PlatformPath = dynamic(
   () => import('./PlatformPath').then((mod) => ({ default: mod.PlatformPath })),
@@ -22,6 +24,10 @@ export const PlatformPaths: React.FC = () => {
 
   return (
     <>
+      {/* Single pane declaration for all ship/platform layers — must be here
+          (not in PlatformPath) to avoid duplicate-pane errors when multiple
+          ships are selected simultaneously. */}
+      <Pane name={PLATFORM_PANE} style={{ zIndex: PLATFORM_PANE_Z }} />
       {selectedPlatformIds.map((platformId) => {
         const platform = platformMap[platformId]
         if (!platform) return null

--- a/apps/lrauv-dash2/jest/PlatformPath.test.tsx
+++ b/apps/lrauv-dash2/jest/PlatformPath.test.tsx
@@ -3,8 +3,8 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 // Mock react-leaflet so PlatformPath can render without a map context.
-// <Pane> is included because PlatformPath now uses it declaratively to register
-// the custom platformsPane — no need for useMap/map.createPane at all.
+// <Pane> is mocked here as a no-op because PlatformPaths (the parent) renders
+// it; including it keeps the mock complete if future tests render PlatformPaths.
 jest.mock('react-leaflet', () => ({
   Pane: () => null,
   Marker: ({ children }: { children?: React.ReactNode }) => (

--- a/apps/lrauv-dash2/jest/PlatformPath.test.tsx
+++ b/apps/lrauv-dash2/jest/PlatformPath.test.tsx
@@ -2,8 +2,19 @@ import '@testing-library/jest-dom'
 import React from 'react'
 import { render } from '@testing-library/react'
 
-// Mock react-leaflet so PlatformPath can render without a map context
+// Mock react-leaflet so PlatformPath can render without a map context.
+// useMap must return a minimal map stub with getPane/createPane so the
+// platformsPane initialization code in PlatformPath doesn't throw.
+const mockPane = { style: { zIndex: '' } }
+const mockMap = {
+  getPane: jest.fn((name: string) =>
+    name === 'platformsPane' ? undefined : mockPane
+  ),
+  createPane: jest.fn(() => mockPane),
+}
+
 jest.mock('react-leaflet', () => ({
+  useMap: () => mockMap,
   Marker: ({ children }: { children?: React.ReactNode }) => (
     <div data-testid="marker">{children}</div>
   ),

--- a/apps/lrauv-dash2/jest/PlatformPath.test.tsx
+++ b/apps/lrauv-dash2/jest/PlatformPath.test.tsx
@@ -16,8 +16,17 @@ jest.mock('react-leaflet', () => ({
   Tooltip: ({ children }: { children?: React.ReactNode }) => (
     <div data-testid="tooltip">{children}</div>
   ),
-  CircleMarker: ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid="circle-marker">{children}</div>
+  // Expose radius so tests can assert prominent (8) vs historical (2) styling
+  CircleMarker: ({
+    children,
+    radius,
+  }: {
+    children?: React.ReactNode
+    radius?: number
+  }) => (
+    <div data-testid="circle-marker" data-radius={radius}>
+      {children}
+    </div>
   ),
 }))
 
@@ -132,10 +141,12 @@ describe('PlatformPath rendering', () => {
     const { getAllByTestId } = render(
       <PlatformPath platformId="abc" platformName="Test Platform" />
     )
-    // index 0 → prominent current-position CircleMarker
-    // index 1 → historical dot CircleMarker
-    // index 0 is skipped in the historical map loop
-    expect(getAllByTestId('circle-marker')).toHaveLength(2)
+    const markers = getAllByTestId('circle-marker')
+    // index 0 → prominent current-position marker (radius 8)
+    // index 1 → historical dot (radius 2)
+    expect(markers).toHaveLength(2)
+    expect(markers[0]).toHaveAttribute('data-radius', '8')
+    expect(markers[1]).toHaveAttribute('data-radius', '2')
   })
 
   it('skips the latest-position CircleMarker in the historical dots loop', () => {
@@ -153,7 +164,11 @@ describe('PlatformPath rendering', () => {
     const { getAllByTestId } = render(
       <PlatformPath platformId="abc" platformName="Test Platform" />
     )
-    // 1 prominent marker (index 0) + 2 historical dots (index 1, 2) = 3 total
-    expect(getAllByTestId('circle-marker')).toHaveLength(3)
+    const markers = getAllByTestId('circle-marker')
+    // 1 prominent marker (radius 8) + 2 historical dots (radius 2) = 3 total
+    expect(markers).toHaveLength(3)
+    expect(markers[0]).toHaveAttribute('data-radius', '8')
+    expect(markers[1]).toHaveAttribute('data-radius', '2')
+    expect(markers[2]).toHaveAttribute('data-radius', '2')
   })
 })

--- a/apps/lrauv-dash2/jest/PlatformPath.test.tsx
+++ b/apps/lrauv-dash2/jest/PlatformPath.test.tsx
@@ -3,18 +3,10 @@ import React from 'react'
 import { render } from '@testing-library/react'
 
 // Mock react-leaflet so PlatformPath can render without a map context.
-// useMap must return a minimal map stub with getPane/createPane so the
-// platformsPane initialization code in PlatformPath doesn't throw.
-const mockPane = { style: { zIndex: '' } }
-const mockMap = {
-  getPane: jest.fn((name: string) =>
-    name === 'platformsPane' ? undefined : mockPane
-  ),
-  createPane: jest.fn(() => mockPane),
-}
-
+// <Pane> is included because PlatformPath now uses it declaratively to register
+// the custom platformsPane — no need for useMap/map.createPane at all.
 jest.mock('react-leaflet', () => ({
-  useMap: () => mockMap,
+  Pane: () => null,
   Marker: ({ children }: { children?: React.ReactNode }) => (
     <div data-testid="marker">{children}</div>
   ),
@@ -124,5 +116,44 @@ describe('PlatformPath rendering', () => {
       <PlatformPath platformId="abc" platformName="Test Platform" />
     )
     expect(getByTestId('polyline')).toBeInTheDocument()
+  })
+
+  it('renders 1 prominent + 1 historical CircleMarker for 2 fixes with no icon', () => {
+    mockUsePlatformPositions.mockReturnValue({
+      data: {
+        positions: [
+          { timeMs: 2000, lat: 36.1, lon: -122.1 },
+          { timeMs: 1000, lat: 36.0, lon: -122.0 },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    })
+    const { getAllByTestId } = render(
+      <PlatformPath platformId="abc" platformName="Test Platform" />
+    )
+    // index 0 → prominent current-position CircleMarker
+    // index 1 → historical dot CircleMarker
+    // index 0 is skipped in the historical map loop
+    expect(getAllByTestId('circle-marker')).toHaveLength(2)
+  })
+
+  it('skips the latest-position CircleMarker in the historical dots loop', () => {
+    mockUsePlatformPositions.mockReturnValue({
+      data: {
+        positions: [
+          { timeMs: 3000, lat: 36.2, lon: -122.2 },
+          { timeMs: 2000, lat: 36.1, lon: -122.1 },
+          { timeMs: 1000, lat: 36.0, lon: -122.0 },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    })
+    const { getAllByTestId } = render(
+      <PlatformPath platformId="abc" platformName="Test Platform" />
+    )
+    // 1 prominent marker (index 0) + 2 historical dots (index 1, 2) = 3 total
+    expect(getAllByTestId('circle-marker')).toHaveLength(3)
   })
 })

--- a/apps/lrauv-dash2/lib/constants.ts
+++ b/apps/lrauv-dash2/lib/constants.ts
@@ -5,3 +5,9 @@ export const ODSS_BASE_URL = 'https://odss.mbari.org/odss'
  *  so the profile dropdown and resources dropdown stay in sync. */
 export const WATCHBILL_URL =
   'https://docs.google.com/spreadsheets/d/1kOTNsOcUKWlfK1YHQAq38arX9HLQINzlpuR-vL6bCrE/edit?gid=0#gid=0'
+
+/** Leaflet pane name and z-index for ship/platform track layers.
+ *  Defined here (Leaflet-free module) so both PlatformPath and PlatformPaths
+ *  can import them without pulling Leaflet into PlatformPaths' initial bundle. */
+export const PLATFORM_PANE = 'platformsPane'
+export const PLATFORM_PANE_Z = 450


### PR DESCRIPTION
## Summary

The latest-position marker for TrackDB platforms (ships like R/V Paragon) was a `radius={1}` dot — nearly invisible, and actually smaller than the historical track dots. This made it impossible to tell where the vessel is, especially when it has returned to port.

**Before:** 1px dot at current position, 6px faint ring (20% opacity) — hard to see  
**After:** 8px solid filled circle (platform color, 90% opacity) with white outline — immediately obvious

Historical fix dots remain small (`radius={2}`) so they don't clutter the track.

## Changes

- `PlatformPath.tsx`: Replace the tiny name-label dot with a proper prominent `CircleMarker` (`radius=8`, `fillOpacity=0.9`, white outline) at index 0 (latest position)
- Historical positions now all use `radius={2}` consistently (was inconsistently mixing 6px/2px)
- Permanent name label and hover detail tooltip both attached to the new prominent marker

Closes #755

## Test plan

- [ ] Ship with recent positions: current location shows as a solid colored circle with white ring and name label
- [ ] Historical dots along the track remain small and unobtrusive
- [ ] Hover on any dot shows lat/lon and timestamp tooltip
- [ ] Platform icon size increased from 32×32px to 44×44px (anchor and tooltip anchor updated accordingly)