### PR TITLE
feat: Watch Summary tab for vehicle drawer (#777)

### DIFF
--- a/apps/lrauv-dash2/components/WatchSummarySection.tsx
+++ b/apps/lrauv-dash2/components/WatchSummarySection.tsx
@@ -1,5 +1,6 @@
+import { useMemo, useState, useCallback, useEffect, useRef } from 'react'
 import dynamic from 'next/dynamic'
-import { useEvents, useDepthSparkline } from '@mbari/api-client'
+import { useEvents, useDepthSparkline, EventType } from '@mbari/api-client'
 import { DateTime } from 'luxon'
 import clsx from 'clsx'
 
@@ -13,34 +14,77 @@ const DepthSparkline = dynamic(
 
 const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000
 
-// Event types to surface in the watch summary timeline
-const WATCH_EVENT_TYPES = [
-  'note',
+// Alphabetical by display label: Command, Comms, Critical, Emergency, Fault, Important, Mission, Note
+const WATCH_EVENT_TYPES: EventType[] = [
+  'command',
+  'sbdSend',
   'logCritical',
+  'emergency',
   'logFault',
   'logImportant',
   'run',
-  'command',
-  'emergency',
-  'sbdSend',
-] as const
-
-type WatchEventType = (typeof WATCH_EVENT_TYPES)[number]
+  'note',
+]
 
 interface BadgeConfig {
   label: string
+  /** Applied to the event row badge pill */
   className: string
+  /** Applied to the chip when actively selected */
+  activeChipClassName: string
+  /** Applied to the chip when inactive (faded version of active color) */
+  inactiveChipClassName: string
 }
 
-const BADGE: Record<WatchEventType, BadgeConfig> = {
-  emergency: { label: 'Emergency', className: 'bg-red-600 text-white' },
-  logCritical: { label: 'Critical', className: 'bg-red-500 text-white' },
-  logFault: { label: 'Fault', className: 'bg-orange-500 text-white' },
-  logImportant: { label: 'Important', className: 'bg-yellow-500 text-white' },
-  run: { label: 'Mission', className: 'bg-blue-600 text-white' },
-  command: { label: 'Command', className: 'bg-blue-400 text-white' },
-  sbdSend: { label: 'Comms', className: 'bg-teal-500 text-white' },
-  note: { label: 'Note', className: 'bg-green-500 text-white' },
+const BADGE: Partial<Record<EventType, BadgeConfig>> = {
+  emergency: {
+    label: 'Emergency',
+    className: 'bg-red-600 text-white',
+    activeChipClassName: 'border-red-600 bg-red-600 text-white',
+    inactiveChipClassName: 'border-red-200 bg-red-50 text-red-300',
+  },
+  logCritical: {
+    label: 'Critical',
+    className: 'bg-red-500 text-white',
+    activeChipClassName: 'border-red-500 bg-red-500 text-white',
+    inactiveChipClassName: 'border-red-200 bg-red-50 text-red-300',
+  },
+  logFault: {
+    label: 'Fault',
+    className: 'bg-orange-500 text-white',
+    activeChipClassName: 'border-orange-500 bg-orange-500 text-white',
+    inactiveChipClassName: 'border-orange-200 bg-orange-50 text-orange-300',
+  },
+  logImportant: {
+    label: 'Important',
+    className: 'bg-yellow-500 text-white',
+    activeChipClassName: 'border-yellow-500 bg-yellow-500 text-white',
+    inactiveChipClassName: 'border-yellow-200 bg-yellow-50 text-yellow-400',
+  },
+  run: {
+    label: 'Mission',
+    className: 'bg-blue-600 text-white',
+    activeChipClassName: 'border-blue-600 bg-blue-600 text-white',
+    inactiveChipClassName: 'border-blue-200 bg-blue-50 text-blue-300',
+  },
+  command: {
+    label: 'Command',
+    className: 'bg-blue-400 text-white',
+    activeChipClassName: 'border-blue-400 bg-blue-400 text-white',
+    inactiveChipClassName: 'border-blue-200 bg-blue-50 text-blue-300',
+  },
+  sbdSend: {
+    label: 'Comms',
+    className: 'bg-teal-500 text-white',
+    activeChipClassName: 'border-teal-500 bg-teal-500 text-white',
+    inactiveChipClassName: 'border-teal-200 bg-teal-50 text-teal-300',
+  },
+  note: {
+    label: 'Note',
+    className: 'bg-green-500 text-white',
+    activeChipClassName: 'border-green-500 bg-green-500 text-white',
+    inactiveChipClassName: 'border-green-200 bg-green-50 text-green-300',
+  },
 }
 
 interface WatchSummarySectionProps {
@@ -50,83 +94,307 @@ interface WatchSummarySectionProps {
 const WatchSummarySection: React.FC<WatchSummarySectionProps> = ({
   vehicleName,
 }) => {
-  const windowFrom = Date.now() - EIGHT_HOURS_MS
+  const windowFrom = useMemo(() => Date.now() - EIGHT_HOURS_MS, [])
+
+  // null = "All" mode (show everything); otherwise only the selected types show
+  const [activeFilters, setActiveFilters] = useState<Set<EventType> | null>(
+    null
+  )
+
+  // The event time the user clicked — used to draw the sparkline indicator
+  const [indicatorTime, setIndicatorTime] = useState<number | null>(null)
+
+  const isAllMode = activeFilters === null
+
+  const toggleFilter = useCallback((type: EventType) => {
+    setActiveFilters((prev) => {
+      if (prev === null) {
+        // Coming from "All" — select only this type
+        return new Set([type])
+      }
+      const next = new Set(prev)
+      if (next.has(type)) {
+        next.delete(type)
+        // If nothing left selected, revert to All
+        return next.size === 0 ? null : next
+      } else {
+        next.add(type)
+        // If all types are now selected, revert to All
+        return next.size === WATCH_EVENT_TYPES.length ? null : next
+      }
+    })
+    setIndicatorTime(null)
+  }, [])
 
   const { data: sparklineData, isLoading: sparklineLoading } =
     useDepthSparkline({ vehicle: vehicleName })
 
-  const { data: events, isLoading: eventsLoading } = useEvents({
-    vehicles: [vehicleName],
-    eventTypes: [...WATCH_EVENT_TYPES],
-    from: windowFrom,
-    limit: 200,
-    ascending: 'n',
-  })
+  // Measure the sparkline container so the SVG viewBox aspect ratio can be
+  // matched exactly — eliminates letterboxing without distortion.
+  const sparklineContainerRef = useRef<HTMLDivElement>(null)
+  const [containerDims, setContainerDims] = useState<{
+    w: number
+    h: number
+  } | null>(null)
+  useEffect(() => {
+    const el = sparklineContainerRef.current
+    if (!el) return
+    const ro = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect
+      if (width > 0 && height > 0) setContainerDims({ w: width, h: height })
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
 
-  const isLoading = sparklineLoading || eventsLoading
+  // compact mode label font size (SVG units) — kept small so depth chart dominates
+  const LABEL_FONT_SIZE = 2.8
+  // Derive chart body height so viewBox aspect ratio matches container exactly.
+  // Uses compact overhead: tickArea ≈ 7.8, axisOverhead = LABEL_FONT_SIZE + 4
+  const sparklineChartH = useMemo(() => {
+    if (!containerDims || containerDims.w === 0) return 20
+    const svgWidth = 122
+    const compactTickOverhead = 1.2 * 4 + 0.6 + 2 // 7.4 (matches tickRowHeight=0.6)
+    const compactAxisOverhead = LABEL_FONT_SIZE + 7 // matches axisOverhead in DepthSparkline
+    const totalOverhead = compactTickOverhead + compactAxisOverhead // ≈ 15.3
+    const targetViewBoxH = (containerDims.h / containerDims.w) * svgWidth
+    return Math.max(8, Math.round(targetViewBoxH - totalOverhead))
+  }, [containerDims])
+
+  // Tick once per minute so the "X ago" label stays current
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 60000)
+    return () => clearInterval(id)
+  }, [])
+
+  // Compute legend values from raw sparkline data so we can render as HTML
+  const sparklineLegend = useMemo(() => {
+    if (!sparklineData) return null
+    const { depthTimes, depthValues, padded } = sparklineData
+    const safeLen = Math.min(depthTimes.length, depthValues.length)
+    if (safeLen === 0) return null
+    const isPadded = (padded ?? false) && safeLen >= 4
+    const realTimes = isPadded ? depthTimes.slice(0, -3) : depthTimes
+    const lastDataMs = Math.max(...realTimes) * 60 * 1000
+    const ageHours = (nowMs - lastDataMs) / 3600000
+    const isStale = ageHours > 1.25
+    const d = new Date(lastDataMs)
+    const timeLabel = `${d.getHours()}:${d
+      .getMinutes()
+      .toString()
+      .padStart(2, '0')}`
+    const clamped = Math.max(0, nowMs - lastDataMs)
+    const absMin = Math.round(clamped / 60000)
+    const agoLabel =
+      absMin < 60 ? `${absMin}m ago` : `${(clamped / 3600000).toFixed(1)}h ago`
+    return { timeLabel, agoLabel, isStale, isPadded }
+  }, [sparklineData, nowMs])
+
+  const { data: events, isLoading: eventsLoading } = useEvents(
+    {
+      vehicles: [vehicleName],
+      eventTypes: WATCH_EVENT_TYPES,
+      from: windowFrom,
+      limit: 200,
+      ascending: 'n',
+    },
+    { staleTime: 5 * 60 * 1000 }
+  )
+
+  const filteredEvents = useMemo(
+    () =>
+      activeFilters === null
+        ? events ?? []
+        : events?.filter((e) => activeFilters.has(e.eventType)) ?? [],
+    [events, activeFilters]
+  )
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden">
-      <header className="flex items-center gap-3 px-4 pt-2 pb-1">
-        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
-          Last 8 Hours
-        </span>
-        {isLoading && <span className="text-xs text-slate-400">Loading…</span>}
-      </header>
+    <div className="flex h-full w-full flex-row overflow-hidden">
+      {/* Left — SVG fills remaining width after vertical legend; ResizeObserver matches aspect ratio */}
+      <div className="flex w-2/3 overflow-hidden">
+        {/* Sparkline — flex-1 so legend column takes its natural width */}
+        <div
+          ref={sparklineContainerRef}
+          className="relative min-h-0 flex-1 overflow-hidden"
+        >
+          {sparklineLoading && (
+            <p className="absolute inset-0 flex items-center justify-center text-xs text-slate-400">
+              Loading…
+            </p>
+          )}
+          {!sparklineLoading && !sparklineData && (
+            <p className="absolute inset-0 flex items-center justify-center text-xs text-slate-400">
+              No depth data
+            </p>
+          )}
+          {sparklineData && containerDims && (
+            <DepthSparkline
+              {...sparklineData}
+              responsive
+              height={sparklineChartH}
+              legendPosition="none"
+              compact
+              labelFontSize={LABEL_FONT_SIZE}
+              highlightTime={indicatorTime ?? undefined}
+              preserveAspectRatio="none"
+              className="h-full w-full"
+            />
+          )}
+        </div>
 
-      {/* Depth sparkline — full width, taller than the vehicle panel version */}
-      <div className="mx-4 mb-2 flex-shrink-0 overflow-hidden rounded border border-slate-200 bg-slate-50">
-        {sparklineData && (
-          <DepthSparkline
-            {...sparklineData}
-            responsive
-            className="h-16 w-full"
-          />
-        )}
-        {!sparklineData && !sparklineLoading && (
-          <p className="py-3 text-center text-xs text-slate-400">
-            No depth data
-          </p>
+        {/* Vertical legend column — right of SVG, no separator line */}
+        {sparklineLegend && (
+          <div
+            className="flex w-24 flex-shrink-0 flex-col pb-2 pl-2 text-sm text-gray-600"
+            style={{ paddingTop: '80px' }}
+          >
+            {/* Last-data time — pushed down to sit beside the most-recent surface area */}
+            <div className="flex flex-col gap-1 text-gray-500">
+              <span className="font-semibold text-gray-700">
+                {sparklineLegend.timeLabel}{' '}
+                <span className="text-xs font-normal text-gray-600">local</span>
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span
+                  className={clsx(
+                    'inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full',
+                    sparklineLegend.isPadded && sparklineLegend.isStale
+                      ? 'bg-orange-500'
+                      : 'bg-green-500'
+                  )}
+                />
+                {sparklineLegend.agoLabel}
+              </span>
+            </div>
+            {/* Extra white space, Legend header, then comms key */}
+            <div
+              style={{ marginTop: '32px' }}
+              className="flex flex-col gap-1.5"
+            >
+              <p className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-600">
+                Legend
+              </p>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full bg-blue-500" />
+                argo
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full bg-purple-500" />
+                gps
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full bg-orange-500" />
+                sat
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className="inline-block h-2.5 w-2.5 flex-shrink-0 rounded-full bg-green-500" />
+                cell
+              </span>
+            </div>
+          </div>
         )}
       </div>
 
-      {/* Event timeline */}
-      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-2">
-        {!isLoading && !events?.length && (
-          <p className="mt-2 text-center text-sm text-slate-400">
-            No events in the last 8 hours.
-          </p>
-        )}
-        {events?.map((event) => {
-          const badge = BADGE[event.eventType as WatchEventType]
-          const time = DateTime.fromMillis(event.unixTime, {
-            zone: 'utc',
-          }).toFormat('HH:mm')
-          const text = event.text ?? event.note ?? ''
-          return (
-            <div
-              key={event.eventId}
-              className="flex items-start gap-2 border-b border-slate-100 py-1.5 last:border-0"
+      {/* Right — event timeline (1/3) */}
+      <div className="flex w-1/3 flex-col overflow-hidden border-l border-slate-200">
+        {/* Header + filter chips */}
+        <div className="flex-shrink-0 border-b border-slate-100 px-3 py-1">
+          <div className="mb-1 flex items-center gap-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-600">
+              Events — Last 8h
+            </p>
+            {eventsLoading && (
+              <span className="text-xs text-slate-300">Loading…</span>
+            )}
+          </div>
+          {/* Filter chips */}
+          <div className="flex flex-wrap gap-1">
+            {/* All — solid chip when active (default); faded when a type filter is selected */}
+            <button
+              onClick={() => {
+                setActiveFilters(null)
+                setIndicatorTime(null)
+              }}
+              className={clsx(
+                'rounded border px-2 py-0.5 text-xs font-semibold leading-tight transition-colors',
+                isAllMode
+                  ? 'border-gray-600 bg-gray-600 text-white'
+                  : 'border-gray-300 bg-gray-100 text-gray-400'
+              )}
             >
-              <span className="mt-0.5 w-10 flex-shrink-0 text-right text-xs tabular-nums text-slate-400">
-                {time}
-              </span>
-              {badge && (
-                <span
+              All
+            </button>
+            {WATCH_EVENT_TYPES.map((type) => {
+              const badge = BADGE[type]
+              if (!badge) return null
+              // Active = explicitly selected; inactive = faded version of own color
+              const isSelected =
+                !isAllMode && (activeFilters?.has(type) ?? false)
+              return (
+                <button
+                  key={type}
+                  onClick={() => toggleFilter(type)}
                   className={clsx(
-                    'flex-shrink-0 rounded px-1.5 py-0.5 text-xs font-medium leading-tight',
-                    badge.className
+                    'rounded border px-1.5 py-0.5 text-xs font-medium leading-tight transition-colors',
+                    isSelected
+                      ? badge.activeChipClassName
+                      : badge.inactiveChipClassName
                   )}
                 >
                   {badge.label}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Event rows */}
+        <div className="min-h-0 flex-1 overflow-y-auto pl-6">
+          {!eventsLoading && !filteredEvents.length && (
+            <p className="mt-4 text-center text-xs text-slate-400">
+              No matching events in the last 8 hours.
+            </p>
+          )}
+          {filteredEvents.map((event) => {
+            const badge = BADGE[event.eventType]
+            const time = DateTime.fromMillis(event.unixTime, {
+              zone: 'utc',
+            }).toFormat('HH:mm')
+            const text = event.text ?? event.note ?? ''
+            const isSelected = indicatorTime === event.unixTime
+            return (
+              <button
+                key={event.eventId}
+                onClick={() =>
+                  setIndicatorTime(isSelected ? null : event.unixTime)
+                }
+                className={clsx(
+                  'flex w-full items-start gap-1.5 border-b border-slate-100 px-3 py-1 text-left last:border-0 hover:bg-slate-50',
+                  isSelected && 'bg-red-50'
+                )}
+              >
+                <span className="mt-0.5 w-9 flex-shrink-0 text-right text-xs tabular-nums text-slate-400">
+                  {time}
                 </span>
-              )}
-              <span className="min-w-0 truncate text-xs text-slate-700">
-                {text}
-              </span>
-            </div>
-          )
-        })}
+                {badge && (
+                  <span
+                    className={clsx(
+                      'flex-shrink-0 rounded px-1 py-0.5 text-xs font-medium leading-tight',
+                      badge.className
+                    )}
+                  >
+                    {badge.label}
+                  </span>
+                )}
+                <span className="min-w-0 truncate text-xs text-slate-700">
+                  {text}
+                </span>
+              </button>
+            )
+          })}
+        </div>
       </div>
     </div>
   )

--- a/apps/lrauv-dash2/components/WatchSummarySection.tsx
+++ b/apps/lrauv-dash2/components/WatchSummarySection.tsx
@@ -1,0 +1,135 @@
+import dynamic from 'next/dynamic'
+import { useEvents, useDepthSparkline } from '@mbari/api-client'
+import { DateTime } from 'luxon'
+import clsx from 'clsx'
+
+const DepthSparkline = dynamic(
+  () =>
+    import('@mbari/react-ui/dist/Charts/DepthSparkline').then(
+      (m) => m.default ?? m
+    ),
+  { ssr: false }
+)
+
+const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000
+
+// Event types to surface in the watch summary timeline
+const WATCH_EVENT_TYPES = [
+  'note',
+  'logCritical',
+  'logFault',
+  'logImportant',
+  'run',
+  'command',
+  'emergency',
+  'sbdSend',
+] as const
+
+type WatchEventType = (typeof WATCH_EVENT_TYPES)[number]
+
+interface BadgeConfig {
+  label: string
+  className: string
+}
+
+const BADGE: Record<WatchEventType, BadgeConfig> = {
+  emergency: { label: 'Emergency', className: 'bg-red-600 text-white' },
+  logCritical: { label: 'Critical', className: 'bg-red-500 text-white' },
+  logFault: { label: 'Fault', className: 'bg-orange-500 text-white' },
+  logImportant: { label: 'Important', className: 'bg-yellow-500 text-white' },
+  run: { label: 'Mission', className: 'bg-blue-600 text-white' },
+  command: { label: 'Command', className: 'bg-blue-400 text-white' },
+  sbdSend: { label: 'Comms', className: 'bg-teal-500 text-white' },
+  note: { label: 'Note', className: 'bg-green-500 text-white' },
+}
+
+interface WatchSummarySectionProps {
+  vehicleName: string
+}
+
+const WatchSummarySection: React.FC<WatchSummarySectionProps> = ({
+  vehicleName,
+}) => {
+  const windowFrom = Date.now() - EIGHT_HOURS_MS
+
+  const { data: sparklineData, isLoading: sparklineLoading } =
+    useDepthSparkline({ vehicle: vehicleName })
+
+  const { data: events, isLoading: eventsLoading } = useEvents({
+    vehicles: [vehicleName],
+    eventTypes: [...WATCH_EVENT_TYPES],
+    from: windowFrom,
+    limit: 200,
+    ascending: 'n',
+  })
+
+  const isLoading = sparklineLoading || eventsLoading
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden">
+      <header className="flex items-center gap-3 px-4 pt-2 pb-1">
+        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+          Last 8 Hours
+        </span>
+        {isLoading && <span className="text-xs text-slate-400">Loading…</span>}
+      </header>
+
+      {/* Depth sparkline — full width, taller than the vehicle panel version */}
+      <div className="mx-4 mb-2 flex-shrink-0 overflow-hidden rounded border border-slate-200 bg-slate-50">
+        {sparklineData && (
+          <DepthSparkline
+            {...sparklineData}
+            responsive
+            className="h-16 w-full"
+          />
+        )}
+        {!sparklineData && !sparklineLoading && (
+          <p className="py-3 text-center text-xs text-slate-400">
+            No depth data
+          </p>
+        )}
+      </div>
+
+      {/* Event timeline */}
+      <div className="min-h-0 flex-1 overflow-y-auto px-4 pb-2">
+        {!isLoading && !events?.length && (
+          <p className="mt-2 text-center text-sm text-slate-400">
+            No events in the last 8 hours.
+          </p>
+        )}
+        {events?.map((event) => {
+          const badge = BADGE[event.eventType as WatchEventType]
+          const time = DateTime.fromMillis(event.unixTime, {
+            zone: 'utc',
+          }).toFormat('HH:mm')
+          const text = event.text ?? event.note ?? ''
+          return (
+            <div
+              key={event.eventId}
+              className="flex items-start gap-2 border-b border-slate-100 py-1.5 last:border-0"
+            >
+              <span className="mt-0.5 w-10 flex-shrink-0 text-right text-xs tabular-nums text-slate-400">
+                {time}
+              </span>
+              {badge && (
+                <span
+                  className={clsx(
+                    'flex-shrink-0 rounded px-1.5 py-0.5 text-xs font-medium leading-tight',
+                    badge.className
+                  )}
+                >
+                  {badge.label}
+                </span>
+              )}
+              <span className="min-w-0 truncate text-xs text-slate-700">
+                {text}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default WatchSummarySection

--- a/apps/lrauv-dash2/components/WatchSummarySection.tsx
+++ b/apps/lrauv-dash2/components/WatchSummarySection.tsx
@@ -155,7 +155,7 @@ const WatchSummarySection: React.FC<WatchSummarySectionProps> = ({
     if (!containerDims || containerDims.w === 0) return 20
     const svgWidth = 122
     const compactTickOverhead = 1.2 * 4 + 0.6 + 2 // 7.4 (matches tickRowHeight=0.6)
-    const compactAxisOverhead = LABEL_FONT_SIZE + 7 // matches axisOverhead in DepthSparkline
+    const compactAxisOverhead = LABEL_FONT_SIZE + 4 // matches actual axisOverhead in DepthSparkline (compact)
     const totalOverhead = compactTickOverhead + compactAxisOverhead // ≈ 15.3
     const targetViewBoxH = (containerDims.h / containerDims.w) * svgWidth
     return Math.max(8, Math.round(targetViewBoxH - totalOverhead))
@@ -238,7 +238,7 @@ const WatchSummarySection: React.FC<WatchSummarySectionProps> = ({
               compact
               labelFontSize={LABEL_FONT_SIZE}
               highlightTime={indicatorTime ?? undefined}
-              preserveAspectRatio="none"
+              preserveAspectRatio="xMidYMin meet"
               className="h-full w-full"
             />
           )}

--- a/apps/lrauv-dash2/components/WatchSummarySection.tsx
+++ b/apps/lrauv-dash2/components/WatchSummarySection.tsx
@@ -238,7 +238,7 @@ const WatchSummarySection: React.FC<WatchSummarySectionProps> = ({
               compact
               labelFontSize={LABEL_FONT_SIZE}
               highlightTime={indicatorTime ?? undefined}
-              preserveAspectRatio="xMidYMin meet"
+              preserveAspectRatio="xMaxYMin meet"
               className="h-full w-full"
             />
           )}
@@ -247,7 +247,7 @@ const WatchSummarySection: React.FC<WatchSummarySectionProps> = ({
         {/* Vertical legend column — right of SVG, no separator line */}
         {sparklineLegend && (
           <div
-            className="flex w-24 flex-shrink-0 flex-col pb-2 pl-2 text-sm text-gray-600"
+            className="flex w-24 flex-shrink-0 flex-col pb-2 pl-1 text-sm text-gray-600"
             style={{ paddingTop: '80px' }}
           >
             {/* Last-data time — pushed down to sit beside the most-recent surface area */}

--- a/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
+++ b/apps/lrauv-dash2/pages/vehicle/[...deployment].tsx
@@ -32,6 +32,7 @@ import Layout from '../../components/Layout'
 import VehicleDiagram from '../../components/VehicleDiagram'
 import VehicleAccordion from '../../components/VehicleAccordion'
 import DepthSection from '../../components/DepthSection'
+import WatchSummarySection from '../../components/WatchSummarySection'
 import useGlobalModalId from '../../lib/useGlobalModalId'
 import useCurrentDeployment from '../../lib/useCurrentDeployment'
 import useGlobalDrawerState from '../../lib/useGlobalDrawerState'
@@ -69,7 +70,7 @@ const DeploymentMap = dynamic(() => import('../../components/DeploymentMap'), {
   ssr: false,
 })
 
-type AvailableTab = 'vehicle' | 'depth' | null
+type AvailableTab = 'vehicle' | 'depth' | 'watch' | null
 type MobileView = 'main' | 'sidebar'
 
 const useIsDesktop = () => {
@@ -343,6 +344,11 @@ const Vehicle: NextPage = () => {
               label="Depth Data"
               onClick={setCurrentTab('depth')}
               selected={currentTab === 'depth'}
+            />
+            <Tab
+              label="Watch Summary"
+              onClick={setCurrentTab('watch')}
+              selected={currentTab === 'watch'}
               className="mr-auto"
             />
           </TabGroup>
@@ -370,6 +376,9 @@ const Vehicle: NextPage = () => {
                 onHover={handleTimeScrub}
                 indicatorTime={indicatorTime}
               />
+            )}
+            {currentTab === 'watch' && (
+              <WatchSummarySection vehicleName={vehicleName as string} />
             )}
           </div>
         </div>

--- a/packages/react-ui/src/Charts/DepthSparkline.tsx
+++ b/packages/react-ui/src/Charts/DepthSparkline.tsx
@@ -335,7 +335,7 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
   // Reduce top gap so comms bars sit near the SVG top edge (was -2, now -0.5)
   const viewBoxTop = y0 - tickAreaHeight - 0.5 - topLegendHeight
   // compact: extra room so axis labels clear the chart border
-  const axisOverhead = compact ? labelFontSize + 7 : 14
+  const axisOverhead = compact ? labelFontSize + 4 : 14
   const viewBoxH = h + tickAreaHeight + axisOverhead + topLegendHeight
 
   // Highlight line x coordinate (SVG units). Computed outside useMemo since it
@@ -549,13 +549,8 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
         </text>
       ))}
 
-      {/* Max depth label — positioned near bottom of box but clear of the border */}
-      <text
-        x={x0 + 1}
-        y={y0 + h - (compact ? labelFontSize + 0.5 : 1)}
-        fontSize={labelFontSize}
-        fill="#374151"
-      >
+      {/* Max depth label — pegged to bottom-left corner where y-axis meets x-axis */}
+      <text x={x0 + 1} y={y0 + h - 0.5} fontSize={labelFontSize} fill="#374151">
         {depthScale}m
       </text>
 

--- a/packages/react-ui/src/Charts/DepthSparkline.tsx
+++ b/packages/react-ui/src/Charts/DepthSparkline.tsx
@@ -13,9 +13,45 @@ export interface DepthSparklineProps {
   height?: number // SVG box height (default 20)
   windowMinutes?: number // time window to show (default 480 = 8h)
   responsive?: boolean // when true, fills container (no explicit width/height on SVG element)
+  /**
+   * Controls where the comms legend and last-data labels are rendered.
+   * 'right' (default): to the right of the chart.
+   * 'top': compact row above the tick rows.
+   * 'none': legend is omitted entirely — render it externally as HTML.
+   */
+  legendPosition?: 'right' | 'top' | 'none'
+  /**
+   * ms-epoch timestamp at which to draw a vertical indicator line inside
+   * the plot area. Useful for highlighting a selected event.
+   */
+  highlightTime?: number
+  /**
+   * SVG preserveAspectRatio attribute. Defaults to 'xMidYMid meet'.
+   * Pass 'none' to stretch the chart to fill the container (no letterboxing).
+   */
+  preserveAspectRatio?: string
+  /**
+   * Font size for axis labels (depth scale and time labels). Defaults to 6 SVG units.
+   * Pass a smaller value (e.g. 4) when displaying in a large container where the
+   * labels would otherwise appear oversized.
+   */
+  labelFontSize?: number
+  /**
+   * When true, reduces the comms tick area height and axis label space so the
+   * depth chart body occupies the maximum proportion of the SVG height.
+   */
+  compact?: boolean
   className?: string
   style?: React.CSSProperties
 }
+
+/**
+ * SVG unit overhead values for compact mode (legendPosition='none').
+ * Use these to compute the `height` prop that fills a measured container.
+ * viewBoxH = height + COMPACT_TICK_OVERHEAD + COMPACT_AXIS_OVERHEAD
+ */
+export const COMPACT_TICK_OVERHEAD = 1 * 4 * 1.2 + 1 + 2 // tickRowGap*4 + tickRowHeight + 2 ≈ 7.8
+export const COMPACT_AXIS_OVERHEAD_BASE = 4 // added to labelFontSize: axisOverhead = labelFontSize + 4
 
 // Dynamic max-depth scale matching auvstatus.py
 const DEPTH_STOPS = [40, 80, 120, 160, 240, 300, 600, 1200, 1600, 2500]
@@ -73,6 +109,11 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
   height: h = 20,
   windowMinutes = 480,
   responsive = false,
+  legendPosition = 'right',
+  highlightTime,
+  preserveAspectRatio,
+  labelFontSize = 6,
+  compact = false,
   className,
   style,
 }) => {
@@ -99,11 +140,10 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
 
   const xdiv = windowMinutes / w // minutes per pixel
 
-  const svgWidth = w + 68 // right margin: comms legend row + combined time·dot·ago row
-
-  // Rows of comms ticks sit above the depth box
-  const tickRowHeight = 1.5
-  const tickRowGap = 2
+  // Rows of comms ticks sit above the depth box.
+  // compact=true squeezes these to give the depth chart more room.
+  const tickRowHeight = compact ? 0.6 : 1.5
+  const tickRowGap = compact ? 1.2 : 2
   const tickRows: Record<
     string,
     { times: number[]; color: string; y: number }
@@ -267,6 +307,7 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
     nowBucket,
     nowMs,
     nowMin,
+    // tickRows is derived from props above — no extra dep needed
   ])
 
   if (!chart) return null
@@ -287,9 +328,22 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
     isPadded,
   } = chart
 
-  // SVG viewBox: x0=0, top accounting for tick rows, full width + right labels
-  const viewBoxTop = y0 - tickAreaHeight - 2
-  const viewBoxH = h + tickAreaHeight + 14 // +14 for axis labels below
+  // 'none' and 'top' both eliminate the right margin; 'top' also reserves
+  // extra space above tick rows for the compact in-SVG legend row.
+  const svgWidth = legendPosition === 'right' ? w + 68 : w + 2
+  const topLegendHeight = legendPosition === 'top' ? 7 : 0
+  // Reduce top gap so comms bars sit near the SVG top edge (was -2, now -0.5)
+  const viewBoxTop = y0 - tickAreaHeight - 0.5 - topLegendHeight
+  // compact: extra room so axis labels clear the chart border
+  const axisOverhead = compact ? labelFontSize + 7 : 14
+  const viewBoxH = h + tickAreaHeight + axisOverhead + topLegendHeight
+
+  // Highlight line x coordinate (SVG units). Computed outside useMemo since it
+  // depends on highlightTime which can change independently of chart data.
+  const highlightX =
+    highlightTime != null
+      ? boxRight - (nowMin - highlightTime / 60000) / xdiv
+      : null
 
   return (
     <svg
@@ -297,6 +351,7 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
       viewBox={`${x0 - 1} ${viewBoxTop} ${svgWidth} ${viewBoxH}`}
       width={responsive ? undefined : svgWidth}
       height={responsive ? undefined : viewBoxH}
+      preserveAspectRatio={preserveAspectRatio}
       className={clsx('depth-sparkline', className)}
       style={responsive ? { width: '100%', height: '100%', ...style } : style}
       role="img"
@@ -350,55 +405,143 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
       {/* Comms + GPS tick marks */}
       {tickElems}
 
-      {/* Legend — dot flush against label, both vertically centered on the same baseline */}
-      <circle cx={x0 + w + 3} cy={y0} r={1.5} fill="#3b82f6" />
-      <text
-        x={x0 + w + 5}
-        y={y0}
-        fontSize={5}
-        fill="#374151"
-        dominantBaseline="central"
-      >
-        argo
-      </text>
-      <circle cx={x0 + w + 20} cy={y0} r={1.5} fill="#a855f7" />
-      <text
-        x={x0 + w + 22}
-        y={y0}
-        fontSize={5}
-        fill="#374151"
-        dominantBaseline="central"
-      >
-        gps
-      </text>
-      <circle cx={x0 + w + 37} cy={y0} r={1.5} fill="#f97316" />
-      <text
-        x={x0 + w + 39}
-        y={y0}
-        fontSize={5}
-        fill="#374151"
-        dominantBaseline="central"
-      >
-        sat
-      </text>
-      <circle cx={x0 + w + 53} cy={y0} r={1.5} fill="#22c55e" />
-      <text
-        x={x0 + w + 55}
-        y={y0}
-        fontSize={5}
-        fill="#374151"
-        dominantBaseline="central"
-      >
-        cell
-      </text>
+      {/* Legend: right layout (default) */}
+      {legendPosition === 'right' && (
+        <>
+          <circle cx={x0 + w + 3} cy={y0} r={1.5} fill="#3b82f6" />
+          <text
+            x={x0 + w + 5}
+            y={y0}
+            fontSize={5}
+            fill="#374151"
+            dominantBaseline="central"
+          >
+            argo
+          </text>
+          <circle cx={x0 + w + 20} cy={y0} r={1.5} fill="#a855f7" />
+          <text
+            x={x0 + w + 22}
+            y={y0}
+            fontSize={5}
+            fill="#374151"
+            dominantBaseline="central"
+          >
+            gps
+          </text>
+          <circle cx={x0 + w + 37} cy={y0} r={1.5} fill="#f97316" />
+          <text
+            x={x0 + w + 39}
+            y={y0}
+            fontSize={5}
+            fill="#374151"
+            dominantBaseline="central"
+          >
+            sat
+          </text>
+          <circle cx={x0 + w + 53} cy={y0} r={1.5} fill="#22c55e" />
+          <text
+            x={x0 + w + 55}
+            y={y0}
+            fontSize={5}
+            fill="#374151"
+            dominantBaseline="central"
+          >
+            cell
+          </text>
+          <text x={x0 + w + 2} y={y0 + 10} fontSize={6} fill="#374151">
+            {timeLabel}
+          </text>
+          <circle
+            cx={x0 + w + 23}
+            cy={y0 + 7}
+            r={2}
+            fill={isPadded && isStale ? '#f97316' : '#22c55e'}
+          />
+          <text x={x0 + w + 27} y={y0 + 10} fontSize={5} fill="#6b7280">
+            ({agoLabel})
+          </text>
+        </>
+      )}
+
+      {/* Legend: top layout — single compact row above tick rows */}
+      {legendPosition === 'top' && (
+        <>
+          {/* comms type dots — left half */}
+          <circle cx={x0} cy={viewBoxTop + 3} r={1.2} fill="#3b82f6" />
+          <text
+            x={x0 + 2.5}
+            y={viewBoxTop + 3}
+            fontSize={4}
+            fill="#374151"
+            dominantBaseline="central"
+          >
+            argo
+          </text>
+          <circle cx={x0 + 14} cy={viewBoxTop + 3} r={1.2} fill="#a855f7" />
+          <text
+            x={x0 + 16.5}
+            y={viewBoxTop + 3}
+            fontSize={4}
+            fill="#374151"
+            dominantBaseline="central"
+          >
+            gps
+          </text>
+          <circle cx={x0 + 27} cy={viewBoxTop + 3} r={1.2} fill="#f97316" />
+          <text
+            x={x0 + 29.5}
+            y={viewBoxTop + 3}
+            fontSize={4}
+            fill="#374151"
+            dominantBaseline="central"
+          >
+            sat
+          </text>
+          <circle cx={x0 + 39} cy={viewBoxTop + 3} r={1.2} fill="#22c55e" />
+          <text
+            x={x0 + 41.5}
+            y={viewBoxTop + 3}
+            fontSize={4}
+            fill="#374151"
+            dominantBaseline="central"
+          >
+            cell
+          </text>
+          {/* last-data time · freshness dot · ago — right half */}
+          <text
+            x={x0 + 60}
+            y={viewBoxTop + 3}
+            fontSize={4}
+            fill="#374151"
+            dominantBaseline="central"
+          >
+            {timeLabel}
+          </text>
+          <circle
+            cx={x0 + 73}
+            cy={viewBoxTop + 3}
+            r={1.5}
+            fill={isPadded && isStale ? '#f97316' : '#22c55e'}
+          />
+          <text
+            x={x0 + 76}
+            y={viewBoxTop + 3}
+            fontSize={4}
+            fill="#6b7280"
+            dominantBaseline="central"
+          >
+            ({agoLabel})
+          </text>
+        </>
+      )}
 
       {/* Axis time labels below the box */}
       {axisLabels.map(({ frac, label, anchor }) => (
         <text
           key={`ax-${frac}`}
           x={x0 + w * frac + (frac === 0 ? 1 : -2)}
-          y={y0 + h + 5}
-          fontSize={6}
+          y={y0 + h + (compact ? 4 : 5)}
+          fontSize={labelFontSize}
           fill="#6b7280"
           textAnchor={anchor}
         >
@@ -406,24 +549,28 @@ const DepthSparkline: React.FC<DepthSparklineProps> = ({
         </text>
       ))}
 
-      {/* Max depth label (bottom-left inside box) */}
-      <text x={x0 + 1} y={y0 + h - 1} fontSize={6} fill="#374151">
+      {/* Max depth label — positioned near bottom of box but clear of the border */}
+      <text
+        x={x0 + 1}
+        y={y0 + h - (compact ? labelFontSize + 0.5 : 1)}
+        fontSize={labelFontSize}
+        fill="#374151"
+      >
         {depthScale}m
       </text>
 
-      {/* Last data: time · freshness dot · age — all on one line */}
-      <text x={x0 + w + 2} y={y0 + 10} fontSize={6} fill="#374151">
-        {timeLabel}
-      </text>
-      <circle
-        cx={x0 + w + 23}
-        cy={y0 + 7}
-        r={2}
-        fill={isPadded && isStale ? '#f97316' : '#22c55e'}
-      />
-      <text x={x0 + w + 27} y={y0 + 10} fontSize={5} fill="#6b7280">
-        ({agoLabel})
-      </text>
+      {/* Vertical indicator line for a selected event time */}
+      {highlightX != null && highlightX >= x0 && highlightX <= boxRight && (
+        <line
+          x1={highlightX}
+          y1={y0}
+          x2={highlightX}
+          y2={y0 + h}
+          stroke="#ef4444"
+          strokeWidth={0.3}
+          strokeDasharray="2 1"
+        />
+      )}
 
       {/* Border rendered last so it sits on top of grid lines and polygons */}
       <rect


### PR DESCRIPTION
## Summary

- Adds a new **Watch Summary** tab to the vehicle drawer, implementing Issue #777
- Displays an adaptive 8-hour depth sparkline (left, ~2/3 width) alongside a scrollable event timeline (right, ~1/3 width)
- Sparkline uses a `ResizeObserver` to match its SVG viewBox aspect ratio exactly to the container — no letterboxing or distortion, fully responsive to drawer resize
- Comms legend (argo/gps/sat/cell) and last-data time rendered as HTML alongside the SVG for maximum chart real estate
- Event timeline shows the last 8 hours of command, comms, critical, emergency, fault, important, mission, and note events with color-coded filter chips (All / per-type toggle)
- Clicking an event row draws a vertical red indicator line on the sparkline at that event's timestamp

## DepthSparkline enhancements (`packages/react-ui`)

- `legendPosition='none'` — omits the in-SVG legend entirely for external rendering
- `compact` — reduces comms tick bar height and axis label spacing so the depth chart occupies maximum vertical space
- `labelFontSize` — configurable axis label font size (SVG units)
- `preserveAspectRatio` — passed through to the SVG element for caller-controlled scaling behavior

## Test plan

- [ ] Open Watch Summary tab on a vehicle with active deployment — sparkline renders and fills the left column
- [ ] Comms bars (argo/gps/sat/cell) visible above the depth chart
- [ ] Last-data time and freshness dot display correctly in the right legend column
- [ ] Event list loads and scrolls; All chip active by default; type chips filter correctly
- [ ] Clicking an event row shows red vertical line on sparkline; clicking again clears it
- [ ] Resize the vehicle drawer panel — sparkline re-fits without letterboxing
- [ ] Depth Data tab and Vehicle State tab still work normally

[Dash5 - feat: Watch Summary tab for vehicle drawer (#777) #778 - Watch Video](https://www.loom.com/share/ff536edfdc204a0baaad54fee48f8f30)
