### PR TITLE
fix: prevent Leaflet zoom crash when query params change mid-animation

### DIFF
--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -655,7 +655,11 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       ) : null}
       <div className="relative h-full min-h-0 w-full">
         <Map
-          key={`deployment-map-${router.asPath}-${vehicleName ?? 'unknown'}`}
+          key={`deployment-map-${
+            (router.query?.deployment as string[] | undefined)?.join('/') ??
+            vehicleName ??
+            'unknown'
+          }`}
           ref={mapRef}
           className="h-full min-h-0 w-full"
           maxZoom={MAP_MAX_ZOOM}


### PR DESCRIPTION
## Summary

Fixes an unhandled runtime error (`TypeError: Cannot read properties of undefined (reading '_leaflet_pos')`) that occurred when the map was zoomed while query parameters updated in the background.

## Root Cause

The `MapContainer` key was `deployment-map-${router.asPath}-${vehicleName}`. Since `router.asPath` includes query parameters (`?logsetId=...`, `?timeWindow=...`), any time those changed during normal usage the entire map was unmounted and remounted. If a Leaflet zoom animation was in progress at that moment, `_onZoomTransitionEnd` fired after the map pane was already destroyed — reading `_leaflet_pos` on an `undefined` element and crashing.

## Fix

Replace `router.asPath` with `router.query.deployment` (the URL path segments — `[vehicleName, deploymentId]`). This only changes when the user actually navigates to a different vehicle or deployment, never on query param changes, so zoom animations always complete cleanly.

## Test plan

- [ ] Open a vehicle deployment page
- [ ] Zoom the map repeatedly while the logset selector or time window updates in the background — no crash
- [ ] Navigate between vehicles — map remounts correctly
- [ ] Navigate between deployments for the same vehicle — map remounts correctly