### PR TITLE
fix: scale trackline hover circles by pixels, not geographic metres

### DIFF
--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -95,16 +95,6 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   startTime,
   endTime,
 }) => {
-  // Compute the Leaflet MapContainer key once on first client render using the
-  // URL pathname (no query string). window.location is available immediately —
-  // unlike router.query or vehicleName, it is never undefined mid-hydration —
-  // so the key never flips and the map is never unmounted mid-zoom-animation.
-  const stableMapKey = useRef(
-    typeof window !== 'undefined'
-      ? `deployment-map-${window.location.pathname}`
-      : `deployment-map-unknown`
-  )
-
   const mapRef = useRef<any>(null)
   const {
     updatedWaypoints,
@@ -663,7 +653,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       ) : null}
       <div className="relative h-full min-h-0 w-full">
         <Map
-          key={stableMapKey.current}
+          key={`deployment-map-${vehicleName ?? 'unknown'}`}
           ref={mapRef}
           className="h-full min-h-0 w-full"
           maxZoom={MAP_MAX_ZOOM}

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -95,6 +95,16 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   startTime,
   endTime,
 }) => {
+  // Compute the Leaflet MapContainer key once on first client render using the
+  // URL pathname (no query string). window.location is available immediately —
+  // unlike router.query or vehicleName, it is never undefined mid-hydration —
+  // so the key never flips and the map is never unmounted mid-zoom-animation.
+  const stableMapKey = useRef(
+    typeof window !== 'undefined'
+      ? `deployment-map-${window.location.pathname}`
+      : `deployment-map-unknown`
+  )
+
   const mapRef = useRef<any>(null)
   const {
     updatedWaypoints,
@@ -653,7 +663,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       ) : null}
       <div className="relative h-full min-h-0 w-full">
         <Map
-          key={`deployment-map-${vehicleName ?? 'unknown'}`}
+          key={stableMapKey.current}
           ref={mapRef}
           className="h-full min-h-0 w-full"
           maxZoom={MAP_MAX_ZOOM}

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -1,4 +1,5 @@
 import dynamic from 'next/dynamic'
+import { useRouter } from 'next/router'
 import React, { useCallback, useState, useRef, useEffect, useMemo } from 'react'
 import { useManagedWaypoints } from '@mbari/react-ui'
 import useGoogleElevator from '../lib/useGoogleElevator'
@@ -95,6 +96,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   startTime,
   endTime,
 }) => {
+  const router = useRouter()
   const mapRef = useRef<any>(null)
   const {
     updatedWaypoints,
@@ -653,7 +655,11 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       ) : null}
       <div className="relative h-full min-h-0 w-full">
         <Map
-          key={`deployment-map-${vehicleName ?? 'unknown'}`}
+          key={`deployment-map-${
+            (router.query?.deployment as string[] | undefined)?.join('/') ??
+            vehicleName ??
+            'unknown'
+          }`}
           ref={mapRef}
           className="h-full min-h-0 w-full"
           maxZoom={MAP_MAX_ZOOM}

