### PR TITLE
fix: prevent Leaflet zoom crash with stable window.location.pathname map key

### DIFF
--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -95,15 +95,16 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   startTime,
   endTime,
 }) => {
-  // Compute the Leaflet MapContainer key once on first client render using the
-  // URL pathname (no query string). window.location is available immediately —
-  // unlike router.query or vehicleName, it is never undefined mid-hydration —
-  // so the key never flips and the map is never unmounted mid-zoom-animation.
-  const stableMapKey = useRef(
+  // Derive the Leaflet MapContainer key from window.location.pathname (no
+  // query string) at render time. window.location is available immediately on
+  // the client — unlike router.query or vehicleName it is never undefined
+  // mid-hydration — so the key stays stable across query-string changes
+  // (preventing mid-zoom remounts) while still updating on real
+  // vehicle/deployment path changes (allowing the map to remount correctly).
+  const mapKey =
     typeof window !== 'undefined'
       ? `deployment-map-${window.location.pathname}`
       : `deployment-map-unknown`
-  )
 
   const mapRef = useRef<any>(null)
   const {
@@ -663,7 +664,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       ) : null}
       <div className="relative h-full min-h-0 w-full">
         <Map
-          key={stableMapKey.current}
+          key={mapKey}
           ref={mapRef}
           className="h-full min-h-0 w-full"
           maxZoom={MAP_MAX_ZOOM}

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -1,5 +1,4 @@
 import dynamic from 'next/dynamic'
-import { useRouter } from 'next/router'
 import React, { useCallback, useState, useRef, useEffect, useMemo } from 'react'
 import { useManagedWaypoints } from '@mbari/react-ui'
 import useGoogleElevator from '../lib/useGoogleElevator'
@@ -96,7 +95,6 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   startTime,
   endTime,
 }) => {
-  const router = useRouter()
   const mapRef = useRef<any>(null)
   const {
     updatedWaypoints,
@@ -655,11 +653,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       ) : null}
       <div className="relative h-full min-h-0 w-full">
         <Map
-          key={`deployment-map-${
-            (router.query?.deployment as string[] | undefined)?.join('/') ??
-            vehicleName ??
-            'unknown'
-          }`}
+          key={`deployment-map-${vehicleName ?? 'unknown'}`}
           ref={mapRef}
           className="h-full min-h-0 w-full"
           maxZoom={MAP_MAX_ZOOM}

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -96,11 +96,11 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   endTime,
 }) => {
   // Derive the Leaflet MapContainer key from window.location.pathname (no
-  // query string) at render time. window.location is available immediately on
-  // the client — unlike router.query or vehicleName it is never undefined
-  // mid-hydration — so the key stays stable across query-string changes
-  // (preventing mid-zoom remounts) while still updating on real
-  // vehicle/deployment path changes (allowing the map to remount correctly).
+  // query string) at render time. Unlike router.query route params, which are
+  // undefined before router.isReady, window.location.pathname is available
+  // immediately on the client. This keeps the key stable across query-string
+  // changes (time window, logset — preventing mid-zoom-animation remounts)
+  // while still updating on real path changes (vehicle/deployment navigation).
   const mapKey =
     typeof window !== 'undefined'
       ? `deployment-map-${window.location.pathname}`

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -95,6 +95,16 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   startTime,
   endTime,
 }) => {
+  // Compute the Leaflet MapContainer key once on first client render using the
+  // URL pathname (no query string). window.location is available immediately —
+  // unlike router.query or vehicleName, it is never undefined mid-hydration —
+  // so the key never flips and the map is never unmounted mid-zoom-animation.
+  const stableMapKey = useRef(
+    typeof window !== 'undefined'
+      ? `deployment-map-${window.location.pathname}`
+      : `deployment-map-unknown`
+  )
+
   const mapRef = useRef<any>(null)
   const {
     updatedWaypoints,
@@ -653,7 +663,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
       ) : null}
       <div className="relative h-full min-h-0 w-full">
         <Map
-          key={`deployment-map-${vehicleName ?? 'unknown'}`}
+          key={stableMapKey.current}
           ref={mapRef}
           className="h-full min-h-0 w-full"
           maxZoom={MAP_MAX_ZOOM}


### PR DESCRIPTION
## Summary

Eliminates the remaining edge-case Leaflet zoom crash by deriving the \`MapContainer\` key from \`window.location.pathname\` instead of Next.js router params.

**Root cause:** The previous key (\`router.query.deployment.join('/')\`) is \`undefined\` before \`router.isReady\`, so the map initially rendered with key \`'unknown'\`, then remounted once the router hydrated — potentially mid-zoom-animation, causing the crash.

**Fix:** Compute \`mapKey\` from \`window.location.pathname\` (no query string) at render time:

- **No hydration race** — \`window.location.pathname\` is available immediately on the client; it never goes through an undefined intermediate state like route params do
- **Stable** across query-string changes (\`?logsetId=\`, \`?timeWindow=\`) — no remount, no crash
- **Updates** on real path changes (\`/vehicle/triton/...\` → \`/vehicle/brizo/...\`) — map remounts correctly for new vehicle or deployment

Also removes the now-unused \`useRouter\` import and hook call from \`DeploymentMap.tsx\`.

## Test plan

- [ ] Load a vehicle deployment page and zoom the map rapidly — no crash
- [ ] Change time window or logset filter — map does NOT remount (key is stable)
- [ ] Navigate to a different vehicle — map remounts correctly (pathname changes)
- [ ] Navigate between two deployments of the same vehicle — map remounts (pathname changes)