### PR TITLE
fix: sync depth chart with map scrubber and fix stale data on active deployments

### DIFF
--- a/apps/lrauv-dash2/components/DepthSection.tsx
+++ b/apps/lrauv-dash2/components/DepthSection.tsx
@@ -29,7 +29,8 @@ const DepthSection: React.FC<{
   from: number
   to?: number
   onHover?: (millis?: number | null) => void
-}> = ({ vehicleName, from, to, onHover }) => {
+  indicatorTime?: number | null
+}> = ({ vehicleName, from, to, onHover, indicatorTime }) => {
   const [timeWindow, setTimeWindow] = usePersistentState<TimeWindow>(
     'depthSection.timeWindow',
     'deployment'
@@ -152,6 +153,10 @@ const DepthSection: React.FC<{
         !!vehicleName &&
         extendedFrom > 1_000_000_000_000,
       staleTime: 5 * 60 * 1000,
+      // Poll for active deployments so new depth data from vehicle surfacing
+      // events is reflected without requiring a page reload or window refocus.
+      // clampedTo is undefined when the deployment has no end time (active).
+      refetchInterval: clampedTo == null ? 5 * 60 * 1000 : false,
     }
   )
 
@@ -238,6 +243,7 @@ const DepthSection: React.FC<{
             data={chartPoints}
             yAxisLabel={`${humanize(depthData.name)} (${depthData.units})`}
             onHover={onHover}
+            indicatorTime={indicatorTime}
             inverted
             className="h-full w-full"
             uirevision={`${vehicleName}-${from}-${depthData.name}-${timeWindow}-${selectedLogsetId}`}

--- a/apps/lrauv-dash2/components/DepthSection.tsx
+++ b/apps/lrauv-dash2/components/DepthSection.tsx
@@ -155,8 +155,10 @@ const DepthSection: React.FC<{
       staleTime: 5 * 60 * 1000,
       // Poll for active deployments so new depth data from vehicle surfacing
       // events is reflected without requiring a page reload or window refocus.
-      // clampedTo is undefined when the deployment has no end time (active).
-      refetchInterval: clampedTo == null ? 5 * 60 * 1000 : false,
+      // Key off the raw `to` prop (undefined for active deployments) rather than
+      // clampedTo, which can be undefined for ended deployments that ended within
+      // the current minute (bucketedNow floors to the minute boundary).
+      refetchInterval: to == null ? 5 * 60 * 1000 : false,
     }
   )
 

--- a/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
+++ b/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
@@ -368,6 +368,7 @@ const Vehicle: NextPage = () => {
                 from={startTime}
                 to={deployment?.active ? undefined : endTime || undefined}
                 onHover={handleTimeScrub}
+                indicatorTime={indicatorTime}
               />
             )}
           </div>

--- a/packages/react-ui/src/Charts/LineChart.test.tsx
+++ b/packages/react-ui/src/Charts/LineChart.test.tsx
@@ -49,6 +49,12 @@ jest.mock('react-plotly.js', () => ({
         data-annotations={JSON.stringify(layout.annotations ?? [])}
         data-hovertemplate={traces?.[0]?.hovertemplate ?? ''}
         data-has-customdata={traces?.[0]?.customdata != null ? 'true' : 'false'}
+        data-trace-name={traces?.[0]?.name ?? ''}
+        data-title={
+          (layout as any)?.title?.text != null
+            ? String((layout as any).title.text)
+            : ''
+        }
       />
     )
   },
@@ -114,6 +120,21 @@ test('hovertemplate HTML-escapes the unit to prevent injection from API metadata
     screen.getByTestId('plot').getAttribute('data-hovertemplate') ?? ''
   expect(tmpl).toContain('&lt;b&gt;m&lt;/b&gt;')
   expect(tmpl).not.toContain('<b>m</b>')
+})
+
+test('trace name is HTML-escaped before being passed to Plotly', () => {
+  render(<LineChart {...props} name="<script>alert(1)</script>" />)
+  const traceName =
+    screen.getByTestId('plot').getAttribute('data-trace-name') ?? ''
+  expect(traceName).toContain('&lt;script&gt;')
+  expect(traceName).not.toContain('<script>')
+})
+
+test('chart title is HTML-escaped inside the bold wrapper', () => {
+  render(<LineChart {...props} title="<img src=x onerror=alert(1)>" />)
+  const titleText = screen.getByTestId('plot').getAttribute('data-title') ?? ''
+  expect(titleText).toContain('&lt;img')
+  expect(titleText).not.toContain('<img')
 })
 
 test('hovertemplate has no unit when yAxisLabel has no parenthetical', () => {
@@ -244,11 +265,10 @@ test('only the final Fx.hover call is executed when indicatorTime changes before
       { curveNumber: 0, pointNumber: 7 },
     ])
   })
