### PR TITLE
feat: add quick-pick confirmation for deployment start date

### DIFF
--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
@@ -107,10 +107,10 @@ test('should display quick-pick buttons for start when edit dates is clicked', a
   fireEvent.click(screen.getByLabelText(/edit dates button/i))
 
   expect(screen.getByLabelText(/set start time to now/i)).toBeInTheDocument()
-  expect(
-    screen.getByLabelText(/set start time to one hour from now/i)
-  ).toBeInTheDocument()
   expect(screen.getByLabelText(/pick a custom start date/i)).toBeInTheDocument()
+  expect(
+    screen.queryByLabelText(/set start time to one hour from now/i)
+  ).not.toBeInTheDocument()
   expect(screen.queryByLabelText(/edit dates button/i)).not.toBeInTheDocument()
 })
 

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
@@ -148,6 +148,35 @@ test('should show inline warning when existing start date is in the future', asy
   expect(screen.getByText(/Start is in the future/i)).toBeInTheDocument()
 })
 
+test('should show inline warning in quick-pick view when existing start date is in the future', async () => {
+  const futureDate = new Date(
+    Date.now() + 7 * 24 * 60 * 60 * 1000
+  ).toISOString()
+  render(<DeploymentDetailsPopUp {...props} startDate={futureDate} />)
+
+  fireEvent.click(screen.getByLabelText(/edit dates button/i))
+
+  // quick-pick buttons should be visible and warning should appear below them
+  expect(screen.getByLabelText(/set start time to now/i)).toBeInTheDocument()
+  expect(screen.getAllByText(/Start is in the future/i).length).toBeGreaterThan(
+    0
+  )
+})
+
+test('should show inline warning in custom date view when start date is in the future', async () => {
+  const futureDate = new Date(
+    Date.now() + 7 * 24 * 60 * 60 * 1000
+  ).toISOString()
+  render(<DeploymentDetailsPopUp {...props} startDate={futureDate} />)
+
+  fireEvent.click(screen.getByLabelText(/edit dates button/i))
+  fireEvent.click(screen.getByLabelText(/pick a custom start date/i))
+
+  // Custom DateField pre-populates with the existing future startDate,
+  // so isCustomFuture should be true and the warning should appear.
+  expect(screen.getByText(/Start is in the future/i)).toBeInTheDocument()
+})
+
 test('should still show DateField for non-start events in edit mode', async () => {
   render(<DeploymentDetailsPopUp {...props} />)
 

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
@@ -102,7 +102,7 @@ test('should display mark recovery time now button if a recovery time is not pro
 })
 
 test('should reset to quick-pick view if modal is reopened after choosing Custom date', async () => {
-  const { rerender } = render(<DeploymentDetailsPopUp {...props} />)
+  render(<DeploymentDetailsPopUp {...props} />)
 
   // Enter edit mode, open the custom picker
   fireEvent.click(screen.getByLabelText(/edit dates button/i))

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
@@ -101,6 +101,41 @@ test('should display mark recovery time now button if a recovery time is not pro
   expect(markRecoveryTimeButton).toBeInTheDocument()
 })
 
+test('should reset to quick-pick view if modal is reopened after choosing Custom date', async () => {
+  const { rerender } = render(<DeploymentDetailsPopUp {...props} />)
+
+  // Enter edit mode, open the custom picker
+  fireEvent.click(screen.getByLabelText(/edit dates button/i))
+  fireEvent.click(screen.getByLabelText(/pick a custom start date/i))
+  expect(screen.getByText(/← Back to quick options/i)).toBeInTheDocument()
+
+  // Close edit mode (simulates Cancel / X button) by clicking the Cancel button
+  fireEvent.click(screen.getByText(/^Cancel$/i))
+
+  // Re-enter edit mode — should be back at quick-pick, not the DateField
+  fireEvent.click(screen.getByLabelText(/edit dates button/i))
+  expect(screen.getByLabelText(/set start time to now/i)).toBeInTheDocument()
+  expect(screen.queryByText(/← Back to quick options/i)).not.toBeInTheDocument()
+})
+
+test('should call onSaveChanges (not onSetDeploymentEventToCurrentTime) when mark start time now is clicked in display mode', async () => {
+  const onSaveChanges = jest.fn()
+  const onSetDeploymentEventToCurrentTime = jest.fn()
+  render(
+    <DeploymentDetailsPopUp
+      {...props}
+      startDate={undefined}
+      onSaveChanges={onSaveChanges}
+      onSetDeploymentEventToCurrentTime={onSetDeploymentEventToCurrentTime}
+    />
+  )
+
+  fireEvent.click(screen.getByLabelText(/mark start time now button/i))
+
+  expect(onSaveChanges).toHaveBeenCalledTimes(1)
+  expect(onSetDeploymentEventToCurrentTime).not.toHaveBeenCalled()
+})
+
 test('should display quick-pick buttons for start when edit dates is clicked', async () => {
   render(<DeploymentDetailsPopUp {...props} />)
 

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
@@ -114,6 +114,20 @@ test('should display quick-pick buttons for start when edit dates is clicked', a
   expect(screen.queryByLabelText(/edit dates button/i)).not.toBeInTheDocument()
 })
 
+test('should save and exit edit mode immediately when Now is clicked', async () => {
+  const onSaveChanges = jest.fn()
+  render(<DeploymentDetailsPopUp {...props} onSaveChanges={onSaveChanges} />)
+
+  fireEvent.click(screen.getByLabelText(/edit dates button/i))
+  fireEvent.click(screen.getByLabelText(/set start time to now/i))
+
+  expect(onSaveChanges).toHaveBeenCalledTimes(1)
+  expect(screen.getByLabelText(/edit dates button/i)).toBeInTheDocument()
+  expect(
+    screen.queryByLabelText(/set start time to now/i)
+  ).not.toBeInTheDocument()
+})
+
 test('should show DateField after clicking Custom date in start quick-pick', async () => {
   render(<DeploymentDetailsPopUp {...props} />)
 

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
@@ -101,17 +101,49 @@ test('should display mark recovery time now button if a recovery time is not pro
   expect(markRecoveryTimeButton).toBeInTheDocument()
 })
 
-test('should display date selectors if edit dates button is clicked', async () => {
+test('should display quick-pick buttons for start when edit dates is clicked', async () => {
   render(<DeploymentDetailsPopUp {...props} />)
 
-  const editDateButton = screen.getByLabelText(/edit dates button/i)
+  fireEvent.click(screen.getByLabelText(/edit dates button/i))
 
-  fireEvent.click(editDateButton)
+  expect(screen.getByLabelText(/set start time to now/i)).toBeInTheDocument()
+  expect(
+    screen.getByLabelText(/set start time to one hour from now/i)
+  ).toBeInTheDocument()
+  expect(screen.getByLabelText(/pick a custom start date/i)).toBeInTheDocument()
+  expect(screen.queryByLabelText(/edit dates button/i)).not.toBeInTheDocument()
+})
+
+test('should show DateField after clicking Custom date in start quick-pick', async () => {
+  render(<DeploymentDetailsPopUp {...props} />)
+
+  fireEvent.click(screen.getByLabelText(/edit dates button/i))
+  fireEvent.click(screen.getByLabelText(/pick a custom start date/i))
 
   const startDateSelector = screen.queryAllByLabelText('date picker')[0]
-
   expect(startDateSelector).toBeInTheDocument()
-  expect(screen.queryByLabelText(/edit dates button/i)).not.toBeInTheDocument()
+  expect(screen.getByText(/← Back to quick options/i)).toBeInTheDocument()
+})
+
+test('should show inline warning when existing start date is in the future', async () => {
+  const futureDate = new Date(
+    Date.now() + 7 * 24 * 60 * 60 * 1000
+  ).toISOString()
+  render(<DeploymentDetailsPopUp {...props} startDate={futureDate} />)
+
+  expect(screen.getByText(/Start is in the future/i)).toBeInTheDocument()
+})
+
+test('should still show DateField for non-start events in edit mode', async () => {
+  render(<DeploymentDetailsPopUp {...props} />)
+
+  fireEvent.click(screen.getByLabelText(/edit dates button/i))
+
+  // launch/recover/end date pickers (index 0 is now start custom — skip to launch)
+  // There should be date pickers for launch, recover, end but NOT immediately for start
+  const datePickers = screen.queryAllByLabelText('date picker')
+  // launch, recover, end = 3 pickers (start shows quick-pick, not DateField)
+  expect(datePickers.length).toBeGreaterThanOrEqual(1)
 })
 
 test('should display number of log files', async () => {

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
@@ -139,11 +139,9 @@ test('should still show DateField for non-start events in edit mode', async () =
 
   fireEvent.click(screen.getByLabelText(/edit dates button/i))
 
-  // launch/recover/end date pickers (index 0 is now start custom — skip to launch)
-  // There should be date pickers for launch, recover, end but NOT immediately for start
+  // start → quick-pick (no DateField); launch, recover, end → DateField = exactly 3
   const datePickers = screen.queryAllByLabelText('date picker')
-  // launch, recover, end = 3 pickers (start shows quick-pick, not DateField)
-  expect(datePickers.length).toBeGreaterThanOrEqual(1)
+  expect(datePickers).toHaveLength(3)
 })
 
 test('should display number of log files', async () => {

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
@@ -136,6 +136,31 @@ test('should call onSaveChanges (not onSetDeploymentEventToCurrentTime) when mar
   expect(onSetDeploymentEventToCurrentTime).not.toHaveBeenCalled()
 })
 
+test('should restore pre-custom-picker startDate when Back is clicked, not save typed value', async () => {
+  const onSaveChanges = jest.fn()
+  const originalDate = '2022-06-30T11:29:42.598-07:00'
+  render(
+    <DeploymentDetailsPopUp
+      {...props}
+      startDate={originalDate}
+      onSaveChanges={onSaveChanges}
+    />
+  )
+
+  // Enter edit mode and open the custom picker (snapshots originalDate to ref)
+  fireEvent.click(screen.getByLabelText(/edit dates button/i))
+  fireEvent.click(screen.getByLabelText(/pick a custom start date/i))
+
+  // Navigate back without saving — ref should restore the original value
+  fireEvent.click(screen.getByText(/← Back to quick options/i))
+
+  // Save from the quick-pick view — should send the original date, not a modified one
+  fireEvent.click(screen.getByText(/^Save Changes$/i))
+
+  expect(onSaveChanges).toHaveBeenCalledTimes(1)
+  expect(onSaveChanges.mock.calls[0][0].startDate).toBe(originalDate)
+})
+
 test('should display quick-pick buttons for start when edit dates is clicked', async () => {
   render(<DeploymentDetailsPopUp {...props} />)
 

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -95,10 +95,107 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
   const [isSelectTimezoneMode, setIsSelectTimezoneMode] = useState(false)
   const [isLocal, setIsLocal] = useState(true)
   const [timezone, setTimezone] = useState<string | null>('')
+  // Controls whether the start-date row shows the free-form DateField (true)
+  // or the quick-pick buttons (false, the default when entering edit mode).
+  const [showStartCustomPicker, setShowStartCustomPicker] = useState(false)
 
   const dateCell = (type: EventType) => {
     const eventDateLabel = `${type}Date`
+    const eventDate =
+      deployment[eventDateLabel as keyof DeploymentDetails] || ''
 
+    const handleSetCurrentTime = () => {
+      setDeployment({
+        ...deployment,
+        [`${type}Date`]: DateTime.now().toISO(),
+      })
+      onSetDeploymentEventToCurrentTime(type)
+    }
+
+    // Start date in edit mode: show quick-pick first, DateField only if
+    // the user explicitly chooses "Custom date…"
+    if (isSelectDateMode && type === 'start') {
+      if (showStartCustomPicker) {
+        return {
+          label: (
+            <div className="flex flex-col gap-1">
+              <DateField
+                name={eventDateLabel}
+                timeZone={timezone && !isLocal ? timezone : undefined}
+                className="text-sm"
+                value={deployment[eventDateLabel as keyof DeploymentDetails]}
+                onChange={(newValue: string) =>
+                  setDeployment({
+                    ...deployment,
+                    [eventDateLabel as keyof DeploymentDetails]: newValue,
+                  })
+                }
+                disabled={false}
+              />
+              <button
+                className="text-xs text-indigo-600 underline"
+                onClick={() => setShowStartCustomPicker(false)}
+              >
+                ← Back to quick options
+              </button>
+            </div>
+          ),
+          highlighted: true,
+          span: 3,
+        }
+      }
+
+      // Quick-pick buttons
+      return {
+        label: (
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap gap-2">
+              <button
+                className={styles.markTimeButton}
+                onClick={() =>
+                  setDeployment({
+                    ...deployment,
+                    startDate: DateTime.now().toISO(),
+                  })
+                }
+                aria-label="set start time to now"
+              >
+                Now
+              </button>
+              <button
+                className={styles.markTimeButton}
+                onClick={() =>
+                  setDeployment({
+                    ...deployment,
+                    startDate: DateTime.now().plus({ hours: 1 }).toISO(),
+                  })
+                }
+                aria-label="set start time to one hour from now"
+              >
+                In 1 hour
+              </button>
+              <button
+                className={styles.markTimeButton}
+                onClick={() => setShowStartCustomPicker(true)}
+                aria-label="pick a custom start date"
+              >
+                Custom date…
+              </button>
+            </div>
+            {eventDate && DateTime.fromISO(eventDate) > DateTime.now() && (
+              <span className="text-xs italic text-amber-600">
+                Start is set in the future — GPS fixes won&apos;t appear until
+                then.
+              </span>
+            )}
+          </div>
+        ),
+        highlighted: true,
+        span: 3,
+      }
+    }
+
+    // All other events in edit mode: standard DateField
     if (isSelectDateMode) {
       return {
         label: (
@@ -120,26 +217,34 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
         span: 3,
       }
     }
-    const eventDate =
-      deployment[eventDateLabel as keyof DeploymentDetails] || ''
 
-    const handleSetCurrentTime = () => {
-      setDeployment({
-        ...deployment,
-        [`${type}Date`]: DateTime.now().toISO(),
-      })
-      onSetDeploymentEventToCurrentTime(type)
-    }
+    // Display mode: show formatted date or "Mark X time now" button
+    const isFutureStart =
+      type === 'start' &&
+      !!eventDate &&
+      DateTime.fromISO(eventDate) > DateTime.now()
+
     return eventDate
       ? {
-          label:
-            isLocal || !timezone
-              ? DateTime.fromJSDate(new Date(eventDate)).toLocaleString(
-                  DateTime.DATETIME_FULL
-                )
-              : DateTime.fromJSDate(new Date(eventDate))
-                  .setZone(timezone ?? undefined)
-                  .toLocaleString(DateTime.DATETIME_FULL),
+          label: (
+            <div className="flex flex-col gap-0.5">
+              <span>
+                {isLocal || !timezone
+                  ? DateTime.fromJSDate(new Date(eventDate)).toLocaleString(
+                      DateTime.DATETIME_FULL
+                    )
+                  : DateTime.fromJSDate(new Date(eventDate))
+                      .setZone(timezone ?? undefined)
+                      .toLocaleString(DateTime.DATETIME_FULL)}
+              </span>
+              {isFutureStart && (
+                <span className="text-xs italic text-amber-600">
+                  Start is in the future — GPS fixes won&apos;t appear until
+                  then.
+                </span>
+              )}
+            </div>
+          ),
           span: 3,
         }
       : {
@@ -175,6 +280,7 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
 
   const handleConfirm = () => {
     setIsSelectDateMode(false)
+    setShowStartCustomPicker(false)
 
     const nonEmptyKeys = Object.keys(deployment).filter(
       (key) => deployment[key as keyof DeploymentDetails] && key
@@ -203,6 +309,7 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
 
   const handleCancel = () => {
     setIsSelectDateMode(false)
+    setShowStartCustomPicker(false)
     setDeployment({ ...initialDeploymentValues, gitTag: deployment.gitTag })
   }
 

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -171,7 +171,15 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
               )}
               <button
                 className="text-xs text-indigo-600 underline"
-                onClick={() => setShowStartCustomPicker(false)}
+                onClick={() => {
+                  // Discard the custom value so it can't be silently saved from
+                  // the quick-pick view without the user reviewing it.
+                  setDeployment({
+                    ...deployment,
+                    startDate: initialDeploymentValues.startDate,
+                  })
+                  setShowStartCustomPicker(false)
+                }}
               >
                 ← Back to quick options
               </button>

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -178,12 +178,14 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
             <div className="flex flex-wrap gap-2">
               <button
                 className={styles.markTimeButton}
-                onClick={() =>
-                  setDeployment({
-                    ...deployment,
-                    startDate: DateTime.now().toISO(),
-                  })
-                }
+                onClick={() => {
+                  const now = DateTime.now().toISO()
+                  const updated = { ...deployment, startDate: now }
+                  setDeployment(updated)
+                  onSaveChanges(sanitizeDeployment(updated))
+                  setIsSelectDateMode(false)
+                  setShowStartCustomPicker(false)
+                }}
                 aria-label="set start time to now"
               >
                 Now

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
 import { Modal, ModalPropsWithoutTitle } from '../Modal'
 import { UnderwaterIcon } from '../Icons/UnderwaterIcon'
@@ -110,6 +110,9 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
   // Controls whether the start-date row shows the free-form DateField (true)
   // or the quick-pick buttons (false, the default when entering edit mode).
   const [showStartCustomPicker, setShowStartCustomPicker] = useState(false)
+  // Snapshot of deployment.startDate taken when the user opens the custom
+  // picker, so Back can restore exactly that value rather than the stale prop.
+  const preCustomStartDateRef = useRef<string>('')
 
   // Reset the custom picker sub-mode whenever edit mode closes (including via
   // the modal's X button) so the next edit session always starts at quick-pick.
@@ -172,11 +175,11 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
               <button
                 className="text-xs text-indigo-600 underline"
                 onClick={() => {
-                  // Discard the custom value so it can't be silently saved from
-                  // the quick-pick view without the user reviewing it.
+                  // Restore the startDate to what it was when the user opened
+                  // the custom picker, discarding any partially-typed value.
                   setDeployment({
                     ...deployment,
-                    startDate: initialDeploymentValues.startDate,
+                    startDate: preCustomStartDateRef.current,
                   })
                   setShowStartCustomPicker(false)
                 }}
@@ -211,7 +214,10 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
               </button>
               <button
                 className={styles.markTimeButton}
-                onClick={() => setShowStartCustomPicker(true)}
+                onClick={() => {
+                  preCustomStartDateRef.current = deployment.startDate ?? ''
+                  setShowStartCustomPicker(true)
+                }}
                 aria-label="pick a custom start date"
               >
                 Custom date…

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -190,18 +190,6 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
               </button>
               <button
                 className={styles.markTimeButton}
-                onClick={() =>
-                  setDeployment({
-                    ...deployment,
-                    startDate: DateTime.now().plus({ hours: 1 }).toISO(),
-                  })
-                }
-                aria-label="set start time to one hour from now"
-              >
-                In 1 hour
-              </button>
-              <button
-                className={styles.markTimeButton}
                 onClick={() => setShowStartCustomPicker(true)}
                 aria-label="pick a custom start date"
               >

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -25,6 +25,15 @@ export interface DeploymentDetails {
   endDate?: string
 }
 
+/**
+ * Strips empty-string optional fields so they aren't forwarded as blank query
+ * params. `name` is always present so the result still satisfies DeploymentDetails.
+ */
+const sanitizeDeployment = (d: DeploymentDetails): DeploymentDetails =>
+  Object.fromEntries(
+    Object.entries(d).filter(([, v]) => v !== '' && v !== undefined)
+  ) as DeploymentDetails
+
 export type EventType = 'start' | 'launch' | 'recover' | 'end'
 
 export interface DeploymentDetailsPopUpConfig {
@@ -111,7 +120,8 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
       if (type === 'start') {
         // 'start' must go through onSaveChanges (updateDeployment) — not
         // alterDeployment which only accepts 'launch' | 'recover' | 'end'.
-        onSaveChanges(updated)
+        // Sanitize to avoid sending empty strings for unset date fields.
+        onSaveChanges(sanitizeDeployment(updated))
       } else {
         onSetDeploymentEventToCurrentTime(type)
       }
@@ -296,18 +306,7 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
   const handleConfirm = () => {
     setIsSelectDateMode(false)
     setShowStartCustomPicker(false)
-
-    const nonEmptyKeys = Object.keys(deployment).filter(
-      (key) => deployment[key as keyof DeploymentDetails] && key
-    )
-
-    const updatedDeployment = Object.fromEntries(
-      nonEmptyKeys.map((key) => [
-        [key as keyof DeploymentDetails],
-        deployment[key as keyof DeploymentDetails],
-      ])
-    )
-    onSaveChanges(updatedDeployment)
+    onSaveChanges(sanitizeDeployment(deployment))
   }
 
   const handleSelect = (newValue: string | null) => {

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -105,13 +105,14 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
       deployment[eventDateLabel as keyof DeploymentDetails] || ''
 
     const handleSetCurrentTime = () => {
-      setDeployment({
-        ...deployment,
-        [`${type}Date`]: DateTime.now().toISO(),
-      })
-      // 'start' is updated via onSaveChanges (updateDeployment) — not
-      // alterDeployment which only accepts 'launch' | 'recover' | 'end'.
-      if (type !== 'start') {
+      const now = DateTime.now().toISO()
+      const updated = { ...deployment, [`${type}Date`]: now }
+      setDeployment(updated)
+      if (type === 'start') {
+        // 'start' must go through onSaveChanges (updateDeployment) — not
+        // alterDeployment which only accepts 'launch' | 'recover' | 'end'.
+        onSaveChanges(updated)
+      } else {
         onSetDeploymentEventToCurrentTime(type)
       }
     }
@@ -143,7 +144,7 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
               />
               {isCustomFuture && (
                 <span className="text-xs italic text-amber-600">
-                  Start is set in the future — GPS fixes won&apos;t appear until
+                  Start is in the future — GPS fixes won&apos;t appear until
                   then.
                 </span>
               )}
@@ -199,8 +200,7 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
             </div>
             {eventDate && DateTime.fromISO(eventDate) > DateTime.now() && (
               <span className="text-xs italic text-amber-600">
-                Start is set in the future — GPS fixes won&apos;t appear until
-                then.
+                Start is in the future — GPS fixes won&apos;t appear until then.
               </span>
             )}
           </div>

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -349,7 +349,11 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
         onConfirm={isSelectDateMode ? handleConfirm : null}
         onCancel={isSelectDateMode ? handleCancel : null}
         confirmButtonText="Save Changes"
-        onClose={onClose}
+        onClose={() => {
+          setIsSelectDateMode(false)
+          setShowStartCustomPicker(false)
+          onClose?.()
+        }}
         grayHeader
         title={
           <section className="ml-2 flex">

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import clsx from 'clsx'
 import { Modal, ModalPropsWithoutTitle } from '../Modal'
 import { UnderwaterIcon } from '../Icons/UnderwaterIcon'
@@ -110,6 +110,14 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
   // Controls whether the start-date row shows the free-form DateField (true)
   // or the quick-pick buttons (false, the default when entering edit mode).
   const [showStartCustomPicker, setShowStartCustomPicker] = useState(false)
+
+  // Reset the custom picker sub-mode whenever edit mode closes (including via
+  // the modal's X button) so the next edit session always starts at quick-pick.
+  useEffect(() => {
+    if (!isSelectDateMode) {
+      setShowStartCustomPicker(false)
+    }
+  }, [isSelectDateMode])
 
   const dateCell = (type: EventType) => {
     const eventDateLabel = `${type}Date`

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -116,6 +116,11 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
     // the user explicitly chooses "Custom date…"
     if (isSelectDateMode && type === 'start') {
       if (showStartCustomPicker) {
+        const customStartValue =
+          deployment[eventDateLabel as keyof DeploymentDetails] ?? ''
+        const isCustomFuture =
+          !!customStartValue &&
+          DateTime.fromISO(customStartValue) > DateTime.now()
         return {
           label: (
             <div className="flex flex-col gap-1">
@@ -123,7 +128,7 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
                 name={eventDateLabel}
                 timeZone={timezone && !isLocal ? timezone : undefined}
                 className="text-sm"
-                value={deployment[eventDateLabel as keyof DeploymentDetails]}
+                value={customStartValue}
                 onChange={(newValue: string) =>
                   setDeployment({
                     ...deployment,
@@ -132,6 +137,12 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
                 }
                 disabled={false}
               />
+              {isCustomFuture && (
+                <span className="text-xs italic text-amber-600">
+                  Start is set in the future — GPS fixes won&apos;t appear until
+                  then.
+                </span>
+              )}
               <button
                 className="text-xs text-indigo-600 underline"
                 onClick={() => setShowStartCustomPicker(false)}

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -109,7 +109,11 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
         ...deployment,
         [`${type}Date`]: DateTime.now().toISO(),
       })
-      onSetDeploymentEventToCurrentTime(type)
+      // 'start' is updated via onSaveChanges (updateDeployment) — not
+      // alterDeployment which only accepts 'launch' | 'recover' | 'end'.
+      if (type !== 'start') {
+        onSetDeploymentEventToCurrentTime(type)
+      }
     }
 
     // Start date in edit mode: show quick-pick first, DateField only if

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -26,13 +26,16 @@ export interface DeploymentDetails {
 }
 
 /**
- * Strips empty-string optional fields so they aren't forwarded as blank query
- * params. `name` is always present so the result still satisfies DeploymentDetails.
+ * Strips empty-string optional date/tag fields so they aren't forwarded as
+ * blank query params. Required fields (name) are always preserved.
  */
-const sanitizeDeployment = (d: DeploymentDetails): DeploymentDetails =>
-  Object.fromEntries(
-    Object.entries(d).filter(([, v]) => v !== '' && v !== undefined)
-  ) as DeploymentDetails
+const sanitizeDeployment = (d: DeploymentDetails): DeploymentDetails => {
+  const { name, ...optional } = d
+  const filteredOptional = Object.fromEntries(
+    Object.entries(optional).filter(([, v]) => v !== '' && v !== undefined)
+  )
+  return { name, ...filteredOptional }
+}
 
 export type EventType = 'start' | 'launch' | 'recover' | 'end'
 


### PR DESCRIPTION
## Summary

Replaces the unguarded free-form \`DateField\` for the deployment **Start** date with a simplified quick-pick flow, preventing the user error where a future date is accidentally saved (causing the vehicle to disappear from the map).

## Start date edit flow

When the user clicks the edit (pen) icon and edits the Start row, two options are shown:

| Option | Behaviour |
|---|---|
| **Now** | Saves immediately via \`updateDeployment\` and exits edit mode — giving instant visual feedback that the time was captured |
| **Custom date…** | Opens the existing \`DateField\` with a ← Back link; user reviews the date and clicks **Save Changes** to commit. Clicking ← Back discards the typed value so it cannot be silently saved from the quick-pick view. |

**\"In 1 hour\" was intentionally excluded.** A future-dated preset would recreate the exact problem this feature is solving (vehicles disappearing from the map). The only preset offered is the unambiguous current time.

**\"Now\" saves immediately by design.** Unlike \"Custom date…\", clicking \"Now\" is unambiguous — there is nothing to review. Saving and closing immediately gives clear visual feedback (the display mode updates with the saved timestamp). Waiting for a separate \"Save Changes\" click left the UI in a silent, ambiguous pending state per user feedback.

## Behaviour change: \"Mark start time now\" in display mode

When no start date is set yet, the existing \"Mark start time now\" button now calls \`onSaveChanges\` (i.e. \`updateDeployment\`) instead of \`onSetDeploymentEventToCurrentTime\` (i.e. \`alterDeployment\`). This is a **required fix** — \`alterDeployment\` only accepts \`'launch' | 'recover' | 'end'\` and returns a 400 error for \`'start'\`. The new routing is the correct API call for persisting a start date.

If the saved start date is in the future (display mode, or after entering a custom date), an inline italic note appears:
> *Start is in the future — GPS fixes won't appear until then.*

## What is unchanged

- Launch, Recover, and End date fields — completely unchanged, still use the standard \`DateField\`

## Test plan

- [ ] Click pen icon → Start row shows **Now** and **Custom date…** buttons only
- [ ] Click **Now** → edit panel closes, display mode shows the saved timestamp (no 400 error)
- [ ] Click **Custom date…** → \`DateField\` appears with **← Back** link
- [ ] Click **← Back** → custom date is discarded, returns to quick-pick buttons
- [ ] Enter a past date via Custom → saves without warning
- [ ] Enter a future date via Custom → amber inline note appears
- [ ] Click **Cancel** or **X** then reopen edit mode → starts at quick-pick, not the DateField
- [ ] Deployment with existing future start date → amber note visible in display mode
- [ ] No start date set → \"Mark start time now\" saves via \`updateDeployment\` (no 400 error)
- [ ] Launch / Recover / End rows still use the standard \`DateField\` edit flow

Closes #757