--- a/apps/lrauv-dash2/components/VehiclePath.tsx
+++ b/apps/lrauv-dash2/components/VehiclePath.tsx
@@ -21,7 +21,8 @@ import {
 const getDistance = (a: VPosDetail, b: LatLng) =>
   distance([a.longitude, a.latitude], [b.lng, b.lat])
 
-// VehiclePoint component
+// VehiclePoint component — uses CircleMarker (pixel radius) so dots stay
+// the same visual size regardless of zoom level.
 const VehiclePoint: React.FC<{
   position: [number, number]
   color: string
@@ -33,13 +34,13 @@ const VehiclePoint: React.FC<{
 }> = ({
   position,
   color,
-  radius = 10,
+  radius = 4,
   opacity = 1,
   fillOpacity = 1,
   eventHandlers,
   children,
 }) => (
-  <Circle
+  <CircleMarker
     center={{ lat: position[0], lng: position[1] }}
     pathOptions={{ color, opacity }}
     fillColor={color}
@@ -48,7 +49,7 @@ const VehiclePoint: React.FC<{
     eventHandlers={eventHandlers}
   >
     {children}
-  </Circle>
+  </CircleMarker>
 )
 
 // Memoized hit-circle layer so it never re-renders when VehiclePath state
@@ -72,13 +73,13 @@ const HitCircles = React.memo(
   }) => (
     <>
       {route.map((r, index) => (
-        <Circle
+        <CircleMarker
           key={`${name}:${
             grouped ? 'overview' : 'detail'
           }:touch:${index}:${r.join()}`}
           center={{ lat: r[0], lng: r[1] }}
           fillColor={color}
-          radius={200}
+          radius={18}
           fillOpacity={0}
           color={color}
           opacity={0}
@@ -599,7 +600,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
       {/* Scrub indicator dot — shown for any scrub source (depth chart, timeline)
           unless the map-hover highlight is already visible at that position */}
       {indicatorCoord && mapHoverFix?.unixTime !== indicatorCoord.unixTime && (
-        <Circle
+        <CircleMarker
           center={{
             lat: indicatorCoord.latitude,
             lng: indicatorCoord.longitude,
@@ -611,7 +612,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             fillOpacity: 0.85,
             weight: 2,
           }}
-          radius={40}
+          radius={8}
         />
       )}
       {/* Crumb trail dots — only shown while the timeline bar is being hovered */}
@@ -623,14 +624,14 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             }:preview:${i}:${r.join()}`}
             position={r}
             color={color}
-            radius={10}
+            radius={4}
             opacity={1}
             fillOpacity={1}
           />
         ))}
       {/* Hover highlight — grows at the nearest fix when hovering the map track */}
       {mapHoverFix && (
-        <Circle
+        <CircleMarker
           center={{ lat: mapHoverFix.latitude, lng: mapHoverFix.longitude }}
           interactive={false}
           pathOptions={{
@@ -639,7 +640,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
             fillOpacity: 0.85,
             weight: 2,
           }}
-          radius={60}
+          radius={10}
         >
           <Tooltip permanent direction="right" offset={[10, 0]} opacity={0.95}>
             <div className="text-xs leading-snug">
@@ -671,7 +672,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
               </div>
             </div>
           </Tooltip>
-        </Circle>
+        </CircleMarker>
       )}
       {dedupedInactiveRoute && (
         <Polyline
@@ -681,7 +682,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
       )}
       {dedupedInactiveRoute &&
         dedupedInactiveRoute.map((r, i) => (
-          <Circle
+          <CircleMarker
             key={`${name}:${
               grouped ? 'overview' : 'detail'
             }:inactivePreview:${i}:${r.join()}`}
@@ -690,7 +691,7 @@ const VehiclePath: React.FC<VehiclePathProps> = ({
               lng: r[1],
             }}
             fillColor={color}
-            radius={10}
+            radius={4}
             fillOpacity={0.5}
             color={color}
             opacity={0.5}


### PR DESCRIPTION
## Summary

- Trackline hover circles (and related markers) were using Leaflet's `Circle` component, which takes a radius in **geographic metres**. At high zoom levels these circles became enormous on screen.
- Converted all non-geographic circles in `VehiclePath.tsx` to `CircleMarker` (pixel-based radius) so they stay a consistent visual size at any zoom level.

| Element | Before | After |
|---|---|---|
| Hover highlight | `Circle` 60 m | `CircleMarker` 10 px |
| Hit targets (invisible) | `Circle` 200 m | `CircleMarker` 18 px |
| Scrub indicator | `Circle` 40 m | `CircleMarker` 8 px |
| Crumb trail dots | `Circle` 10 m | `CircleMarker` 4 px |
| Inactive preview dots | `Circle` 10 m | `CircleMarker` 4 px |
| Future waypoint rings | `Circle` 20 m | unchanged (geographic intent) |

## Test plan

- [ ] Hover over a vehicle trackline at low zoom — tooltip and highlight appear correctly
- [ ] Zoom in close and hover — circles remain the same pixel size, not enormous
- [ ] Scrub the timeline bar — crumb trail dots appear at consistent size
- [ ] Future waypoint rings still visually indicate the planned waypoint area