### PR TITLE
fix: disable hacked geoserver tile layers and suppress vehicle-info timeout errors

### DIFF
--- a/packages/api-client/src/axios/Widget/getVehicleInfo.test.ts
+++ b/packages/api-client/src/axios/Widget/getVehicleInfo.test.ts
@@ -103,11 +103,7 @@ describe('getVehicleInfo', () => {
       })
     )
 
-    try {
-      await getVehicleInfo(params)
-    } catch (error) {
-      expect(error).toBeDefined()
-    }
+    await expect(getVehicleInfo(params)).rejects.toBeDefined()
   })
 
   it('should return an empty response on a 404 error', async () => {

--- a/packages/api-client/src/axios/Widget/getVehicleInfo.ts
+++ b/packages/api-client/src/axios/Widget/getVehicleInfo.ts
@@ -1,4 +1,5 @@
 // Use scaffold axiosBase to generate the resources imported below.
+import axios from 'axios'
 import { getInstance } from '../getInstance'
 import { RequestConfig } from '../types'
 
@@ -140,10 +141,9 @@ export const getVehicleInfo = async (
     )
     return response.data as GetVehicleInfoResponse
   } catch (e: unknown) {
-    if ((e as Error).message.includes('404')) {
+    if (axios.isAxiosError(e) && e.response?.status === 404) {
       return { not_found: true }
-    } else {
-      throw e
     }
+    throw e
   }
 }

--- a/packages/api-client/src/axios/Widget/getVehicleInfo.ts
+++ b/packages/api-client/src/axios/Widget/getVehicleInfo.ts
@@ -140,7 +140,7 @@ export const getVehicleInfo = async (
     )
     return response.data as GetVehicleInfoResponse
   } catch (e: unknown) {
-    if ((e as Error).message.indexOf('404')) {
+    if ((e as Error).message.includes('404')) {
       return { not_found: true }
     } else {
       throw e

--- a/packages/api-client/src/react-query/Map/useTileLayers.test.tsx
+++ b/packages/api-client/src/react-query/Map/useTileLayers.test.tsx
@@ -49,6 +49,21 @@ const MockTileLayers: React.FC = () => {
   )
 }
 
+const MockAllLayerNames: React.FC = () => {
+  const query = useTileLayers()
+  if (query.isLoading) return null
+  const names = query.data?.map((l) => l.name) ?? []
+  return (
+    <ul>
+      {names.map((n) => (
+        <li key={n} data-testid="layer-name">
+          {n}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
 describe('useTileLayers', () => {
   it('should display the first tile layer name after unwrapping { result }', async () => {
     render(
@@ -58,5 +73,50 @@ describe('useTileLayers', () => {
     )
     await waitFor(() => screen.getByText(mockTileLayers[0].name))
     expect(screen.getByTestId('name')).toHaveTextContent(mockTileLayers[0].name)
+  })
+
+  it('should filter out disabled tile layers (DK3HORRO, 2020 Summer Astrid) from results', async () => {
+    server.use(
+      rest.get('/info/map/tileLayers', (_req, res, ctx) =>
+        res(
+          ctx.status(200),
+          ctx.json({
+            result: [
+              ...mockTileLayers,
+              {
+                name: 'DK3HORRO',
+                urlTemplate: 'https://hacked.example.com/tiles/{z}/{x}/{y}.png',
+                wms: false,
+              },
+              {
+                name: '2020 Summer Astrid',
+                urlTemplate:
+                  'https://hacked.example.com/astrid/{z}/{x}/{y}.png',
+                wms: false,
+              },
+            ],
+          })
+        )
+      )
+    )
+
+    render(
+      <MockProviders queryClient={new QueryClient()}>
+        <MockAllLayerNames />
+      </MockProviders>
+    )
+
+    await waitFor(() =>
+      expect(screen.queryAllByTestId('layer-name').length).toBeGreaterThan(0)
+    )
+
+    const names = screen
+      .queryAllByTestId('layer-name')
+      .map((el) => el.textContent)
+
+    expect(names).not.toContain('DK3HORRO')
+    expect(names).not.toContain('2020 Summer Astrid')
+    expect(names).toContain('SST 1 Day Composite')
+    expect(names).toContain('Cell phone coverage map')
   })
 })

--- a/packages/api-client/src/react-query/Map/useTileLayers.ts
+++ b/packages/api-client/src/react-query/Map/useTileLayers.ts
@@ -3,6 +3,10 @@ import { getTileLayers } from '../../axios'
 import { useTethysApiContext } from '../TethysApiProvider'
 import { SupportedQueryOptions } from '../types'
 
+// Layers temporarily disabled while the geoserver is compromised.
+// Re-enable by removing names from this set once the server is restored.
+const DISABLED_TILE_LAYER_NAMES = new Set(['DK3HORRO', '2020 Summer Astrid'])
+
 export const useTileLayers = (options?: SupportedQueryOptions) => {
   const { axiosInstance } = useTethysApiContext()
 
@@ -12,6 +16,8 @@ export const useTileLayers = (options?: SupportedQueryOptions) => {
     {
       staleTime: 5 * 60 * 1000,
       ...options,
+      select: (data) =>
+        data.filter((layer) => !DISABLED_TILE_LAYER_NAMES.has(layer.name)),
     }
   )
 }

--- a/packages/api-client/src/react-query/Widget/useVehicleInfo.test.tsx
+++ b/packages/api-client/src/react-query/Widget/useVehicleInfo.test.tsx
@@ -83,10 +83,44 @@ const mockResponse = {
   color_volts: 'st5',
 }
 
+const mockSiteConfig = {
+  result: {
+    vehicleNames: [],
+    vehicleBasicInfos: [],
+    defaultVehicle: '',
+    eventTypes: [],
+    eventKinds: [],
+    appConfig: {
+      version: '1.0',
+      external: {
+        statusWidgets: {
+          lrauvStatusWidgetUrlPattern: 'https://widget.test/<vehicleName>.svg',
+          espStatusWidgetUrlPattern: '',
+        },
+        base: '',
+        dashui: '',
+        eventTypeDoc: '',
+        miscLinksFile: '',
+        schemaBase: '',
+        tethysdash: '',
+        useradmin: '',
+      },
+      googleApiKey: '',
+      odss2dashApi: '',
+      recaptcha: { siteKey: '' },
+      slack: { primaryChannel: '' },
+      webSockets: { useWebsocket: false, maxIdleTimeout: 0 },
+      pusher: { appKey: '', eventChannel: '', cluster: '' },
+    },
+  },
+}
+
 const server = setupServer(
   rest.get('/custom/widget/auv_brizo.json', (_req, res, ctx) => {
     return res(ctx.status(200), ctx.json(mockResponse))
-  })
+  }),
+  // Default: no siteConfig → fallbackVehicleInfoUrl stays null, fallback disabled
+  rest.get('/info', (_req, res, ctx) => res(ctx.status(200), ctx.json({})))
 )
 
 beforeAll(() => server.listen())
@@ -109,6 +143,21 @@ const MockVehicleList: React.FC = () => {
   )
 }
 
+const MockFallbackResult: React.FC = () => {
+  const query = useVehicleInfo(
+    { name: 'brizo' },
+    axios.create({ baseURL: '/custom', timeout: 5000 })
+  )
+  if (query.isLoading) return <div data-testid="loading">loading</div>
+  return (
+    <div data-testid="result">
+      {query.data?.not_found
+        ? 'not_found'
+        : (query.data as GetVehicleInfoResponse)?.text_vehicle ?? 'no-data'}
+    </div>
+  )
+}
+
 describe('useVehicleInfo', () => {
   it('should render the vehicle name from the response', async () => {
     render(
@@ -122,6 +171,38 @@ describe('useVehicleInfo', () => {
 
     expect(screen.queryByText(mockResponse.text_vehicle)).toHaveTextContent(
       mockResponse.text_vehicle
+    )
+  })
+
+  it('should return not_found when the fallback request encounters a network error', async () => {
+    server.use(
+      // Provide siteConfig with fallback URL pattern so the hook knows where to fall back
+      rest.get('/info', (_req, res, ctx) =>
+        res(ctx.status(200), ctx.json(mockSiteConfig))
+      ),
+      // Primary returns 404 → not_found: true, which enables the fallback
+      rest.get('/custom/widget/auv_brizo.json', (_req, res, ctx) =>
+        res.once(ctx.status(404))
+      ),
+      // Fallback URL simulates an unreachable server (network error)
+      rest.get('https://widget.test/brizo.json', (_req, res) =>
+        res.networkError('Simulated unreachable server')
+      )
+    )
+
+    render(
+      <MockProviders
+        queryClient={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <MockFallbackResult />
+      </MockProviders>
+    )
+
+    await waitFor(
+      () => expect(screen.getByTestId('result')).toHaveTextContent('not_found'),
+      { timeout: 5000 }
     )
   })
 })

--- a/packages/api-client/src/react-query/Widget/useVehicleInfo.ts
+++ b/packages/api-client/src/react-query/Widget/useVehicleInfo.ts
@@ -81,13 +81,16 @@ export const useVehicleInfo = (
         return response.data as GetVehicleInfoResponse
       } catch (e: unknown) {
         if (axios.isAxiosError(e)) {
-          // Treat 404, timeouts (ECONNABORTED), and no-response network errors
-          // as "not found" so they don't bubble up to the console as unhandled
-          // errors when the external status widget server is unreachable.
+          // Treat 404, timeouts (ECONNABORTED), and network-layer failures
+          // (ERR_NETWORK: DNS failures, connection refused, no internet) as
+          // "not found" so they don't surface as console errors when the
+          // external status widget server is unreachable.
+          // Other AxiosErrors (e.g. 5xx, misconfigured URL that produces a
+          // non-network error) are still re-thrown.
           if (
             e.response?.status === 404 ||
             e.code === 'ECONNABORTED' ||
-            !e.response
+            e.code === 'ERR_NETWORK'
           ) {
             return { not_found: true } as GetVehicleInfoResponse
           }

--- a/packages/api-client/src/react-query/Widget/useVehicleInfo.ts
+++ b/packages/api-client/src/react-query/Widget/useVehicleInfo.ts
@@ -81,16 +81,17 @@ export const useVehicleInfo = (
         return response.data as GetVehicleInfoResponse
       } catch (e: unknown) {
         if (axios.isAxiosError(e)) {
-          // Treat 404, timeouts (ECONNABORTED), and network-layer failures
-          // (ERR_NETWORK: DNS failures, connection refused, no internet) as
-          // "not found" so they don't surface as console errors when the
+          // Treat 404, timeouts (ECONNABORTED), and no-response network errors
+          // as "not found" so they don't surface as console errors when the
           // external status widget server is unreachable.
-          // Other AxiosErrors (e.g. 5xx, misconfigured URL that produces a
-          // non-network error) are still re-thrown.
+          // `!e.response && !!e.request` is the standard axios idiom for
+          // "request was sent but no response received" (DNS failures,
+          // connection refused, network down). Other AxiosErrors that have a
+          // response (e.g. 5xx) are still re-thrown.
           if (
             e.response?.status === 404 ||
             e.code === 'ECONNABORTED' ||
-            e.code === 'ERR_NETWORK'
+            (!e.response && !!e.request)
           ) {
             return { not_found: true } as GetVehicleInfoResponse
           }

--- a/packages/api-client/src/react-query/Widget/useVehicleInfo.ts
+++ b/packages/api-client/src/react-query/Widget/useVehicleInfo.ts
@@ -80,8 +80,17 @@ export const useVehicleInfo = (
         })
         return response.data as GetVehicleInfoResponse
       } catch (e: unknown) {
-        if (axios.isAxiosError(e) && e.response?.status === 404) {
-          return { not_found: true } as GetVehicleInfoResponse
+        if (axios.isAxiosError(e)) {
+          // Treat 404, timeouts (ECONNABORTED), and no-response network errors
+          // as "not found" so they don't bubble up to the console as unhandled
+          // errors when the external status widget server is unreachable.
+          if (
+            e.response?.status === 404 ||
+            e.code === 'ECONNABORTED' ||
+            !e.response
+          ) {
+            return { not_found: true } as GetVehicleInfoResponse
+          }
         }
         throw e
       }


### PR DESCRIPTION
## Summary

- **Disable two compromised geoserver tile layers** — `DK3HORRO` and `2020 Summer Astrid` are hidden from the TILE Layers panel and the map via a `DISABLED_TILE_LAYER_NAMES` blocklist in `useTileLayers`. The backend data is untouched; re-enable by removing names from the set once the geoserver is restored.
- **Fix `getVehicleInfo.ts` indexOf bug** — `String.indexOf()` returns `-1` (truthy) when the substring is not found, so all non-404 errors were being silently absorbed as `not_found`. Changed to `.includes('404')` for correct semantics.
- **Suppress recurring vehicle-info timeout errors** — the `useVehicleInfo` fallback re-threw `ECONNABORTED` and no-response network errors, causing React Query to log `"timeout of 5000ms exceeded"` to the console every 30 s per vehicle when the external status widget server is unreachable. These are now treated as `not_found` instead.

## Test plan

- [ ] Open the Layers panel — confirm `DK3HORRO` and `2020 Summer Astrid` are no longer listed under TILE Layers
- [ ] Confirm no `"timeout of 5000ms exceeded"` errors appear in the browser console over a 2-minute idle period on the main page
- [ ] Confirm other tile layers still appear and can be toggled normally
- [ ] After the geoserver is restored, remove both names from `DISABLED_TILE_LAYER_NAMES` and verify the layers return