### PR TITLE
fix: correct active schedule queue ordering and fix running-mission matching (#760, #762)

### DIFF
--- a/apps/lrauv-dash2/components/DeploymentDetails.tsx
+++ b/apps/lrauv-dash2/components/DeploymentDetails.tsx
@@ -94,7 +94,7 @@ const DeploymentDetails: React.FC<{
       alterDeployment({
         deploymentId: deployment.deploymentId as number,
         date: DateTime.now().toISO(),
-        deploymentType: event as 'launch' | 'recover' | 'end',
+        deploymentType: event,
         note,
       })
     }

--- a/apps/lrauv-dash2/components/DeploymentDetails.tsx
+++ b/apps/lrauv-dash2/components/DeploymentDetails.tsx
@@ -4,7 +4,7 @@ import {
   useUpdateDeployment,
   useAlterDeployment,
 } from '@mbari/api-client'
-import { DeploymentDetailsPopUp, EventType } from '@mbari/react-ui'
+import { DeploymentDetailsPopUp, AlterableEventType } from '@mbari/react-ui'
 import type { DeploymentDetails as DeploymentDetailsType } from '@mbari/react-ui'
 import { DateTime } from 'luxon'
 import useCurrentDeployment from '../lib/useCurrentDeployment'
@@ -78,7 +78,7 @@ const DeploymentDetails: React.FC<{
     }
   }
 
