### PR TITLE
fix: match _vt vehicle-tailored mission files to telemetry mission name

### DIFF
--- a/apps/lrauv-dash2/jest/missionUtils.test.ts
+++ b/apps/lrauv-dash2/jest/missionUtils.test.ts
@@ -84,6 +84,16 @@ describe('normalizeMissionName', () => {
     expect(normalizeMissionName('Long-Range/Default.xml')).toBe('default')
   })
 
+  test('strips _vt vehicle-tailored suffix so it matches telemetry name', () => {
+    expect(normalizeMissionName('Science/profile_station_vt.tl')).toBe(
+      'profile_station'
+    )
+  })
+
+  test('strips _vt suffix when no directory prefix', () => {
+    expect(normalizeMissionName('profile_station_vt')).toBe('profile_station')
+  })
+
   test('returns empty string for undefined', () => {
     expect(normalizeMissionName(undefined)).toBe('')
   })

--- a/apps/lrauv-dash2/lib/missionUtils.ts
+++ b/apps/lrauv-dash2/lib/missionUtils.ts
@@ -3,7 +3,13 @@ export const normalizeMissionName = (missionName?: string): string => {
   const trimmed = missionName.trim()
   if (!trimmed) return ''
   const filename = trimmed.split('/').pop() ?? ''
-  return filename.replace(/\.(xml|tl)$/i, '').toLowerCase()
+  // Strip the MBARI vehicle-tailored suffix (_vt) before comparing so that
+  // a file named "profile_station_vt.tl" matches telemetry that reports
+  // "Started mission profile_station" (the vehicle omits the suffix).
+  return filename
+    .replace(/\.(xml|tl)$/i, '')
+    .replace(/_vt$/i, '')
+    .toLowerCase()
 }
 
 export const normalizeMissionPath = (missionName?: string): string => {


### PR DESCRIPTION
## Summary

- Mission files ending in `_vt` (MBARI "Vehicle Tailored" suffix, e.g. `profile_station_vt.tl`) never matched the vehicle's own mission-started telemetry, which reports the base name without the suffix (`profile_station`).
- Because `normalizeMissionName` compared `profile_station_vt` ≠ `profile_station`, no command row was ever linked to the running mission.
- Dash5 fell back to injecting a **synthetic** row tied to the raw telemetry event (e.g. event 27398292) with a fabricated payload of `load profile_station;run`, which is what operators saw in Mission Details instead of the actual scheduled command and its full parameters.

**Fix:** strip the `_vt` suffix in `normalizeMissionName` so both sides resolve to the same key. The actual operator command (with all `sched` parameters) is now correctly matched and displayed as the running mission row.

## Root cause walkthrough

| Step | Value |
|------|-------|
| Vehicle telemetry text | `"Started mission profile_station"` |
| After `missionNameFromStartedText` | `"profile_station"` |
| File loaded by operator command | `Science/profile_station_vt.tl` |
| After `missionPathFromEventData` | `"science/profile_station_vt"` |
| `normalizeMissionName` comparison (before fix) | `"profile_station_vt"` ≠ `"profile_station"` → **no match** |
| `normalizeMissionName` comparison (after fix) | `"profile_station"` = `"profile_station"` → **match** ✓ |

## Test plan

- [x] `jest/missionUtils.test.ts` — two new tests assert `profile_station_vt.tl` and `profile_station_vt` both normalize to `profile_station`; all 29 tests pass.
- [ ] Load a vehicle page for Makai (or any vehicle running a `_vt`-suffixed mission) and verify the Schedule section shows the actual operator command as the running row, with correct parameters in Mission Details.