### PR TITLE
fix: display vehicle-reported mission ID as schedule row label

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -577,8 +577,14 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
             const missionParamColon = `${currentMissionEntry.name}:`
             const sourceEvent = enriched.find((item) => {
               const d = item.event.data ?? item.event.text ?? ''
+              // Only accept candidates that carry an actual mission file path
+              // (load <file>;run) — a standalone set <missionId>.* param update
+              // would match the prefix check but contains no loadable path and
+              // would produce an empty "Use for new mission" pre-fill.
               return (
-                d.includes(missionParamPrefix) || d.includes(missionParamColon)
+                isMissionCommand(item.event.data, item.event.text) &&
+                (d.includes(missionParamPrefix) ||
+                  d.includes(missionParamColon))
               )
             })
             enriched.unshift({

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -965,20 +965,20 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       )
     }
 
-    const { parameters: missionParams } = parseMissionCommand(
-      mission?.event.data ?? ''
-    )
-    // Display name priority:
+    const { name: parsedMissionName, parameters: missionParams } =
+      parseMissionCommand(mission?.event.data ?? '')
+    // Display name priority (|| so empty strings fall through to the next level):
     // 1. missionId — vehicle-reported mission ID from missionStarted telemetry
     //    (e.g. "keepstation", "follow_that_car"). Most accurate: it's what the
     //    vehicle actually calls the mission, regardless of filename or _vt suffix.
     // 2. missionNameFromEventData — filename without path/extension as a clean
     //    fallback when the row hasn't been matched to a missionStarted event.
-    // 3. parseMissionCommand is kept for parameters and modal pre-fill only.
+    // 3. parsedMissionName from parseMissionCommand — last resort for edge cases
+    //    not covered by missionNameFromEventData (e.g. non-load command formats).
     const missionName =
-      mission?.missionId ??
-      missionNameFromEventData(mission?.event.data) ??
-      undefined
+      mission?.missionId ||
+      missionNameFromEventData(mission?.event.data) ||
+      parsedMissionName
     const isMission =
       mission?.event?.eventType === 'run' ||
       isMissionCommand(mission?.event?.data, mission?.event?.text)

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -33,6 +33,7 @@ import { useQueryClient } from 'react-query'
 import useGlobalModalId from '../lib/useGlobalModalId'
 import {
   missionNameFromStartedText,
+  missionNameFromEventData,
   missionPathFromEventData,
   rawMissionPathFromEventData,
   normalizeMissionName,
@@ -70,6 +71,9 @@ export interface CommandStatusItem {
   isDefaultMission?: boolean
   /** Vehicle GPS position at the moment this mission started (from missionStarted telemetry) */
   fix?: { latitude: number; longitude: number }
+  /** Vehicle-reported mission ID from missionStarted telemetry (e.g. "keepstation",
+   *  "follow_that_car"). Preferred display name over the raw command text. */
+  missionId?: string
 }
 
 const VALID_SCHEDULE_CELL_STATUSES: ScheduleCellStatus[] = [
@@ -435,6 +439,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
               status: newerRun.status,
               endedAt: newerRun.endedAt,
               startedAt: newerRun.startedAt,
+              missionId: newerRun.name,
             }
           }
         }
@@ -443,6 +448,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
           status: inInterval.status,
           endedAt: inInterval.endedAt,
           startedAt: inInterval.startedAt,
+          missionId: inInterval.name,
         }
       }
 
@@ -463,6 +469,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         status: best.status,
         endedAt: best.endedAt,
         startedAt: best.startedAt,
+        missionId: best.name,
       }
     })
 
@@ -524,11 +531,13 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
             status: 'running',
             endedAt: undefined,
             startedAt: currentMissionEntry.startedAt,
+            missionId: currentMissionEntry.name,
           }
         } else if (!matchingItem.startedAt) {
           enriched[matchingMissionIndex] = {
             ...matchingItem,
             startedAt: currentMissionEntry.startedAt,
+            missionId: currentMissionEntry.name,
           }
         }
         // Demote any OTHER rows for the same mission that are still marked
@@ -560,9 +569,9 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
           if (currentRawEvent) {
             enriched.unshift({
               event: {
-                // Construct a command-format data string so parseMissionCommand
-                // produces a consistent label and "Use for new mission" receives
-                // a valid path. GetMissionStartedEventResponse has no data field.
+                // Construct a command-format data string so "Use for new mission"
+                // receives a valid path. GetMissionStartedEventResponse has no
+                // data field. missionId carries the clean display name separately.
                 data: `load ${currentMissionEntry.name};run`,
                 unixTime: currentRawEvent.unixTime,
                 eventId: currentRawEvent.eventId,
@@ -571,6 +580,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
               },
               status: 'running',
               endedAt: undefined,
+              missionId: currentMissionEntry.name,
             })
           }
         }
@@ -955,8 +965,20 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       )
     }
 
