### PR TITLE
fix: preserve depth chart zoom state across hover-driven re-renders

### DIFF
--- a/apps/lrauv-dash2/components/DepthSection.tsx
+++ b/apps/lrauv-dash2/components/DepthSection.tsx
@@ -160,6 +160,16 @@ const DepthSection: React.FC<{
     ? depthQuery.data ?? undefined
     : latestChartData?.find((d) => d.name === 'depth')
 
+  const chartPoints = useMemo(
+    () =>
+      depthData?.values?.map((v: number, i: number) => ({
+        value: v,
+        timestamp: depthData.times?.[i],
+      })),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [depthData?.values, depthData?.times]
+  )
+
   // While logsets are still loading / auto-selecting, latestQuery is disabled
   // (isLoading = false). Treat that wait as loading so "No depth data" doesn't
   // appear prematurely before any data has been fetched.
@@ -222,10 +232,7 @@ const DepthSection: React.FC<{
         {chartAvailable && (
           <LineChart
             name={depthData.name}
-            data={depthData.values?.map((v: number, i: number) => ({
-              value: v,
-              timestamp: depthData.times?.[i],
-            }))}
+            data={chartPoints}
             yAxisLabel={`${humanize(depthData.name)} (${depthData.units})`}
             onHover={onHover}
             inverted

--- a/apps/lrauv-dash2/components/DepthSection.tsx
+++ b/apps/lrauv-dash2/components/DepthSection.tsx
@@ -162,14 +162,16 @@ const DepthSection: React.FC<{
 
   const depthValues = depthData?.values
   const depthTimes = depthData?.times
-  const chartPoints = useMemo(
-    () =>
-      depthValues?.map((v: number, i: number) => ({
-        value: v,
-        timestamp: depthTimes?.[i],
-      })),
-    [depthValues, depthTimes]
-  )
+  const chartPoints = useMemo(() => {
+    if (!depthValues || !depthTimes) return undefined
+    // Clamp to the shorter array so indices are always in-bounds and
+    // timestamps are always defined (both arrays are number[] per the API).
+    const len = Math.min(depthValues.length, depthTimes.length)
+    return Array.from({ length: len }, (_, i) => ({
+      value: depthValues[i],
+      timestamp: depthTimes[i],
+    }))
+  }, [depthValues, depthTimes])
 
   // While logsets are still loading / auto-selecting, latestQuery is disabled
   // (isLoading = false). Treat that wait as loading so "No depth data" doesn't

--- a/apps/lrauv-dash2/components/DepthSection.tsx
+++ b/apps/lrauv-dash2/components/DepthSection.tsx
@@ -160,14 +160,15 @@ const DepthSection: React.FC<{
     ? depthQuery.data ?? undefined
     : latestChartData?.find((d) => d.name === 'depth')
 
+  const depthValues = depthData?.values
+  const depthTimes = depthData?.times
   const chartPoints = useMemo(
     () =>
-      depthData?.values?.map((v: number, i: number) => ({
+      depthValues?.map((v: number, i: number) => ({
         value: v,
-        timestamp: depthData.times?.[i],
+        timestamp: depthTimes?.[i],
       })),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [depthData?.values, depthData?.times]
+    [depthValues, depthTimes]
   )
 
   // While logsets are still loading / auto-selecting, latestQuery is disabled

--- a/apps/lrauv-dash2/components/DepthSection.tsx
+++ b/apps/lrauv-dash2/components/DepthSection.tsx
@@ -237,6 +237,7 @@ const DepthSection: React.FC<{
             onHover={onHover}
             inverted
             className="h-full w-full"
+            uirevision={`${depthData.name}-${timeWindow}-${selectedLogsetId}`}
           />
         )}
       </div>

--- a/apps/lrauv-dash2/components/DepthSection.tsx
+++ b/apps/lrauv-dash2/components/DepthSection.tsx
@@ -238,7 +238,7 @@ const DepthSection: React.FC<{
             onHover={onHover}
             inverted
             className="h-full w-full"
-            uirevision={`${depthData.name}-${timeWindow}-${selectedLogsetId}`}
+            uirevision={`${vehicleName}-${from}-${depthData.name}-${timeWindow}-${selectedLogsetId}`}
           />
         )}
       </div>

--- a/packages/react-ui/src/Charts/LineChart.test.tsx
+++ b/packages/react-ui/src/Charts/LineChart.test.tsx
@@ -10,9 +10,7 @@ jest.mock('react-plotly.js', () => ({
     <div
       data-testid="plot"
       data-uirevision={
-        layout.uirevision !== undefined
-          ? String(layout.uirevision)
-          : '__unset__'
+        'uirevision' in layout ? String(layout.uirevision) : '__unset__'
       }
     />
   ),

--- a/packages/react-ui/src/Charts/LineChart.test.tsx
+++ b/packages/react-ui/src/Charts/LineChart.test.tsx
@@ -1,8 +1,22 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import LineChart, { LineChartProps } from './LineChart'
 import { DateTime } from 'luxon'
+
+jest.mock('react-plotly.js', () => ({
+  __esModule: true,
+  default: ({ layout }: { layout: Record<string, unknown> }) => (
+    <div
+      data-testid="plot"
+      data-uirevision={
+        layout.uirevision !== undefined
+          ? String(layout.uirevision)
+          : '__unset__'
+      }
+    />
+  ),
+}))
 
 const props: LineChartProps = {
   data: new Array(60).fill('').map((_, i) => ({
@@ -21,4 +35,20 @@ const props: LineChartProps = {
 
 test('should render the component', async () => {
   expect(() => render(<LineChart {...props} />)).not.toThrow()
+})
+
+test('does not set uirevision on the Plotly layout when the prop is omitted', () => {
+  render(<LineChart {...props} />)
+  expect(screen.getByTestId('plot')).toHaveAttribute(
+    'data-uirevision',
+    '__unset__'
+  )
+})
+
+test('passes uirevision to the Plotly layout when the prop is provided', () => {
+  render(<LineChart {...props} uirevision="depth-latest-logset42" />)
+  expect(screen.getByTestId('plot')).toHaveAttribute(
+    'data-uirevision',
+    'depth-latest-logset42'
+  )
 })

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -22,6 +22,12 @@ export interface LineChartProps {
   /** When provided, locks the x-axis to this [start, end] range (ms since epoch) */
   xAxisRange?: [number, number]
   onHover?: (millis?: number | null) => void
+  /**
+   * Plotly uirevision key. When this value changes, Plotly resets zoom/pan.
+   * When it stays the same, user zoom is preserved across re-renders.
+   * Defaults to `name` when omitted.
+   */
+  uirevision?: string
 }
 
 const LineChart: React.FC<LineChartProps> = ({
@@ -35,6 +41,7 @@ const LineChart: React.FC<LineChartProps> = ({
   inverted,
   xAxisRange,
   onHover: handleHoverFromParent,
+  uirevision,
 }) => {
   const container = useRef(null)
   const { size } = useResizeObserver({ element: container })
@@ -79,7 +86,8 @@ const LineChart: React.FC<LineChartProps> = ({
         layout={{
           // Preserve user zoom/pan across React re-renders. When uirevision
           // doesn't change, Plotly keeps its internal UI state (axes, zoom).
-          uirevision: name,
+          // Changes to uirevision (e.g. time-window switch) reset zoom.
+          uirevision: uirevision ?? name,
           title: {
             text: title ? `<b>${title}</b>` : undefined,
             font: {

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -77,6 +77,9 @@ const LineChart: React.FC<LineChartProps> = ({
           },
         ]}
         layout={{
+          // Preserve user zoom/pan across React re-renders. When uirevision
+          // doesn't change, Plotly keeps its internal UI state (axes, zoom).
+          uirevision: name,
           title: {
             text: title ? `<b>${title}</b>` : undefined,
             font: {

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -23,9 +23,10 @@ export interface LineChartProps {
   xAxisRange?: [number, number]
   onHover?: (millis?: number | null) => void
   /**
-   * Plotly uirevision key. When this value changes, Plotly resets zoom/pan.
-   * When it stays the same, user zoom is preserved across re-renders.
-   * Defaults to `name` when omitted.
+   * Opt-in Plotly uirevision key. When provided and unchanged across renders,
+   * Plotly preserves user zoom/pan state. When it changes, Plotly resets zoom.
+   * When omitted, Plotly's default behavior applies (zoom resets on every
+   * data/layout update).
    */
   uirevision?: string
 }
@@ -84,10 +85,11 @@ const LineChart: React.FC<LineChartProps> = ({
           },
         ]}
         layout={{
-          // Preserve user zoom/pan across React re-renders. When uirevision
-          // doesn't change, Plotly keeps its internal UI state (axes, zoom).
-          // Changes to uirevision (e.g. time-window switch) reset zoom.
-          uirevision: uirevision ?? name,
+          // Only set uirevision when the caller opts in. Without it Plotly
+          // uses its default behavior (zoom resets on every re-render).
+          // When provided and stable, Plotly preserves zoom/pan; when it
+          // changes (e.g. time-window switch) Plotly resets the axes.
+          ...(uirevision !== undefined && { uirevision }),
           title: {
             text: title ? `<b>${title}</b>` : undefined,
             font: {


### PR DESCRIPTION
## Summary

Fixes the depth chart zoom immediately resetting when the user moves the mouse after zooming in (reported in the Depth Data tab only, not Science/Vehicle Data charts).

**Root cause:** The Depth Data chart is the only `LineChart` consumer that wires `onHover` to a parent `setState` (`setIndicatorTime`). Every mouse move triggered a re-render, which passed a fresh `data` array reference to Plotly. Without `uirevision`, Plotly treats each new render as a full reset and discards the user's zoom state.

## Changes

- **`LineChart.tsx`** — Added an opt-in `uirevision` prop. When provided and unchanged across renders, Plotly preserves zoom/pan state; when it changes, Plotly resets the axes. When omitted (default), Plotly's standard reset-on-render behavior is preserved for all other consumers.
- **`DepthSection.tsx`** — Passes `uirevision` keyed to `vehicleName`, deployment `from`, time window, and logset ID so zoom persists across hover re-renders but resets correctly when switching vehicles, deployments, time windows, or logsets. Also memoizes chart data points, clamping to the shorter of `values`/`times` to guarantee in-bounds, defined timestamps.

Science/Vehicle Data charts are unaffected — they don't wire `onHover` to parent state and don't pass `uirevision`.

## Test plan

- [ ] Navigate to the Depth Data tab for any active vehicle deployment
- [ ] Zoom into a region of the depth chart
- [ ] Move the mouse — zoom should now stay put
- [ ] Verify the timeline scrubber/indicator still updates as the mouse moves over the chart (hover wiring is unchanged)
- [ ] Switch time window (e.g. Latest Dive -> 3 Days) — zoom should reset
- [ ] Navigate to a different vehicle/deployment — zoom should reset
- [ ] Confirm Science/Vehicle Data charts still work normally

Closes #763