-  const handleSetDeploymentTime = (event: EventType) => {
+  const handleSetDeploymentTime = (event: AlterableEventType) => {
     let note = ''
     switch (event) {
       case 'launch':

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -699,7 +699,14 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     return hasScheduledTimestamp
   }
 
-  const scheduledCells = missions?.filter(isAboveSeparator)
+  const scheduledCells = missions?.filter(isAboveSeparator).sort((a, b) => {
+    // Running mission always pins to the top.
+    const aRunning = a.status === 'running' ? 0 : 1
+    const bRunning = b.status === 'running' ? 0 : 1
+    if (aRunning !== bRunning) return aRunning - bRunning
+    // Pending items in FIFO order: oldest-sent command executes first.
+    return (a.event.unixTime ?? 0) - (b.event.unixTime ?? 0)
+  })
 
   const allHistoricCells = missions?.filter((v) => !isAboveSeparator(v))
 

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -714,7 +714,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     return hasScheduledTimestamp
   }
 
-  const scheduledCells = missions?.filter(isAboveSeparator).sort((a, b) => {
+  const scheduledCells = missions?.filter(isAboveSeparator)?.sort((a, b) => {
     // Running mission sits just above the history separator (bottom of queue).
     // Use toScheduleCellStatus for consistent normalisation (trims, lowercases,
     // maps 'tbd' → 'pending') in case raw status strings ever vary.

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -700,12 +700,12 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
   }
 
   const scheduledCells = missions?.filter(isAboveSeparator).sort((a, b) => {
-    // Running mission always pins to the top.
-    const aRunning = a.status === 'running' ? 0 : 1
-    const bRunning = b.status === 'running' ? 0 : 1
+    // Running mission sits just above the history separator (bottom of queue).
+    const aRunning = a.status === 'running' ? 1 : 0
+    const bRunning = b.status === 'running' ? 1 : 0
     if (aRunning !== bRunning) return aRunning - bRunning
-    // Pending items in FIFO order: oldest-sent command executes first.
-    return (a.event.unixTime ?? 0) - (b.event.unixTime ?? 0)
+    // Pending items newest-queued first: most recently sent command at top.
+    return (b.event.unixTime ?? 0) - (a.event.unixTime ?? 0)
   })
 
   const allHistoricCells = missions?.filter((v) => !isAboveSeparator(v))

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -492,11 +492,26 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         // matching — it belongs to a prior run of this same mission, and
         // promoting it would incorrectly show the old row as running.
         if (item.status === 'completed') return bestIdx
+        // Skip future-scheduled commands: if this row has a sched TIMESTAMP
+        // that is after the mission's known startedAt, it is queued to run
+        // later — it is not the currently running instance. Without this guard,
+        // a second queued profile_station (sent more recently) would win the
+        // "most recently sent" heuristic and be incorrectly promoted to running,
+        // hiding the future-queued row from the pending queue.
+        const itemScheduledTime = parseScheduledUnixTime(
+          item.event.data,
+          item.event.text
+        )
+        if (
+          itemScheduledTime != null &&
+          currentMissionEntry.startedAt != null &&
+          itemScheduledTime > currentMissionEntry.startedAt
+        )
+          return bestIdx
         if (bestIdx === -1) return idx
         // Prefer the most recently SENT command: when the same mission is
-        // commanded multiple times, the newest ack'd command is the active
-        // one. Picking "closest to telemetry startedAt" was backwards —
-        // it selected the oldest row when only one timeline entry exists.
+        // retried (re-sent without a future sched timestamp), the newest
+        // ack'd command is the active one.
         const bestSentTime = enriched[bestIdx].event.unixTime ?? 0
         return (item.event.unixTime ?? 0) > bestSentTime ? idx : bestIdx
       }, -1)

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -701,8 +701,10 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
 
   const scheduledCells = missions?.filter(isAboveSeparator).sort((a, b) => {
     // Running mission sits just above the history separator (bottom of queue).
-    const aRunning = a.status === 'running' ? 1 : 0
-    const bRunning = b.status === 'running' ? 1 : 0
+    // Use toScheduleCellStatus for consistent normalisation (trims, lowercases,
+    // maps 'tbd' → 'pending') in case raw status strings ever vary.
+    const aRunning = toScheduleCellStatus(a.status) === 'running' ? 1 : 0
+    const bRunning = toScheduleCellStatus(b.status) === 'running' ? 1 : 0
     if (aRunning !== bRunning) return aRunning - bRunning
     // Pending items newest-queued first: most recently sent command at top.
     return (b.event.unixTime ?? 0) - (a.event.unixTime ?? 0)

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.test.tsx
@@ -101,7 +101,7 @@ test('should display mark recovery time now button if a recovery time is not pro
   expect(markRecoveryTimeButton).toBeInTheDocument()
 })
 
-test('should reset to quick-pick view if modal is reopened after choosing Custom date', async () => {
+test('should reset to quick-pick view when re-entering edit mode after choosing Custom date', async () => {
   render(<DeploymentDetailsPopUp {...props} />)
 
   // Enter edit mode, open the custom picker
@@ -136,7 +136,7 @@ test('should call onSaveChanges (not onSetDeploymentEventToCurrentTime) when mar
   expect(onSetDeploymentEventToCurrentTime).not.toHaveBeenCalled()
 })
 
-test('should restore pre-custom-picker startDate when Back is clicked, not save typed value', async () => {
+test('should restore pre-custom-picker startDate when Back is clicked', async () => {
   const onSaveChanges = jest.fn()
   const originalDate = '2022-06-30T11:29:42.598-07:00'
   render(

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -37,7 +37,14 @@ const sanitizeDeployment = (d: DeploymentDetails): DeploymentDetails => {
   return { name, ...filteredOptional }
 }
 
+/** All four deployment timeline event types, used for UI rendering. */
 export type EventType = 'start' | 'launch' | 'recover' | 'end'
+
+/**
+ * Event types supported by alterDeployment (excludes 'start', which must go
+ * through updateDeployment via onSaveChanges to avoid a 400 error).
+ */
+export type AlterableEventType = Exclude<EventType, 'start'>
 
 export interface DeploymentDetailsPopUpConfig {
   complete?: boolean
@@ -48,7 +55,7 @@ export interface DeploymentDetailsPopUpConfig {
   onExpand?: () => void
   onSaveChanges: (details: DeploymentDetails) => void
   onChangeGitTag: (gitTag: string) => void
-  onSetDeploymentEventToCurrentTime: (event: EventType) => void
+  onSetDeploymentEventToCurrentTime: (event: AlterableEventType) => void
 }
 
 export type DeploymentDetailsPopUpProps = DeploymentDetailsPopUpConfig &
@@ -137,7 +144,7 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
         // Sanitize to avoid sending empty strings for unset date fields.
         onSaveChanges(sanitizeDeployment(updated))
       } else {
-        onSetDeploymentEventToCurrentTime(type)
+        onSetDeploymentEventToCurrentTime(type as AlterableEventType)
       }
     }
 

--- a/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
+++ b/packages/react-ui/src/PopUps/DeploymentDetailsPopUp.tsx
@@ -144,7 +144,7 @@ export const DeploymentDetailsPopUp: React.FC<DeploymentDetailsPopUpProps> = ({
         // Sanitize to avoid sending empty strings for unset date fields.
         onSaveChanges(sanitizeDeployment(updated))
       } else {
-        onSetDeploymentEventToCurrentTime(type as AlterableEventType)
+        onSetDeploymentEventToCurrentTime(type)
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes two Schedule tab bugs reported by Emme Wiederhold, plus type safety improvements from the merged PR #759 rebase.

---

## Fix 1: Schedule queue display order (closes #760)

**Problem**: The active queue (above the history separator) rendered in raw event-fetch order (newest-first from \`GET /events\`), so pending missions appeared in an arbitrary and confusing order.

**Fix**: Sort \`scheduledCells\` so:
- **Pending items** appear newest-queued-first (most recently sent command at top)
- **Running mission** pins to the bottom of the active queue, just above the history separator — it visually drains into history as it completes

This matches the operator mental model confirmed by Emme: the queue reads top-to-bottom as \"what's coming next → what's happening now → what's done\".

---

## Fix 2: Future-scheduled mission incorrectly promoted to running (closes #762)

**Problem**: When two commands share the same mission path (e.g. \`profile_station\` currently running + \`profile_station\` scheduled for 11:00am), the enrichment logic picked the **more recently sent** command as the running match. The future-scheduled command won the heuristic, got promoted to \`running\`, and disappeared from the pending queue — leaving the UI showing the running mission in the wrong timeline slot.

**Fix**: Skip any candidate row whose \`sched TIMESTAMP\` is after the mission's known \`startedAt\`. A future-scheduled command cannot be the currently running instance, so it stays in the pending queue unchanged.

---

## Type safety improvements (from merged PR #759)

- \`AlterableEventType = Exclude<EventType, 'start'>\` narrows the \`onSetDeploymentEventToCurrentTime\` callback — passing \`'start'\` is now a compile-time error
- Redundant type casts removed: TypeScript's control flow narrowing handles both the \`type\` parameter and the \`alterDeployment\` call without explicit assertions
- \`sanitizeDeployment()\` strips empty-string optional fields before calling \`onSaveChanges\` to avoid blank query params

## Test plan

- [ ] Active queue: newest-sent pending command appears at top; running mission at bottom above separator
- [ ] History: unchanged, still newest-first below \"Previous Vehicle Directives\"
- [ ] Two same-mission entries (e.g. profile_station running + profile_station scheduled for later): both appear — running at bottom, future-scheduled in pending above it
- [ ] Deployment start date: Now / Custom date… quick-pick works, no 400 error
- [ ] Mark start time now (no start date set) calls updateDeployment, no 400 error

Closes #760
Closes #762