-    const { name: missionName, parameters: missionParams } =
-      parseMissionCommand(mission?.event.data ?? '')
+    const { parameters: missionParams } = parseMissionCommand(
+      mission?.event.data ?? ''
+    )
+    // Display name priority:
+    // 1. missionId — vehicle-reported mission ID from missionStarted telemetry
+    //    (e.g. "keepstation", "follow_that_car"). Most accurate: it's what the
+    //    vehicle actually calls the mission, regardless of filename or _vt suffix.
+    // 2. missionNameFromEventData — filename without path/extension as a clean
+    //    fallback when the row hasn't been matched to a missionStarted event.
+    // 3. parseMissionCommand is kept for parameters and modal pre-fill only.
+    const missionName =
+      mission?.missionId ??
+      missionNameFromEventData(mission?.event.data) ??
+      undefined
     const isMission =
       mission?.event?.eventType === 'run' ||
       isMissionCommand(mission?.event?.data, mission?.event?.text)

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -965,19 +965,21 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       )
     }
 
+    const commandData = mission?.event.data ?? mission?.event.text ?? ''
     const { name: parsedMissionName, parameters: missionParams } =
-      parseMissionCommand(mission?.event.data ?? '')
+      parseMissionCommand(commandData)
     // Display name priority (|| so empty strings fall through to the next level):
     // 1. missionId — vehicle-reported mission ID from missionStarted telemetry
     //    (e.g. "keepstation", "follow_that_car"). Most accurate: it's what the
     //    vehicle actually calls the mission, regardless of filename or _vt suffix.
-    // 2. missionNameFromEventData — filename without path/extension as a clean
-    //    fallback when the row hasn't been matched to a missionStarted event.
+    // 2. missionNameFromEventData — filename without path/extension. Checked
+    //    against both data and text since commands can arrive in either field.
     // 3. parsedMissionName from parseMissionCommand — last resort for edge cases
     //    not covered by missionNameFromEventData (e.g. non-load command formats).
     const missionName =
       mission?.missionId ||
       missionNameFromEventData(mission?.event.data) ||
+      missionNameFromEventData(mission?.event.text) ||
       parsedMissionName
     const isMission =
       mission?.event?.eventType === 'run' ||

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -567,12 +567,26 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
         if (!isDefaultMissionName(currentMissionEntry.name)) {
           const currentRawEvent = missionStartedResponse.data?.[0]
           if (currentRawEvent) {
+            // For missions where the vehicle-reported ID differs from the script
+            // filename (e.g. tail_acoustic_contact.tl reports follow_that_car),
+            // look for an unmatched command event whose data/text references the
+            // mission ID in parameter names (e.g. "set follow_that_car.Timeout").
+            // That event carries the real file path needed by "Use for new mission".
+            // Fall back to a synthetic load string only when no such event exists.
+            const missionParamPrefix = `${currentMissionEntry.name}.`
+            const missionParamColon = `${currentMissionEntry.name}:`
+            const sourceEvent = enriched.find((item) => {
+              const d = item.event.data ?? item.event.text ?? ''
+              return (
+                d.includes(missionParamPrefix) || d.includes(missionParamColon)
+              )
+            })
             enriched.unshift({
               event: {
-                // Construct a command-format data string so "Use for new mission"
-                // receives a valid path. GetMissionStartedEventResponse has no
-                // data field. missionId carries the clean display name separately.
-                data: `load ${currentMissionEntry.name};run`,
+                data:
+                  sourceEvent?.event.data ??
+                  sourceEvent?.event.text ??
+                  `load ${currentMissionEntry.name};run`,
                 unixTime: currentRawEvent.unixTime,
                 eventId: currentRawEvent.eventId,
                 eventType: 'run',

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -994,6 +994,59 @@ test('bare command row does not show "No parameters" secondary text', async () =
   ).not.toBeInTheDocument()
 })
 
+test('running mission label uses vehicle-reported missionId over raw command text', async () => {
+  // When the vehicle reports "Started mission keepstation", the schedule row
+  // for "load Transport/keepstation.tl;run" should display "keepstation"
+  // (the mission ID), not the raw "load Transport/keepstation.tl" command text.
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            {
+              data: 'load Transport/keepstation.tl;run',
+              unixTime: Date.now() - 60 * 1000,
+              eventId: 402,
+              eventType: 'run',
+              text: null,
+              note: null,
+              user: 'test-operator',
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            {
+              text: 'Started mission keepstation',
+              unixTime: Date.now() - 55 * 1000,
+              eventId: 403,
+            },
+          ],
+        })
+      )
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection {...props} currentDeploymentId={1} />
+    </MockProviders>
+  )
+
+  await waitFor(() => {
+    expect(screen.getByText('keepstation')).toBeInTheDocument()
+  })
+  expect(
+    screen.queryByText('load Transport/keepstation.tl')
+  ).not.toBeInTheDocument()
+})
+
 test('mission command row shows "No parameters" secondary text when no params set', async () => {
   server.use(
     rest.get('/events', (_req, res, ctx) =>
@@ -1026,7 +1079,8 @@ test('mission command row shows "No parameters" secondary text when no params se
   )
 
   await waitFor(() => {
-    expect(screen.getByText('load Transport/transit.tl')).toBeInTheDocument()
+    // missionNameFromEventData extracts the clean name from the command path
+    expect(screen.getByText('transit')).toBeInTheDocument()
   })
   expect(screen.getByText('No parameters')).toBeInTheDocument()
 })
@@ -1120,7 +1174,8 @@ test('legacy run <file> mission row does not show "No parameters" subtitle', asy
   )
 
   await waitFor(() => {
-    expect(screen.getByText('Science/mbts_sci2.tl')).toBeInTheDocument()
+    // Legacy bare-run format: missionNameFromEventData strips path and extension
+    expect(screen.getByText('mbts_sci2')).toBeInTheDocument()
   })
   expect(screen.queryByText('No parameters')).not.toBeInTheDocument()
 })

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -994,10 +994,11 @@ test('bare command row does not show "No parameters" secondary text', async () =
   ).not.toBeInTheDocument()
 })
 