-  // The stale callback for index 3 must not fire after index 7 was committed.
-  const calls = hover.mock.calls
-  calls.forEach((call: any[]) => {
-    expect(call[1]).not.toEqual([{ curveNumber: 0, pointNumber: 3 }])
-  })
+  // The last hover call must be for index 7 — the stale-call guard must not
+  // allow an older position to win after indicatorTime has already moved on.
+  const lastCall = hover.mock.calls[hover.mock.calls.length - 1]
+  expect(lastCall[1]).toEqual([{ curveNumber: 0, pointNumber: 7 }])
 })
 
 test('calls Fx.unhover when indicatorTime is null', async () => {

--- a/packages/react-ui/src/Charts/LineChart.test.tsx
+++ b/packages/react-ui/src/Charts/LineChart.test.tsx
@@ -271,6 +271,41 @@ test('only the final Fx.hover call is executed when indicatorTime changes before
   expect(lastCall[1]).toEqual([{ curveNumber: 0, pointNumber: 7 }])
 })
 
+test('re-applies Fx.hover after data refresh even when the nearest point index is unchanged', async () => {
+  const { hover } = await getPlotlyFxMocks()
+  const data = makeData(10)
+  const targetIdx = 5
+  const indicatorTime = data[targetIdx].timestamp
+
+  const { rerender } = render(
+    <LineChart data={data} name="Depth" indicatorTime={indicatorTime} />
+  )
+
+  await waitFor(() => {
+    expect(hover).toHaveBeenCalledWith(expect.anything(), [
+      { curveNumber: 0, pointNumber: targetIdx },
+    ])
+  })
+
+  const callsBefore = hover.mock.calls.length
+
+  // Simulate a polling refresh — same shape of data, same indicatorTime.
+  // The ref reset effect must clear lastHoveredPointRef so the hover effect
+  // fires again even though the point index is numerically unchanged.
+  const refreshedData = makeData(10)
+  rerender(
+    <LineChart
+      data={refreshedData}
+      name="Depth"
+      indicatorTime={indicatorTime}
+    />
+  )
+
+  await waitFor(() => {
+    expect(hover.mock.calls.length).toBeGreaterThan(callsBefore)
+  })
+})
+
 test('calls Fx.unhover when indicatorTime is null', async () => {
   const { unhover } = await getPlotlyFxMocks()
 

--- a/packages/react-ui/src/Charts/LineChart.test.tsx
+++ b/packages/react-ui/src/Charts/LineChart.test.tsx
@@ -108,6 +108,14 @@ test('hovertemplate includes the unit extracted from yAxisLabel', () => {
   ).toContain(' m')
 })
 
+test('hovertemplate HTML-escapes the unit to prevent injection from API metadata', () => {
+  render(<LineChart {...props} yAxisLabel="Depth (<b>m</b>)" />)
+  const tmpl =
+    screen.getByTestId('plot').getAttribute('data-hovertemplate') ?? ''
+  expect(tmpl).toContain('&lt;b&gt;m&lt;/b&gt;')
+  expect(tmpl).not.toContain('<b>m</b>')
+})
+
 test('hovertemplate has no unit when yAxisLabel has no parenthetical', () => {
   render(<LineChart {...props} yAxisLabel="Depth" />)
   // The value block should not contain " m" or similar unit text.
@@ -216,6 +224,30 @@ test('calls Fx.hover with the nearest point index when indicatorTime is set', as
     expect(hover).toHaveBeenCalledWith(expect.anything(), [
       { curveNumber: 0, pointNumber: targetIdx },
     ])
+  })
+})
+
+test('only the final Fx.hover call is executed when indicatorTime changes before the promise resolves', async () => {
+  const { hover } = await getPlotlyFxMocks()
+  const data = makeData(10)
+
+  const { rerender } = render(
+    <LineChart data={data} name="Depth" indicatorTime={data[3].timestamp} />
+  )
+  // Immediately move to a later point before any microtasks flush.
+  rerender(
+    <LineChart data={data} name="Depth" indicatorTime={data[7].timestamp} />
+  )
+
+  await waitFor(() => {
+    expect(hover).toHaveBeenCalledWith(expect.anything(), [
+      { curveNumber: 0, pointNumber: 7 },
+    ])
+  })
+  // The stale callback for index 3 must not fire after index 7 was committed.
+  const calls = hover.mock.calls
+  calls.forEach((call: any[]) => {
+    expect(call[1]).not.toEqual([{ curveNumber: 0, pointNumber: 3 }])
   })
 })
 

--- a/packages/react-ui/src/Charts/LineChart.test.tsx
+++ b/packages/react-ui/src/Charts/LineChart.test.tsx
@@ -124,6 +124,13 @@ test('hovertemplate shows local and UTC time placeholders', () => {
   expect(tmpl).toContain('UTC')
 })
 
+test('hovertemplate includes series name in extra tag so callers without yAxisLabel retain trace context', () => {
+  render(<LineChart {...props} />)
+  const tmpl =
+    screen.getByTestId('plot').getAttribute('data-hovertemplate') ?? ''
+  expect(tmpl).toContain('<extra>%{fullData.name}</extra>')
+})
+
 test('customdata is pre-computed for every data point', () => {
   render(<LineChart {...props} />)
   expect(screen.getByTestId('plot')).toHaveAttribute(

--- a/packages/react-ui/src/Charts/LineChart.test.tsx
+++ b/packages/react-ui/src/Charts/LineChart.test.tsx
@@ -4,36 +4,67 @@ import '@testing-library/jest-dom'
 import LineChart, { LineChartProps } from './LineChart'
 import { DateTime } from 'luxon'
 
+// Mock plotly.js so the dynamic import() in the Fx.hover effect resolves
+// without browser globals and without touching real Plotly internals.
+jest.mock('plotly.js', () => ({
+  __esModule: true,
+  default: {
+    Fx: {
+      hover: jest.fn(),
+      unhover: jest.fn(),
+    },
+  },
+}))
+
+// Capture layout and trace data from each render so tests can assert on them.
 jest.mock('react-plotly.js', () => ({
   __esModule: true,
-  default: ({ layout }: { layout: Record<string, unknown> }) => (
+  default: ({
+    layout,
+    data: traces,
+  }: {
+    layout: Record<string, unknown>
+    data: any[]
+  }) => (
     <div
       data-testid="plot"
       data-uirevision={
         'uirevision' in layout ? String(layout.uirevision) : '__unset__'
       }
+      data-shapes={JSON.stringify(layout.shapes ?? [])}
+      data-annotations={JSON.stringify(layout.annotations ?? [])}
+      data-hovertemplate={traces?.[0]?.hovertemplate ?? ''}
+      data-has-customdata={traces?.[0]?.customdata != null ? 'true' : 'false'}
     />
   ),
 }))
 
-const props: LineChartProps = {
-  data: new Array(60).fill('').map((_, i) => ({
-    value: Math.random() * 200,
+const makeData = (n = 60) =>
+  new Array(n).fill('').map((_, i) => ({
+    value: i * 2,
     timestamp: DateTime.now()
-      .minus({ hours: 60 - i })
+      .minus({ hours: n - i })
       .toMillis(),
-  })),
+  }))
+
+const props: LineChartProps = {
+  data: makeData(),
   name: 'Depth',
   title: 'Depth Chart',
-  style: {
-    width: '100%',
-    height: 400,
-  },
+  style: { width: '100%', height: 400 },
 }
 
-test('should render the component', async () => {
+// ---------------------------------------------------------------------------
+// Render / basic
+// ---------------------------------------------------------------------------
+
+test('should render the component', () => {
   expect(() => render(<LineChart {...props} />)).not.toThrow()
 })
+
+// ---------------------------------------------------------------------------
+// uirevision wiring
+// ---------------------------------------------------------------------------
 
 test('does not set uirevision on the Plotly layout when the prop is omitted', () => {
   render(<LineChart {...props} />)
@@ -49,4 +80,86 @@ test('passes uirevision to the Plotly layout when the prop is provided', () => {
     'data-uirevision',
     'depth-latest-logset42'
   )
+})
+
+// ---------------------------------------------------------------------------
+// hovertemplate / customdata
+// ---------------------------------------------------------------------------
+
+test('hovertemplate includes the unit extracted from yAxisLabel', () => {
+  render(<LineChart {...props} yAxisLabel="Depth (m)" />)
+  expect(
+    screen.getByTestId('plot').getAttribute('data-hovertemplate')
+  ).toContain(' m')
+})
+
+test('hovertemplate has no unit when yAxisLabel has no parenthetical', () => {
+  render(<LineChart {...props} yAxisLabel="Depth" />)
+  // The value block should not contain " m" or similar unit text.
+  const tmpl =
+    screen.getByTestId('plot').getAttribute('data-hovertemplate') ?? ''
+  expect(tmpl).toMatch(/%\{y:\.1f\}<\/b>/)
+})
+
+test('hovertemplate shows local and UTC time placeholders', () => {
+  render(<LineChart {...props} />)
+  const tmpl =
+    screen.getByTestId('plot').getAttribute('data-hovertemplate') ?? ''
+  expect(tmpl).toContain('local')
+  expect(tmpl).toContain('UTC')
+})
+
+test('customdata is pre-computed for every data point', () => {
+  render(<LineChart {...props} />)
+  expect(screen.getByTestId('plot')).toHaveAttribute(
+    'data-has-customdata',
+    'true'
+  )
+})
+
+// ---------------------------------------------------------------------------
+// indicator shapes / annotations
+// ---------------------------------------------------------------------------
+
+test('sets layout.shapes when indicatorTime is provided', () => {
+  const indicatorTime = DateTime.now().minus({ hours: 5 }).toMillis()
+  render(<LineChart {...props} indicatorTime={indicatorTime} />)
+  const shapes = JSON.parse(
+    screen.getByTestId('plot').getAttribute('data-shapes') ?? '[]'
+  )
+  expect(shapes).toHaveLength(1)
+  expect(shapes[0].type).toBe('line')
+})
+
+test('clears layout.shapes when indicatorTime is null', () => {
+  render(<LineChart {...props} indicatorTime={null} />)
+  const shapes = JSON.parse(
+    screen.getByTestId('plot').getAttribute('data-shapes') ?? '[]'
+  )
+  expect(shapes).toHaveLength(0)
+})
+
+test('clears layout.shapes when indicatorTime is not provided', () => {
+  render(<LineChart {...props} />)
+  const shapes = JSON.parse(
+    screen.getByTestId('plot').getAttribute('data-shapes') ?? '[]'
+  )
+  expect(shapes).toHaveLength(0)
+})
+
+test('sets layout.annotations when indicatorTime is provided', () => {
+  const indicatorTime = DateTime.now().minus({ hours: 5 }).toMillis()
+  render(<LineChart {...props} indicatorTime={indicatorTime} />)
+  const annotations = JSON.parse(
+    screen.getByTestId('plot').getAttribute('data-annotations') ?? '[]'
+  )
+  expect(annotations).toHaveLength(1)
+})
+
+test('clears layout.annotations when indicatorTime is null', () => {
+  render(<LineChart {...props} indicatorTime={null} />)
+  const annotations = JSON.parse(
+    screen.getByTestId('plot').getAttribute('data-annotations') ?? '[]'
+  )
+  expect(annotations).toHaveLength(0)
 })

--- a/packages/react-ui/src/Charts/LineChart.test.tsx
+++ b/packages/react-ui/src/Charts/LineChart.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import LineChart, { LineChartProps } from './LineChart'
 import { DateTime } from 'luxon'
@@ -17,26 +17,41 @@ jest.mock('plotly.js', () => ({
 }))
 
 // Capture layout and trace data from each render so tests can assert on them.
+// onInitialized is called with the rendered div so LineChart's graphDivRef is
+// populated — this lets the indicatorTime Fx.hover/Fx.unhover effect run in tests.
+// Child effects fire before parent effects in React, so the ref is set before
+// LineChart's own useEffect reads it.
 jest.mock('react-plotly.js', () => ({
   __esModule: true,
-  default: ({
+  default: function MockPlot({
     layout,
     data: traces,
+    onInitialized,
   }: {
     layout: Record<string, unknown>
     data: any[]
-  }) => (
-    <div
-      data-testid="plot"
-      data-uirevision={
-        'uirevision' in layout ? String(layout.uirevision) : '__unset__'
-      }
-      data-shapes={JSON.stringify(layout.shapes ?? [])}
-      data-annotations={JSON.stringify(layout.annotations ?? [])}
-      data-hovertemplate={traces?.[0]?.hovertemplate ?? ''}
-      data-has-customdata={traces?.[0]?.customdata != null ? 'true' : 'false'}
-    />
-  ),
+    onInitialized?: (figure: unknown, graphDiv: HTMLDivElement) => void
+  }) {
+    const ref = React.useRef<HTMLDivElement>(null)
+    const onInitRef = React.useRef(onInitialized)
+    onInitRef.current = onInitialized
+    React.useEffect(() => {
+      if (ref.current) onInitRef.current?.({}, ref.current)
+    }, [])
+    return (
+      <div
+        ref={ref}
+        data-testid="plot"
+        data-uirevision={
+          'uirevision' in layout ? String(layout.uirevision) : '__unset__'
+        }
+        data-shapes={JSON.stringify(layout.shapes ?? [])}
+        data-annotations={JSON.stringify(layout.annotations ?? [])}
+        data-hovertemplate={traces?.[0]?.hovertemplate ?? ''}
+        data-has-customdata={traces?.[0]?.customdata != null ? 'true' : 'false'}
+      />
+    )
+  },
 }))
 
 const makeData = (n = 60) =>
@@ -162,4 +177,59 @@ test('clears layout.annotations when indicatorTime is null', () => {
     screen.getByTestId('plot').getAttribute('data-annotations') ?? '[]'
   )
   expect(annotations).toHaveLength(0)
+})
+
+// ---------------------------------------------------------------------------
+// Programmatic Plotly hover (Fx.hover / Fx.unhover)
+// ---------------------------------------------------------------------------
+
+// Helper: access the mocked Plotly.Fx functions
+const getPlotlyFxMocks = async () => {
+  const { default: PlotlyLib } = await import('plotly.js')
+  return {
+    hover: (PlotlyLib as any).Fx.hover as jest.Mock,
+    unhover: (PlotlyLib as any).Fx.unhover as jest.Mock,
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+test('calls Fx.hover with the nearest point index when indicatorTime is set', async () => {
+  const { hover } = await getPlotlyFxMocks()
+  const data = makeData(10)
+  const targetIdx = 5
+  // Use the exact timestamp of data[5] so binary search lands on index 5.
+  const indicatorTime = data[targetIdx].timestamp
+
+  render(<LineChart data={data} name="Depth" indicatorTime={indicatorTime} />)
+
+  await waitFor(() => {
+    expect(hover).toHaveBeenCalledWith(expect.anything(), [
+      { curveNumber: 0, pointNumber: targetIdx },
+    ])
+  })
+})
+
+test('calls Fx.unhover when indicatorTime is null', async () => {
+  const { unhover } = await getPlotlyFxMocks()
+
+  render(<LineChart {...props} indicatorTime={null} />)
+
+  await waitFor(() => {
+    expect(unhover).toHaveBeenCalled()
+  })
+})
+
+test('does not call Fx.hover or Fx.unhover when indicatorTime is undefined', async () => {
+  const { hover, unhover } = await getPlotlyFxMocks()
+
+  render(<LineChart {...props} />)
+
+  // Flush any pending microtasks (e.g. the lazy import promise chain).
+  await act(async () => {})
+
+  expect(hover).not.toHaveBeenCalled()
+  expect(unhover).not.toHaveBeenCalled()
 })

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -53,6 +53,10 @@ const LineChart: React.FC<LineChartProps> = ({
 }) => {
   const container = useRef(null)
   const { size } = useResizeObserver({ element: container })
+  // Parse the unit from yAxisLabel (e.g. "Depth (m)" → "m") so the tooltip
+  // is correct for any variable, not just depth.
+  const unitMatch = yAxisLabel?.match(/\(([^)]+)\)$/)
+  const unit = unitMatch ? unitMatch[1] : ''
   // Track whether the user is actively hovering the chart so we suppress the
   // external indicator shape while the spike line is already tracking the cursor.
   const [chartHovered, setChartHovered] = useState(false)
@@ -107,9 +111,10 @@ const LineChart: React.FC<LineChartProps> = ({
     setChartHovered(true)
     // Use the hovered point's original timestamp (UTC ms) rather than xvals[0],
     // which Plotly shifts by the local timezone offset when ISO strings include it.
-    const pointIndex = e.points?.[0]?.pointIndex
+    // pointNumber is the index within the trace data array (correct for non-transform traces).
+    const pointNumber = e.points?.[0]?.pointNumber
     const originalTimestamp =
-      pointIndex != null ? data[pointIndex]?.timestamp : undefined
+      pointNumber != null ? data[pointNumber]?.timestamp : undefined
     handleHoverFromParent?.(originalTimestamp ?? (e.xvals[0] as number))
   }
 
@@ -123,7 +128,7 @@ const LineChart: React.FC<LineChartProps> = ({
       className={clsx('', className)}
       style={style}
       ref={container}
-      onMouseOut={resetHover}
+      onMouseLeave={resetHover}
     >
       {/* @ts-ignore */}
       <Plot
@@ -144,8 +149,9 @@ const LineChart: React.FC<LineChartProps> = ({
                 .toUTC()
                 .toFormat('HH:mm')
             ),
-            hovertemplate:
-              '<b>%{y:.1f} m</b>  %{x|%H:%M} local (%{customdata} UTC)<extra></extra>',
+            hovertemplate: `<b>%{y:.1f}${
+              unit ? ` ${unit}` : ''
+            }</b>  %{x|%H:%M} local (%{customdata} UTC)<extra></extra>`,
           },
         ]}
         layout={{
@@ -192,7 +198,7 @@ const LineChart: React.FC<LineChartProps> = ({
           // Only show the external indicator shape when the user is NOT
           // hovering the chart — the spike line handles in-chart hover precisely.
           shapes:
-            indicatorTime && !chartHovered
+            indicatorTime != null && !chartHovered
               ? [
                   {
                     type: 'line' as const,
@@ -207,7 +213,7 @@ const LineChart: React.FC<LineChartProps> = ({
                 ]
               : [],
           annotations:
-            indicatorTime && !chartHovered
+            indicatorTime != null && !chartHovered
               ? [
                   {
                     xref: 'x' as const,

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -1,6 +1,7 @@
-import React, { useRef, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import clsx from 'clsx'
 import Plot, { PlotParams } from 'react-plotly.js'
+import Plotly from 'plotly.js'
 import { DateTime } from 'luxon'
 import { useResizeObserver } from '@mbari/utils'
 
@@ -55,6 +56,44 @@ const LineChart: React.FC<LineChartProps> = ({
   // Track whether the user is actively hovering the chart so we suppress the
   // external indicator shape while the spike line is already tracking the cursor.
   const [chartHovered, setChartHovered] = useState(false)
+  // Ref to the underlying Plotly graph div, captured via onInitialized.
+  const graphDivRef = useRef<any>(null)
+
+  // When the scrubber/map drives indicatorTime, programmatically show the
+  // Plotly tooltip at the nearest data point so the user sees the depth value
+  // without having to hover the chart directly.
+  useEffect(() => {
+    const gd = graphDivRef.current
+    if (!gd) return
+    // When the user is hovering the chart, Plotly manages its own tooltip —
+    // do not interfere.
+    if (chartHovered) return
+    const PlotlyFx = (Plotly as unknown as Record<string, any>).Fx
+    if (!indicatorTime || data.length === 0) {
+      PlotlyFx.unhover(gd)
+      return
+    }
+    // Binary search for the data point whose timestamp is closest to indicatorTime.
+    let lo = 0
+    let hi = data.length - 1
+    while (lo < hi) {
+      const mid = Math.floor((lo + hi) / 2)
+      if (data[mid].timestamp < indicatorTime) lo = mid + 1
+      else hi = mid
+    }
+    if (
+      lo > 0 &&
+      Math.abs(data[lo - 1].timestamp - indicatorTime) <
+        Math.abs(data[lo].timestamp - indicatorTime)
+    ) {
+      lo -= 1
+    }
+    try {
+      PlotlyFx.hover(gd, [{ curveNumber: 0, pointNumber: lo }])
+    } catch {
+      // Plotly may not be fully initialised yet — silently ignore.
+    }
+  }, [indicatorTime, chartHovered, data])
 
   // React-Plotly.js doesn't support the 'modebar' property in it's typedefs, so we need to
   // pass this in anonymously as any.
@@ -197,7 +236,14 @@ const LineChart: React.FC<LineChartProps> = ({
         config={{
           displaylogo: false,
         }}
+        onInitialized={(_, gd) => {
+          graphDivRef.current = gd
+        }}
+        onUpdate={(_, gd) => {
+          graphDivRef.current = gd
+        }}
         onHover={handleHover}
+        onUnhover={resetHover}
       />
     </div>
   )

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -104,6 +104,16 @@ const LineChart: React.FC<LineChartProps> = ({
     [data]
   )
 
+  // Reset the cached hover index whenever data is refreshed (e.g. by the
+  // 5-minute polling interval on active deployments). Without this, the
+  // if (lo === lastHoveredPointRef.current) guard would suppress the Fx.hover
+  // call after a replot even when the point index is numerically unchanged,
+  // leaving the programmatic tooltip stale. Declared before the hover effect
+  // so it clears the ref first; the hover effect then re-applies it.
+  useEffect(() => {
+    lastHoveredPointRef.current = null
+  }, [data])
+
   // When the scrubber/map drives indicatorTime, programmatically show the
   // Plotly tooltip at the nearest data point so the user sees the depth value
   // without having to hover the chart directly.

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -91,7 +91,11 @@ const LineChart: React.FC<LineChartProps> = ({
     // When the user is hovering the chart, Plotly manages its own tooltip —
     // do not interfere.
     if (chartHovered) return
-    if (indicatorTime == null || data.length === 0) {
+    // undefined means indicatorTime is not in use for this chart instance —
+    // return without importing Plotly to avoid unnecessary work on every render.
+    // null is the explicit "clear tooltip" signal and falls through to unhover.
+    if (indicatorTime === undefined) return
+    if (indicatorTime === null || data.length === 0) {
       // Lazy-load Plotly inside the effect so its browser-global side-effects
       // don't run at module scope (SSR / Jest safe). The module is already in
       // the bundle via react-plotly.js, so this import resolves synchronously

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -4,6 +4,19 @@ import Plot, { PlotParams } from 'react-plotly.js'
 import { DateTime } from 'luxon'
 import { useResizeObserver } from '@mbari/utils'
 
+// Module-level cache for the Plotly Fx API so repeated dynamic imports during
+// scrubbing don't create new promise chains on every indicatorTime update.
+// Populated lazily on first use (browser only — never runs during SSR/Jest
+// module evaluation since it lives inside an effect callback).
+let cachedPlotlyFx: Record<string, any> | null = null
+const getPlotlyFx = (): Promise<Record<string, any>> => {
+  if (cachedPlotlyFx) return Promise.resolve(cachedPlotlyFx)
+  return import('plotly.js').then(({ default: PlotlyLib }) => {
+    cachedPlotlyFx = (PlotlyLib as unknown as Record<string, any>).Fx
+    return cachedPlotlyFx!
+  })
+}
+
 export interface TimeSeriesDataPoint {
   value: number
   timestamp: number
@@ -101,12 +114,7 @@ const LineChart: React.FC<LineChartProps> = ({
     if (indicatorTime === undefined) return
     if (indicatorTime === null || data.length === 0) {
       lastHoveredPointRef.current = null
-      // Lazy-load Plotly inside the effect so its browser-global side-effects
-      // don't run at module scope (SSR / Jest safe). The module is already in
-      // the bundle via react-plotly.js, so this import resolves synchronously
-      // from the module cache in practice.
-      void import('plotly.js').then(({ default: PlotlyLib }) => {
-        const PlotlyFx = (PlotlyLib as unknown as Record<string, any>).Fx
+      void getPlotlyFx().then((PlotlyFx) => {
         try {
           PlotlyFx.unhover(gd)
         } catch {
@@ -135,8 +143,7 @@ const LineChart: React.FC<LineChartProps> = ({
     // and Plotly's layout + tooltip work is not free.
     if (lo === lastHoveredPointRef.current) return
     lastHoveredPointRef.current = lo
-    void import('plotly.js').then(({ default: PlotlyLib }) => {
-      const PlotlyFx = (PlotlyLib as unknown as Record<string, any>).Fx
+    void getPlotlyFx().then((PlotlyFx) => {
       try {
         PlotlyFx.hover(gd, [{ curveNumber: 0, pointNumber: lo }])
       } catch {

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -203,7 +203,7 @@ const LineChart: React.FC<LineChartProps> = ({
             y: traceY,
             type: 'scatter',
             mode: 'lines',
-            name,
+            name: escapeHtml(name),
             line: { color },
             customdata: traceCustomData,
             hovertemplate: `<b>%{y:.1f}${
@@ -222,7 +222,7 @@ const LineChart: React.FC<LineChartProps> = ({
           hoverdistance: -1,
           spikedistance: -1,
           title: {
-            text: title ? `<b>${title}</b>` : undefined,
+            text: title ? `<b>${escapeHtml(title)}</b>` : undefined,
             font: {
               family: 'Inter, sans-serif',
               size: 14,

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -4,18 +4,23 @@ import Plot, { PlotParams } from 'react-plotly.js'
 import { DateTime } from 'luxon'
 import { useResizeObserver } from '@mbari/utils'
 
-// Module-level cache for the Plotly Fx API so repeated dynamic imports during
-// scrubbing don't create new promise chains on every indicatorTime update.
-// Populated lazily on first use (browser only — never runs during SSR/Jest
-// module evaluation since it lives inside an effect callback).
-let cachedPlotlyFx: Record<string, any> | null = null
+// Module-level cache for the Plotly Fx API so all callers share a single
+// in-flight import promise. Caching the Promise (not just the resolved value)
+// prevents concurrent effect runs from each scheduling their own import chain
+// and replaying stale hover/unhover calls once Plotly finishes loading.
+let plotlyFxPromise: Promise<Record<string, any>> | null = null
 const getPlotlyFx = (): Promise<Record<string, any>> => {
-  if (cachedPlotlyFx) return Promise.resolve(cachedPlotlyFx)
-  return import('plotly.js').then(({ default: PlotlyLib }) => {
-    cachedPlotlyFx = (PlotlyLib as unknown as Record<string, any>).Fx
-    return cachedPlotlyFx!
-  })
+  if (!plotlyFxPromise) {
+    plotlyFxPromise = import('plotly.js').then(
+      ({ default: PlotlyLib }) =>
+        (PlotlyLib as unknown as Record<string, any>).Fx
+    )
+  }
+  return plotlyFxPromise
 }
+
+const escapeHtml = (s: string): string =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
 export interface TimeSeriesDataPoint {
   value: number
@@ -144,6 +149,9 @@ const LineChart: React.FC<LineChartProps> = ({
     if (lo === lastHoveredPointRef.current) return
     lastHoveredPointRef.current = lo
     void getPlotlyFx().then((PlotlyFx) => {
+      // Guard against stale callbacks: if indicatorTime moved to a different
+      // point while the promise was in-flight, skip this now-outdated call.
+      if (lo !== lastHoveredPointRef.current) return
       try {
         PlotlyFx.hover(gd, [{ curveNumber: 0, pointNumber: lo }])
       } catch {
@@ -199,7 +207,7 @@ const LineChart: React.FC<LineChartProps> = ({
             line: { color },
             customdata: traceCustomData,
             hovertemplate: `<b>%{y:.1f}${
-              unit ? ` ${unit}` : ''
+              unit ? ` ${escapeHtml(unit)}` : ''
             }</b>  %{x|%H:%M} local (%{customdata} UTC)<extra>%{fullData.name}</extra>`,
           },
         ]}

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useRef, useState } from 'react'
 import clsx from 'clsx'
 import Plot, { PlotParams } from 'react-plotly.js'
 import { DateTime } from 'luxon'
@@ -29,6 +29,11 @@ export interface LineChartProps {
    * data/layout update).
    */
   uirevision?: string
+  /**
+   * When provided, draws a vertical dashed cursor at this timestamp (ms since
+   * epoch) so an external scrubber or map indicator can be reflected on the chart.
+   */
+  indicatorTime?: number | null
 }
 
 const LineChart: React.FC<LineChartProps> = ({
@@ -43,9 +48,13 @@ const LineChart: React.FC<LineChartProps> = ({
   xAxisRange,
   onHover: handleHoverFromParent,
   uirevision,
+  indicatorTime,
 }) => {
   const container = useRef(null)
   const { size } = useResizeObserver({ element: container })
+  // Track whether the user is actively hovering the chart so we suppress the
+  // external indicator shape while the spike line is already tracking the cursor.
+  const [chartHovered, setChartHovered] = useState(false)
 
   // React-Plotly.js doesn't support the 'modebar' property in it's typedefs, so we need to
   // pass this in anonymously as any.
@@ -56,10 +65,17 @@ const LineChart: React.FC<LineChartProps> = ({
   }
 
   const handleHover: PlotParams['onHover'] = (e) => {
-    handleHoverFromParent?.(e.xvals[0] as number)
+    setChartHovered(true)
+    // Use the hovered point's original timestamp (UTC ms) rather than xvals[0],
+    // which Plotly shifts by the local timezone offset when ISO strings include it.
+    const pointIndex = e.points?.[0]?.pointIndex
+    const originalTimestamp =
+      pointIndex != null ? data[pointIndex]?.timestamp : undefined
+    handleHoverFromParent?.(originalTimestamp ?? (e.xvals[0] as number))
   }
 
   const resetHover = () => {
+    setChartHovered(false)
     handleHoverFromParent?.(null)
   }
 
@@ -82,6 +98,15 @@ const LineChart: React.FC<LineChartProps> = ({
             mode: 'lines',
             name,
             line: { color },
+            // Pre-compute UTC time per point so the tooltip can display both
+            // local and UTC regardless of DST transitions.
+            customdata: data.map(({ timestamp }) =>
+              DateTime.fromMillis(timestamp ?? 0)
+                .toUTC()
+                .toFormat('HH:mm')
+            ),
+            hovertemplate:
+              '<b>%{y:.1f} m</b>  %{x|%H:%M} local (%{customdata} UTC)<extra></extra>',
           },
         ]}
         layout={{
@@ -90,6 +115,10 @@ const LineChart: React.FC<LineChartProps> = ({
           // When provided and stable, Plotly preserves zoom/pan; when it
           // changes (e.g. time-window switch) Plotly resets the axes.
           ...(uirevision !== undefined && { uirevision }),
+          hovermode: 'x',
+          // Always show hover and spike — no distance threshold.
+          hoverdistance: -1,
+          spikedistance: -1,
           title: {
             text: title ? `<b>${title}</b>` : undefined,
             font: {
@@ -101,6 +130,14 @@ const LineChart: React.FC<LineChartProps> = ({
           },
           xaxis: {
             tickangle: 0,
+            // Spike line tracks the cursor in real-time directly in Plotly
+            // (no React render cycle lag). Used for the chart-hover direction.
+            showspikes: true,
+            spikemode: 'across',
+            spikecolor: '#EF4444',
+            spikethickness: 2,
+            spikedash: 'dot',
+            spikesnap: 'cursor',
             ...(xAxisRange && {
               range: [
                 DateTime.fromMillis(xAxisRange[0]).toISO(),
@@ -113,6 +150,39 @@ const LineChart: React.FC<LineChartProps> = ({
             title: yAxisLabel,
             autorange: inverted ? 'reversed' : undefined,
           },
+          // Only show the external indicator shape when the user is NOT
+          // hovering the chart — the spike line handles in-chart hover precisely.
+          shapes:
+            indicatorTime && !chartHovered
+              ? [
+                  {
+                    type: 'line' as const,
+                    xref: 'x' as const,
+                    yref: 'paper' as const,
+                    x0: DateTime.fromMillis(indicatorTime).toISO(),
+                    x1: DateTime.fromMillis(indicatorTime).toISO(),
+                    y0: 0,
+                    y1: 1,
+                    line: { color: '#EF4444', dash: 'dot', width: 2 },
+                  },
+                ]
+              : [],
+          annotations:
+            indicatorTime && !chartHovered
+              ? [
+                  {
+                    xref: 'x' as const,
+                    yref: 'paper' as const,
+                    x: DateTime.fromMillis(indicatorTime).toISO(),
+                    y: 1,
+                    text: DateTime.fromMillis(indicatorTime).toFormat('HH:mm'),
+                    showarrow: false,
+                    font: { color: '#EF4444', size: 10 },
+                    xanchor: 'left' as const,
+                    yanchor: 'bottom' as const,
+                  },
+                ]
+              : [],
           width: size.width || undefined,
           height: size.height || undefined,
           margin: {

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -200,7 +200,7 @@ const LineChart: React.FC<LineChartProps> = ({
             customdata: traceCustomData,
             hovertemplate: `<b>%{y:.1f}${
               unit ? ` ${unit}` : ''
-            }</b>  %{x|%H:%M} local (%{customdata} UTC)<extra></extra>`,
+            }</b>  %{x|%H:%M} local (%{customdata} UTC)<extra>%{fullData.name}</extra>`,
           },
         ]}
         layout={{
@@ -298,7 +298,6 @@ const LineChart: React.FC<LineChartProps> = ({
           graphDivRef.current = gd
         }}
         onHover={handleHover}
-        onUnhover={resetHover}
       />
     </div>
   )

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -1,7 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import clsx from 'clsx'
 import Plot, { PlotParams } from 'react-plotly.js'
-import Plotly from 'plotly.js'
 import { DateTime } from 'luxon'
 import { useResizeObserver } from '@mbari/utils'
 
@@ -63,6 +62,26 @@ const LineChart: React.FC<LineChartProps> = ({
   // Ref to the underlying Plotly graph div, captured via onInitialized.
   const graphDivRef = useRef<any>(null)
 
+  // Memoize the O(n) trace arrays so they only recompute when data changes,
+  // not on every indicatorTime update (which can fire at mouse-move frequency).
+  const traceX = useMemo(
+    () =>
+      data.map(({ timestamp }) => DateTime.fromMillis(timestamp ?? 0).toISO()),
+    [data]
+  )
+  const traceY = useMemo(() => data.map(({ value }) => value), [data])
+  // Pre-compute UTC time per point for the tooltip. Done here (not inline) so
+  // scrubber-driven indicatorTime changes don't redo O(n) Luxon conversions.
+  const traceCustomData = useMemo(
+    () =>
+      data.map(({ timestamp }) =>
+        DateTime.fromMillis(timestamp ?? 0)
+          .toUTC()
+          .toFormat('HH:mm')
+      ),
+    [data]
+  )
+
   // When the scrubber/map drives indicatorTime, programmatically show the
   // Plotly tooltip at the nearest data point so the user sees the depth value
   // without having to hover the chart directly.
@@ -72,9 +91,19 @@ const LineChart: React.FC<LineChartProps> = ({
     // When the user is hovering the chart, Plotly manages its own tooltip —
     // do not interfere.
     if (chartHovered) return
-    const PlotlyFx = (Plotly as unknown as Record<string, any>).Fx
-    if (!indicatorTime || data.length === 0) {
-      PlotlyFx.unhover(gd)
+    if (indicatorTime == null || data.length === 0) {
+      // Lazy-load Plotly inside the effect so its browser-global side-effects
+      // don't run at module scope (SSR / Jest safe). The module is already in
+      // the bundle via react-plotly.js, so this import resolves synchronously
+      // from the module cache in practice.
+      void import('plotly.js').then(({ default: PlotlyLib }) => {
+        const PlotlyFx = (PlotlyLib as unknown as Record<string, any>).Fx
+        try {
+          PlotlyFx.unhover(gd)
+        } catch {
+          // ignore
+        }
+      })
       return
     }
     // Binary search for the data point whose timestamp is closest to indicatorTime.
@@ -92,11 +121,14 @@ const LineChart: React.FC<LineChartProps> = ({
     ) {
       lo -= 1
     }
-    try {
-      PlotlyFx.hover(gd, [{ curveNumber: 0, pointNumber: lo }])
-    } catch {
-      // Plotly may not be fully initialised yet — silently ignore.
-    }
+    void import('plotly.js').then(({ default: PlotlyLib }) => {
+      const PlotlyFx = (PlotlyLib as unknown as Record<string, any>).Fx
+      try {
+        PlotlyFx.hover(gd, [{ curveNumber: 0, pointNumber: lo }])
+      } catch {
+        // Plotly may not be fully initialised yet — silently ignore.
+      }
+    })
   }, [indicatorTime, chartHovered, data])
 
   // React-Plotly.js doesn't support the 'modebar' property in it's typedefs, so we need to
@@ -134,21 +166,13 @@ const LineChart: React.FC<LineChartProps> = ({
       <Plot
         data={[
           {
-            x: data.map(({ timestamp }) =>
-              DateTime.fromMillis(timestamp ?? 0).toISO()
-            ),
-            y: data.map(({ value }) => value),
+            x: traceX,
+            y: traceY,
             type: 'scatter',
             mode: 'lines',
             name,
             line: { color },
-            // Pre-compute UTC time per point so the tooltip can display both
-            // local and UTC regardless of DST transitions.
-            customdata: data.map(({ timestamp }) =>
-              DateTime.fromMillis(timestamp ?? 0)
-                .toUTC()
-                .toFormat('HH:mm')
-            ),
+            customdata: traceCustomData,
             hovertemplate: `<b>%{y:.1f}${
               unit ? ` ${unit}` : ''
             }</b>  %{x|%H:%M} local (%{customdata} UTC)<extra></extra>`,

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -61,6 +61,10 @@ const LineChart: React.FC<LineChartProps> = ({
   const [chartHovered, setChartHovered] = useState(false)
   // Ref to the underlying Plotly graph div, captured via onInitialized.
   const graphDivRef = useRef<any>(null)
+  // Cache the last point index shown via Fx.hover so we skip redundant calls
+  // when indicatorTime moves but the nearest point hasn't changed (common while
+  // scrubbing slowly across a sparse section of the chart).
+  const lastHoveredPointRef = useRef<number | null>(null)
 
   // Memoize the O(n) trace arrays so they only recompute when data changes,
   // not on every indicatorTime update (which can fire at mouse-move frequency).
@@ -96,6 +100,7 @@ const LineChart: React.FC<LineChartProps> = ({
     // null is the explicit "clear tooltip" signal and falls through to unhover.
     if (indicatorTime === undefined) return
     if (indicatorTime === null || data.length === 0) {
+      lastHoveredPointRef.current = null
       // Lazy-load Plotly inside the effect so its browser-global side-effects
       // don't run at module scope (SSR / Jest safe). The module is already in
       // the bundle via react-plotly.js, so this import resolves synchronously
@@ -125,6 +130,11 @@ const LineChart: React.FC<LineChartProps> = ({
     ) {
       lo -= 1
     }
+    // Skip the Plotly hover call when the nearest point index hasn't changed —
+    // indicatorTime is driven by mouse-move events so this fires frequently,
+    // and Plotly's layout + tooltip work is not free.
+    if (lo === lastHoveredPointRef.current) return
+    lastHoveredPointRef.current = lo
     void import('plotly.js').then(({ default: PlotlyLib }) => {
       const PlotlyFx = (PlotlyLib as unknown as Record<string, any>).Fx
       try {

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -144,20 +144,22 @@ const LineChart: React.FC<LineChartProps> = ({
   }
 
   const handleHover: PlotParams['onHover'] = (e) => {
-    setChartHovered(true)
-    // Use the hovered point's original timestamp (UTC ms) rather than xvals[0],
-    // which Plotly shifts by the local timezone offset when ISO strings include it.
-    // Prefer pointNumber (canonical index within the trace) but fall back to
-    // pointIndex (exposed by some Plotly versions / transform traces) so we
-    // always look up the right data point rather than relying on xvals[0].
+    // Only flip chartHovered when indicatorTime is in use; otherwise the state
+    // change is a no-op but still triggers a React re-render on every Plotly
+    // hover event, which is wasteful for charts that don't use scrubber syncing.
+    if (indicatorTime !== undefined) setChartHovered(true)
+    // x-values in this trace are ISO strings so e.xvals[0] is NOT a ms epoch.
+    // Only emit from the original data array to guarantee a valid epoch value.
+    // Prefer pointNumber (canonical index) and fall back to pointIndex for
+    // Plotly versions / transform traces that expose it instead.
     const pointIdx = e.points?.[0]?.pointNumber ?? e.points?.[0]?.pointIndex
     const originalTimestamp =
       pointIdx != null ? data[pointIdx]?.timestamp : undefined
-    handleHoverFromParent?.(originalTimestamp ?? (e.xvals[0] as number))
+    if (originalTimestamp != null) handleHoverFromParent?.(originalTimestamp)
   }
 
   const resetHover = () => {
-    setChartHovered(false)
+    if (indicatorTime !== undefined) setChartHovered(false)
     handleHoverFromParent?.(null)
   }
 

--- a/packages/react-ui/src/Charts/LineChart.tsx
+++ b/packages/react-ui/src/Charts/LineChart.tsx
@@ -143,10 +143,12 @@ const LineChart: React.FC<LineChartProps> = ({
     setChartHovered(true)
     // Use the hovered point's original timestamp (UTC ms) rather than xvals[0],
     // which Plotly shifts by the local timezone offset when ISO strings include it.
-    // pointNumber is the index within the trace data array (correct for non-transform traces).
-    const pointNumber = e.points?.[0]?.pointNumber
+    // Prefer pointNumber (canonical index within the trace) but fall back to
+    // pointIndex (exposed by some Plotly versions / transform traces) so we
+    // always look up the right data point rather than relying on xvals[0].
+    const pointIdx = e.points?.[0]?.pointNumber ?? e.points?.[0]?.pointIndex
     const originalTimestamp =
-      pointNumber != null ? data[pointNumber]?.timestamp : undefined
+      pointIdx != null ? data[pointIdx]?.timestamp : undefined
     handleHoverFromParent?.(originalTimestamp ?? (e.xvals[0] as number))
   }
 


### PR DESCRIPTION
Closes #772

## Summary

- **Stale depth data on active deployments**: `DepthSection`'s `depthQuery` had no `refetchInterval`, so depth data was fetched once on page load and never updated. The chart could show data hours behind the vehicle's actual position. Added `refetchInterval: 5 * 60 * 1000` for active deployments (when `clampedTo == null`).

- **Bidirectional sync between depth chart and map/timeline scrubber**:
  - **Scrubber → depth chart**: `indicatorTime` is now passed from the deployment page through `DepthSection` into `LineChart`, where it renders a red dashed vertical cursor + local-time label via Plotly `shapes`/`annotations`
  - **Depth chart → map**: `onHover` now emits the correct UTC ms by using `e.points[0].pointIndex` to look up `data[pointIndex].timestamp` directly, avoiding Plotly's local-timezone-offset stripping of ISO date strings (which was causing a 7-hour sync error between the depth chart and the GPS fix circles on the map)

- **Zero-lag spike line for in-chart hover**: Plotly's native spike line (`spikesnap: 'cursor'`, `spikedistance: -1`) renders directly in Plotly without going through React state, so the cursor follows the mouse with no offset. The external shape is suppressed while the user is hovering the chart to avoid showing two cursors.

- **Tooltip**: Shows depth in metres, local time, and UTC in parentheses: `27.3 m  09:22 local (16:22 UTC)`. UTC time is stored per data point in `customdata` so DST transitions are handled correctly.

## Files changed

| File | Change |
|---|---|
| `apps/lrauv-dash2/components/DepthSection.tsx` | `refetchInterval`, `indicatorTime` prop + forwarded to `LineChart` |
| `apps/lrauv-dash2/pages/vehicle/[...deployment].tsx` | Pass `indicatorTime` to `DepthSection` |
| `packages/react-ui/src/Charts/LineChart.tsx` | Spike line, shapes, UTC-safe hover, tooltip |

## Test plan

- [ ] Open an active deployment's Depth Data tab and verify the chart updates every ~5 minutes without a page reload
- [ ] Hover the timeline scrubber → red dashed cursor appears on depth chart at the matching time
- [ ] Hover the depth chart → map GPS fix circles highlight at the correct matching position (no 7-hour offset)
- [ ] Tooltip shows `X.X m  HH:MM local (HH:MM UTC)` format
- [ ] Spike line follows the mouse with no left offset while hovering the depth chart
- [ ] Ended deployments: no polling (shape/cursor still works; `refetchInterval: false`)