-test('running mission label uses vehicle-reported missionId over raw command text', async () => {
-  // When the vehicle reports "Started mission keepstation", the schedule row
-  // for "load Transport/keepstation.tl;run" should display "keepstation"
-  // (the mission ID), not the raw "load Transport/keepstation.tl" command text.
+test('running mission label uses vehicle-reported missionId over filename when they differ', async () => {
+  // tail_acoustic_contact.tl declares "mission follow_that_car" so the vehicle
+  // reports "Started mission follow_that_car". The missionId (follow_that_car)
+  // must win over missionNameFromEventData (tail_acoustic_contact) to prove
+  // that missionId precedence is exercised, not just the filename fallback.
   server.use(
     rest.get('/events', (_req, res, ctx) =>
       res(
@@ -1005,7 +1006,7 @@ test('running mission label uses vehicle-reported missionId over raw command tex
         ctx.json({
           result: [
             {
-              data: 'load Transport/keepstation.tl;run',
+              data: 'load Engineering/tail_acoustic_contact.tl;set follow_that_car.MissionTimeout 3 h;run',
               unixTime: Date.now() - 60 * 1000,
               eventId: 402,
               eventType: 'run',
@@ -1023,7 +1024,7 @@ test('running mission label uses vehicle-reported missionId over raw command tex
         ctx.json({
           result: [
             {
-              text: 'Started mission keepstation',
+              text: 'Started mission follow_that_car',
               unixTime: Date.now() - 55 * 1000,
               eventId: 403,
             },
@@ -1040,11 +1041,11 @@ test('running mission label uses vehicle-reported missionId over raw command tex
   )
 
   await waitFor(() => {
-    expect(screen.getByText('keepstation')).toBeInTheDocument()
+    expect(screen.getByText('follow_that_car')).toBeInTheDocument()
   })
-  expect(
-    screen.queryByText('load Transport/keepstation.tl')
-  ).not.toBeInTheDocument()
+  // Must not show the filename-derived label or raw command text
+  expect(screen.queryByText('tail_acoustic_contact')).not.toBeInTheDocument()
+  expect(screen.queryByText(/load Engineering/)).not.toBeInTheDocument()
 })
 
 test('mission command row shows "No parameters" secondary text when no params set', async () => {


### PR DESCRIPTION
## Problem

Mission rows in the schedule section were showing raw command text (e.g. `load Transport/keepstation.tl`) instead of the clean mission name the vehicle actually reports (e.g. `keepstation`).

Additionally, in cases like Quinn's `tail_acoustic_contact.tl` where the author declared `mission follow_that_car {...}`, the vehicle reports `follow_that_car` as the mission ID — so the correct label is `follow_that_car`, not `tail_acoustic_contact`.

Reported by Emme Wiederhold. Closes #775.

## Root Cause

`parseMissionCommand()` returned the full `"load <path>"` string as the display name. The `load` keyword was not stripped and the directory path and file extension were not cleaned up.

## Fix

Two changes applied:

1. **`missionId` on `CommandStatusItem`** — populated from `missionTimeline` (vehicle-reported mission ID via `missionStarted` telemetry) whenever a schedule row is matched or promoted to running/completed. This gives the accurate vehicle-reported ID (`follow_that_car`) even when the filename differs (`tail_acoustic_contact.tl`).

2. **Priority chain at the display site**:
   - `missionId` (vehicle telemetry) — most accurate
   - `missionNameFromEventData` — clean filename fallback for unmatched rows
   - `parseMissionCommand` — preserved unchanged for "Use for new mission" modal pre-fill, which needs the full load path

## Tests

- Updated two tests that were asserting the old broken display text
- Added a new test verifying the `missionId` display path end-to-end (keepstation case)