### PR TITLE
fix: gate map marker edits behind login

### DIFF
--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -13,6 +13,8 @@ import VehicleColorsModal from './VehicleColorsModal'
 import { MapRefreshButton } from './MapRefreshButton'
 import useTrackedVehicles from '../lib/useTrackedVehicles'
 import { useRefreshPositions } from '../lib/useRefreshPositions'
+import { useClearMarkerEditModeWhenLoggedOut } from '../lib/useClearMarkerEditModeWhenLoggedOut'
+import { getDraggableMarkerEditProps } from '../lib/getDraggableMarkerEditProps'
 
 // This is a tricky workaround to prevent leaflet from crashing next.js
 // SSR. If we don't do this, the leaflet map will be loaded server side
@@ -238,19 +240,13 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   const { authenticated } = useTethysApiContext()
   const canEditMarkers = !!authenticated
 
-  // Prevent add/edit marker mode from sticking after logout.
-  useEffect(() => {
-    if (!canEditMarkers) {
-      if (isAddingMarkers) setIsAddingMarkers(false)
-      if (activeEditMarkerId) setActiveEditMarkerId(null)
-    }
-  }, [
+  useClearMarkerEditModeWhenLoggedOut({
     canEditMarkers,
     isAddingMarkers,
     activeEditMarkerId,
     setIsAddingMarkers,
     setActiveEditMarkerId,
-  ])
+  })
 
   const latestVehicle = useRef(vehicleName)
   useEffect(() => {
@@ -735,54 +731,30 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
                     position={[marker.lat, marker.lng]}
                     index={marker.index}
                     label={marker.label}
-                    draggable={canEditMarkers}
                     isSelected={selectedMarkerId === marker.id.toString()}
                     isNew={marker.isNew}
                     savedToLayer={marker.savedToLayer}
                     iconColor={marker.iconColor || defaultMarkerColor}
                     onClick={() => handleMarkerClick(marker.id.toString())}
-                    onDragEnd={
-                      canEditMarkers
-                        ? (newPos) =>
-                            handleMarkerPositionChange(
-                              marker.id.toString(),
-                              newPos
-                            )
-                        : undefined
-                    }
-                    onEditStateChange={
-                      canEditMarkers
-                        ? (isEditing) => {
-                            setActiveEditMarkerId(
-                              isEditing ? marker.id.toString() : null
-                            )
-                          }
-                        : undefined
-                    }
-                    onEdit={
-                      canEditMarkers
-                        ? () => handleEditMarker(marker.id.toString())
-                        : undefined
-                    }
-                    onDelete={
-                      canEditMarkers
-                        ? () => handleDeleteMarker(marker.id.toString())
-                        : undefined
-                    }
-                    onColorChange={
-                      canEditMarkers
-                        ? (color) =>
-                            handleMarkerColorChange(marker.id.toString(), color)
-                        : undefined
-                    }
-                    onSaveToLayer={
-                      canEditMarkers ? handleSaveMarkerToLayer : undefined
-                    }
-                    onRemoveFromLayer={
-                      canEditMarkers
-                        ? (id) => handleSaveMarkerToLayer(id, false)
-                        : undefined
-                    }
+                    {...getDraggableMarkerEditProps(canEditMarkers, {
+                      onDragEnd: (newPos) =>
+                        handleMarkerPositionChange(
+                          marker.id.toString(),
+                          newPos
+                        ),
+                      onEditStateChange: (isEditing) => {
+                        setActiveEditMarkerId(
+                          isEditing ? marker.id.toString() : null
+                        )
+                      },
+                      onEdit: () => handleEditMarker(marker.id.toString()),
+                      onDelete: () => handleDeleteMarker(marker.id.toString()),
+                      onColorChange: (color) =>
+                        handleMarkerColorChange(marker.id.toString(), color),
+                      onSaveToLayer: handleSaveMarkerToLayer,
+                      onRemoveFromLayer: (id) =>
+                        handleSaveMarkerToLayer(id, false),
+                    })}
                   />
                 )
             )

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -2,7 +2,7 @@ import dynamic from 'next/dynamic'
 import React, { useCallback, useState, useRef, useEffect, useMemo } from 'react'
 import { useManagedWaypoints } from '@mbari/react-ui'
 import useGoogleElevator from '../lib/useGoogleElevator'
-import { VPosDetail, useStations } from '@mbari/api-client'
+import { VPosDetail, useStations, useTethysApiContext } from '@mbari/api-client'
 import { MapLayersListModal } from '../components/MapLayersListModal'
 import { useSelectedStations } from './SelectedStationContext'
 import { useMarkers } from './MarkerContext'
@@ -235,6 +235,15 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
     setActiveEditMarkerId,
     setMarkers,
   } = useMarkers()
+  const { authenticated } = useTethysApiContext()
+  const canEditMarkers = !!authenticated
+
+  // Prevent add-marker mode from sticking after logout.
+  useEffect(() => {
+    if (!canEditMarkers && isAddingMarkers) {
+      setIsAddingMarkers(false)
+    }
+  }, [canEditMarkers, isAddingMarkers, setIsAddingMarkers])
 
   const latestVehicle = useRef(vehicleName)
   useEffect(() => {
@@ -690,19 +699,21 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
           onRequestFitBounds={handleFitBoundsRequest}
           onRequestStations={handleLayersRequest}
           onRequestVehicleColors={handleVehicleColorRequest}
-          isAddingMarkers={isAddingMarkers}
-          onToggleMarkerMode={handleToggleMarkerMode}
+          isAddingMarkers={canEditMarkers && isAddingMarkers}
+          onToggleMarkerMode={
+            canEditMarkers ? handleToggleMarkerMode : undefined
+          }
           onRequestMarkers={handleMarkersRequest}
           renderMapClickHandler={() => (
             <MapClickHandler
-              isAddingMarkers={isAddingMarkers}
+              isAddingMarkers={canEditMarkers && isAddingMarkers}
               isEditingMarker={false}
               onAddMarker={handleAddMarker}
             />
           )}
           renderCustomMarkerSet={() => (
             <CustomMarkerSet
-              isAddingMarkers={isAddingMarkers}
+              isAddingMarkers={canEditMarkers && isAddingMarkers}
               setIsAddingMarkers={(value) => setIsAddingMarkers(value)}
             />
           )}
@@ -717,28 +728,53 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
                     position={[marker.lat, marker.lng]}
                     index={marker.index}
                     label={marker.label}
-                    draggable={true}
+                    draggable={canEditMarkers}
                     isSelected={selectedMarkerId === marker.id.toString()}
                     isNew={marker.isNew}
                     savedToLayer={marker.savedToLayer}
                     iconColor={marker.iconColor || defaultMarkerColor}
                     onClick={() => handleMarkerClick(marker.id.toString())}
-                    onDragEnd={(newPos) =>
-                      handleMarkerPositionChange(marker.id.toString(), newPos)
+                    onDragEnd={
+                      canEditMarkers
+                        ? (newPos) =>
+                            handleMarkerPositionChange(
+                              marker.id.toString(),
+                              newPos
+                            )
+                        : undefined
                     }
-                    onEditStateChange={(isEditing) => {
-                      setActiveEditMarkerId(
-                        isEditing ? marker.id.toString() : null
-                      )
-                    }}
-                    onEdit={() => handleEditMarker(marker.id.toString())}
-                    onDelete={() => handleDeleteMarker(marker.id.toString())}
-                    onColorChange={(color) =>
-                      handleMarkerColorChange(marker.id.toString(), color)
+                    onEditStateChange={
+                      canEditMarkers
+                        ? (isEditing) => {
+                            setActiveEditMarkerId(
+                              isEditing ? marker.id.toString() : null
+                            )
+                          }
+                        : undefined
                     }
-                    onSaveToLayer={handleSaveMarkerToLayer}
-                    onRemoveFromLayer={(id) =>
-                      handleSaveMarkerToLayer(id, false)
+                    onEdit={
+                      canEditMarkers
+                        ? () => handleEditMarker(marker.id.toString())
+                        : undefined
+                    }
+                    onDelete={
+                      canEditMarkers
+                        ? () => handleDeleteMarker(marker.id.toString())
+                        : undefined
+                    }
+                    onColorChange={
+                      canEditMarkers
+                        ? (color) =>
+                            handleMarkerColorChange(marker.id.toString(), color)
+                        : undefined
+                    }
+                    onSaveToLayer={
+                      canEditMarkers ? handleSaveMarkerToLayer : undefined
+                    }
+                    onRemoveFromLayer={
+                      canEditMarkers
+                        ? (id) => handleSaveMarkerToLayer(id, false)
+                        : undefined
                     }
                   />
                 )

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -238,12 +238,19 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
   const { authenticated } = useTethysApiContext()
   const canEditMarkers = !!authenticated
 
-  // Prevent add-marker mode from sticking after logout.
+  // Prevent add/edit marker mode from sticking after logout.
   useEffect(() => {
-    if (!canEditMarkers && isAddingMarkers) {
-      setIsAddingMarkers(false)
+    if (!canEditMarkers) {
+      if (isAddingMarkers) setIsAddingMarkers(false)
+      if (activeEditMarkerId) setActiveEditMarkerId(null)
     }
-  }, [canEditMarkers, isAddingMarkers, setIsAddingMarkers])
+  }, [
+    canEditMarkers,
+    isAddingMarkers,
+    activeEditMarkerId,
+    setIsAddingMarkers,
+    setActiveEditMarkerId,
+  ])
 
   const latestVehicle = useRef(vehicleName)
   useEffect(() => {

--- a/apps/lrauv-dash2/components/DeploymentMap.tsx
+++ b/apps/lrauv-dash2/components/DeploymentMap.tsx
@@ -707,7 +707,7 @@ const DeploymentMap: React.FC<DeploymentMapProps> = ({
           renderMapClickHandler={() => (
             <MapClickHandler
               isAddingMarkers={canEditMarkers && isAddingMarkers}
-              isEditingMarker={false}
+              isEditingMarker={!!activeEditMarkerId}
               onAddMarker={handleAddMarker}
             />
           )}

--- a/apps/lrauv-dash2/components/DraggableMarker.test.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.test.tsx
@@ -93,4 +93,18 @@ describe('DraggableMarker write controls', () => {
     expect(screen.getByTitle('Save to Map Layers')).toBeInTheDocument()
     expect(screen.getByTitle('Close')).toBeInTheDocument()
   })
+
+  it('notifies parent when edit mode changes via onEditStateChange', () => {
+    const onEditStateChange = jest.fn()
+    render(
+      <DraggableMarker
+        {...baseProps}
+        onEdit={jest.fn()}
+        onEditStateChange={onEditStateChange}
+      />
+    )
+
+    // Effect notifies parent of current editMode (false on mount).
+    expect(onEditStateChange).toHaveBeenCalledWith(false)
+  })
 })

--- a/apps/lrauv-dash2/components/DraggableMarker.test.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom'
 import React from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 jest.mock('react-leaflet', () => {
   const mockReact = require('react')
@@ -94,7 +95,8 @@ describe('DraggableMarker write controls', () => {
     expect(screen.getByTitle('Close')).toBeInTheDocument()
   })
 
-  it('notifies parent when edit mode changes via onEditStateChange', () => {
+  it('notifies parent when the user enters edit mode', async () => {
+    const user = userEvent.setup()
     const onEditStateChange = jest.fn()
     render(
       <DraggableMarker
@@ -104,7 +106,8 @@ describe('DraggableMarker write controls', () => {
       />
     )
 
-    // Effect notifies parent of current editMode (false on mount).
-    expect(onEditStateChange).toHaveBeenCalledWith(false)
+    onEditStateChange.mockClear()
+    await user.click(screen.getByTitle('Edit marker'))
+    expect(onEditStateChange).toHaveBeenCalledWith(true)
   })
 })

--- a/apps/lrauv-dash2/components/DraggableMarker.test.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.test.tsx
@@ -1,0 +1,96 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+
+jest.mock('react-leaflet', () => {
+  const mockReact = require('react')
+  return {
+    Marker: mockReact.forwardRef(
+      (
+        { children }: { children?: React.ReactNode },
+        _ref: React.Ref<HTMLDivElement>
+      ) => <div data-testid="leaflet-marker">{children}</div>
+    ),
+    Popup: mockReact.forwardRef(
+      (
+        { children }: { children?: React.ReactNode },
+        _ref: React.Ref<HTMLDivElement>
+      ) => <div data-testid="leaflet-popup">{children}</div>
+    ),
+    Tooltip: ({ children }: { children?: React.ReactNode }) => (
+      <div data-testid="leaflet-tooltip">{children}</div>
+    ),
+    useMap: () => ({}),
+  }
+})
+
+jest.mock('leaflet', () => ({
+  divIcon: jest.fn(() => ({})),
+}))
+
+jest.mock('react-dom/server', () => ({
+  renderToString: jest.fn(() => '<div />'),
+}))
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: Object.assign(jest.fn(), {
+    success: jest.fn(),
+    error: jest.fn(),
+  }),
+}))
+
+jest.mock('@mbari/utils', () => ({
+  createLogger: jest.fn(() => ({
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  })),
+}))
+
+jest.mock('./MarkerContext', () => ({
+  useMarkers: () => ({
+    handleMarkerSave: jest.fn(),
+    saveMarkerToLayer: jest.fn(),
+    removeMarkerFromLayer: jest.fn(),
+  }),
+}))
+
+import DraggableMarker from './DraggableMarker'
+
+const baseProps = {
+  id: '1',
+  position: [36.8, -121.9] as [number, number],
+  label: 'Test Marker',
+  index: 0,
+  isSelected: true,
+  draggable: false,
+}
+
+describe('DraggableMarker write controls', () => {
+  it('hides Edit and Delete when write handlers are omitted', () => {
+    render(<DraggableMarker {...baseProps} />)
+
+    expect(screen.getAllByText('Test Marker').length).toBeGreaterThan(0)
+    expect(screen.getByTitle('Close')).toBeInTheDocument()
+    expect(screen.queryByTitle('Edit marker')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Delete marker')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Save to Map Layers')).not.toBeInTheDocument()
+  })
+
+  it('shows Edit and Delete when write handlers are provided', () => {
+    render(
+      <DraggableMarker
+        {...baseProps}
+        onEdit={jest.fn()}
+        onDelete={jest.fn()}
+        onSaveToLayer={jest.fn()}
+      />
+    )
+
+    expect(screen.getByTitle('Edit marker')).toBeInTheDocument()
+    expect(screen.getByTitle('Delete marker')).toBeInTheDocument()
+    expect(screen.getByTitle('Save to Map Layers')).toBeInTheDocument()
+    expect(screen.getByTitle('Close')).toBeInTheDocument()
+  })
+})

--- a/apps/lrauv-dash2/components/DraggableMarker.test.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.test.tsx
@@ -110,4 +110,22 @@ describe('DraggableMarker write controls', () => {
     await user.click(screen.getByTitle('Edit marker'))
     expect(onEditStateChange).toHaveBeenCalledWith(true)
   })
+
+  it('uses the latest label when entering edit mode after an external rename', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <DraggableMarker {...baseProps} onEdit={jest.fn()} />
+    )
+
+    rerender(
+      <DraggableMarker
+        {...baseProps}
+        label="Renamed Marker"
+        onEdit={jest.fn()}
+      />
+    )
+
+    await user.click(screen.getByTitle('Edit marker'))
+    expect(screen.getByTitle('Edit marker label')).toHaveValue('Renamed Marker')
+  })
 })

--- a/apps/lrauv-dash2/components/DraggableMarker.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.tsx
@@ -210,11 +210,23 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
     }
   }, [isNew, editMode, canEdit])
 
-  // Single notification path for edit-mode changes (covers toggles and
-  // direct setEditMode calls such as logout / new-marker auto-edit).
+  // Keep the latest parent callback without re-subscribing when parents pass
+  // a new inline function each render (which would re-fire this effect).
+  const onEditStateChangeRef = useRef(onEditStateChange)
   useEffect(() => {
-    onEditStateChange?.(editMode)
-  }, [editMode, onEditStateChange])
+    onEditStateChangeRef.current = onEditStateChange
+  }, [onEditStateChange])
+
+  // Notify parent only on real editMode transitions — skip mount so an
+  // initial `false` does not clear another marker's activeEditMarkerId.
+  const isFirstEditModeNotify = useRef(true)
+  useEffect(() => {
+    if (isFirstEditModeNotify.current) {
+      isFirstEditModeNotify.current = false
+      return
+    }
+    onEditStateChangeRef.current?.(editMode)
+  }, [editMode])
 
   // Update position when props change
   useEffect(() => {

--- a/apps/lrauv-dash2/components/DraggableMarker.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.tsx
@@ -152,6 +152,16 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
     // )
   }, [])
 
+  const canEdit = !!onEdit
+
+  // Defense in depth: never remain in edit mode without an edit handler.
+  useEffect(() => {
+    if (!canEdit && editMode) {
+      setEditMode(false)
+      setShowColorOptions(false)
+    }
+  }, [canEdit, editMode])
+
   // Open the popup when the marker is clicked
   useEffect(() => {
     if (isNew) {
@@ -167,25 +177,27 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
         try {
           marker.openPopup()
 
-          // Set edit mode after popup is open
-          setEditMode(true)
-          setShowColorOptions(false)
+          // Set edit mode after popup is open (only when editing is allowed)
+          if (canEdit) {
+            setEditMode(true)
+            setShowColorOptions(false)
 
-          // Focus the input field
-          setTimeout(() => {
-            if (inputRef.current) {
-              inputRef.current.focus()
-              inputRef.current.select()
-            } else {
-              logger.warn('Input ref not available')
-            }
-          }, 100)
+            // Focus the input field
+            setTimeout(() => {
+              if (inputRef.current) {
+                inputRef.current.focus()
+                inputRef.current.select()
+              } else {
+                logger.warn('Input ref not available')
+              }
+            }, 100)
+          }
         } catch (err) {
           toast.error(`Error opening popup: ${(err as Error)?.message || err}`)
         }
       }, 100) // Slightly longer delay
     }
-  }, [isNew, id])
+  }, [isNew, id, canEdit])
 
   // Keep the popup open when editing
   useEffect(() => {
@@ -201,13 +213,13 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
 
   // Keep the popup open when selected
   useEffect(() => {
-    // Only new markers should automatically enter edit mode
-    if (isNew && !editMode) {
+    // Only new markers should automatically enter edit mode when allowed
+    if (isNew && canEdit && !editMode) {
       setEditMode(true)
       setShowColorOptions(false)
     }
     // Remove the isSelected
-  }, [isNew, editMode])
+  }, [isNew, editMode, canEdit])
 
   // Notify parent when edit mode changes
   useEffect(() => {
@@ -411,6 +423,7 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
   // Prevent popup from closing when clicking inside it
   const handleEditClick = useCallback(
     (e: React.MouseEvent) => {
+      if (!onEdit) return
       // Stop popup from closing
       e.stopPropagation()
       e.preventDefault()
@@ -425,7 +438,7 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
       setShowColorOptions(false)
       handleEditModeToggle(true)
     },
-    [handleEditModeToggle]
+    [handleEditModeToggle, onEdit]
   )
 
   const handleToggleColorOptions = useCallback((e: React.MouseEvent) => {
@@ -571,9 +584,9 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
             </div>
           )}
 
-          {/* Control buttons */}
+          {/* Control buttons — write actions only when handlers are provided */}
           <div className={`mt-1 flex h-8 justify-between gap-0`}>
-            {editMode ? (
+            {editMode && canEdit ? (
               <>
                 {/* Edit mode buttons - Cancel, Color, Save */}
                 <button
@@ -582,17 +595,19 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
                 >
                   Cancel
                 </button>
-                <button
-                  onClick={handleToggleColorOptions}
-                  className="rounded bg-blue-500 px-2 py-1 text-xs text-white"
-                  title={
-                    showColorOptions
-                      ? 'Hide marker colors'
-                      : 'Edit marker colors'
-                  }
-                >
-                  <FontAwesomeIcon icon={faPalette} size="lg" />
-                </button>
+                {onColorChange && (
+                  <button
+                    onClick={handleToggleColorOptions}
+                    className="rounded bg-blue-500 px-2 py-1 text-xs text-white"
+                    title={
+                      showColorOptions
+                        ? 'Hide marker colors'
+                        : 'Edit marker colors'
+                    }
+                  >
+                    <FontAwesomeIcon icon={faPalette} size="lg" />
+                  </button>
+                )}
                 <button
                   onClick={handleSaveClick}
                   className="rounded bg-blue-500 px-2 py-1 text-xs text-white"
@@ -602,52 +617,58 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
               </>
             ) : (
               <>
-                <button
-                  onClick={handleDelete}
-                  className="rounded bg-red-500 px-2 py-1 text-xs text-white"
-                  title="Delete marker"
-                >
-                  <FontAwesomeIcon icon={faTrashCan} size="lg" />
-                </button>
-
-                {!savedToLayer ? (
+                {onDelete && (
                   <button
-                    onClick={handleSaveToLayer}
-                    className="rounded bg-green-500 px-2 py-1 text-xs text-white"
-                    title="Save to Map Layers"
+                    onClick={handleDelete}
+                    className="rounded bg-red-500 px-2 py-1 text-xs text-white"
+                    title="Delete marker"
                   >
-                    <FontAwesomeIcon
-                      icon={faFlag} // Use regular star if available
-                      style={{ color: '#FFFFFF' }}
-                      size="lg"
-                    />
-                  </button>
-                ) : (
-                  <button
-                    onClick={handleRemoveFromLayer}
-                    className="relative rounded bg-white px-2 py-1 text-xs text-black"
-                    style={{
-                      borderWidth: '1px',
-                      borderColor: '#3b82f6',
-                      borderStyle: 'solid',
-                    }}
-                    title="Remove from Map Layers"
-                  >
-                    <FontAwesomeIcon
-                      icon={faStar}
-                      style={{ color: '#FFD700' }} // Gold color
-                      size="lg"
-                    />
+                    <FontAwesomeIcon icon={faTrashCan} size="lg" />
                   </button>
                 )}
 
-                <button
-                  onClick={handleEditClick}
-                  className="rounded bg-blue-500 px-2 py-1 text-xs text-white"
-                  title="Edit marker"
-                >
-                  <FontAwesomeIcon icon={faEdit} size="lg" />
-                </button>
+                {!savedToLayer
+                  ? onSaveToLayer && (
+                      <button
+                        onClick={handleSaveToLayer}
+                        className="rounded bg-green-500 px-2 py-1 text-xs text-white"
+                        title="Save to Map Layers"
+                      >
+                        <FontAwesomeIcon
+                          icon={faFlag}
+                          style={{ color: '#FFFFFF' }}
+                          size="lg"
+                        />
+                      </button>
+                    )
+                  : onRemoveFromLayer && (
+                      <button
+                        onClick={handleRemoveFromLayer}
+                        className="relative rounded bg-white px-2 py-1 text-xs text-black"
+                        style={{
+                          borderWidth: '1px',
+                          borderColor: '#3b82f6',
+                          borderStyle: 'solid',
+                        }}
+                        title="Remove from Map Layers"
+                      >
+                        <FontAwesomeIcon
+                          icon={faStar}
+                          style={{ color: '#FFD700' }}
+                          size="lg"
+                        />
+                      </button>
+                    )}
+
+                {canEdit && (
+                  <button
+                    onClick={handleEditClick}
+                    className="rounded bg-blue-500 px-2 py-1 text-xs text-white"
+                    title="Edit marker"
+                  >
+                    <FontAwesomeIcon icon={faEdit} size="lg" />
+                  </button>
+                )}
                 <button
                   onClick={handleClosePopup}
                   className="rounded bg-blue-500 px-2 py-1 text-xs text-white"
@@ -659,7 +680,7 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
             )}
           </div>
 
-          {editMode && showColorOptions && (
+          {editMode && canEdit && showColorOptions && (
             <div className="color-options-container mt-2">
               <p className="mb-1 text-xs font-semibold">Marker Color:</p>
               <div className="flex flex-wrap gap-0">

--- a/apps/lrauv-dash2/components/DraggableMarker.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.tsx
@@ -240,6 +240,13 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
     }
   }, [iconColor])
 
+  // Keep draft label in sync with external renames while not editing.
+  useEffect(() => {
+    if (!effectiveEditMode) {
+      setInputValue(label)
+    }
+  }, [label, effectiveEditMode])
+
   // Focus label input when entering effective edit mode
   useEffect(() => {
     if (effectiveEditMode && inputRef.current) {

--- a/apps/lrauv-dash2/components/DraggableMarker.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.tsx
@@ -147,8 +147,11 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
   }
 
   const canEdit = !!onEdit
+  // Immediate view-only when handlers disappear (logout) — do not wait for
+  // the cleanup effect below to clear editMode after paint.
+  const effectiveEditMode = editMode && canEdit
 
-  // Defense in depth: never remain in edit mode without an edit handler.
+  // Defense in depth: clear stale editMode once write handlers are gone.
   useEffect(() => {
     if (!canEdit && editMode) {
       setEditMode(false)
@@ -190,17 +193,14 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
     }, 100) // Slightly longer delay
   }, [isNew, id, canEdit])
 
-  // Keep the popup open when editing
+  // Keep the popup open while actively editing
   useEffect(() => {
-    // Get the marker's Leaflet instance
     const marker = markerRef.current
     if (!marker) return
-
-    // If in edit mode, ensure popup is open
-    if (editMode) {
+    if (effectiveEditMode) {
       marker.openPopup()
     }
-  }, [editMode])
+  }, [effectiveEditMode])
 
   // Newly added markers auto-enter edit mode when editing is allowed.
   useEffect(() => {
@@ -217,7 +217,7 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
     onEditStateChangeRef.current = onEditStateChange
   }, [onEditStateChange])
 
-  // Notify parent only on real editMode transitions — skip mount so an
+  // Notify parent only on real effective-edit transitions — skip mount so an
   // initial `false` does not clear another marker's activeEditMarkerId.
   const isFirstEditModeNotify = useRef(true)
   useEffect(() => {
@@ -225,8 +225,8 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
       isFirstEditModeNotify.current = false
       return
     }
-    onEditStateChangeRef.current?.(editMode)
-  }, [editMode])
+    onEditStateChangeRef.current?.(effectiveEditMode)
+  }, [effectiveEditMode])
 
   // Update position when props change
   useEffect(() => {
@@ -240,18 +240,17 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
     }
   }, [iconColor])
 
-  // Update input value when label changes
+  // Focus label input when entering effective edit mode
   useEffect(() => {
-    if (editMode && inputRef.current) {
-      // Focus the input and select all text
+    if (effectiveEditMode && inputRef.current) {
       setTimeout(() => {
         if (inputRef.current) {
           inputRef.current.focus()
           inputRef.current.select()
         }
-      }, 10) // Small timeout to ensure the input is rendered
+      }, 10)
     }
-  }, [editMode])
+  }, [effectiveEditMode])
 
   const handleEditModeToggle = useCallback((isEditing: boolean) => {
     setEditMode(isEditing)
@@ -519,9 +518,8 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
       {/* Render the popup only if the marker is selected */}
       <Popup
         ref={popupRef}
-        closeOnClick={!editMode}
+        closeOnClick={!effectiveEditMode}
         autoClose={false}
-        // autoClose={!editMode}
         className="marker-popup-container"
       >
         <div className="flex flex-col gap-0">
@@ -532,7 +530,7 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
                 style={{ backgroundColor: selectedColor }}
                 title={selectedColor}
               />
-              {editMode ? (
+              {effectiveEditMode ? (
                 <input
                   ref={inputRef}
                   type="text"
@@ -581,7 +579,7 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
 
           {/* Control buttons — write actions only when handlers are provided */}
           <div className={`mt-1 flex h-8 justify-between gap-0`}>
-            {editMode && canEdit ? (
+            {effectiveEditMode ? (
               <>
                 {/* Edit mode buttons - Cancel, Color, Save */}
                 <button
@@ -675,7 +673,7 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
             )}
           </div>
 
-          {editMode && canEdit && showColorOptions && (
+          {effectiveEditMode && showColorOptions && (
             <div className="color-options-container mt-2">
               <p className="mb-1 text-xs font-semibold">Marker Color:</p>
               <div className="flex flex-wrap gap-0">

--- a/apps/lrauv-dash2/components/DraggableMarker.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.tsx
@@ -162,41 +162,38 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
     }
   }, [canEdit, editMode])
 
-  // Open the popup when the marker is clicked
+  // Open the popup and enter edit mode for newly added markers (editable only).
+  // Gate on canEdit so logout / missing handlers do not reopen popups.
   useEffect(() => {
-    if (isNew) {
-      // First ensure the marker is mounted
-      const marker = markerRef.current
-      if (!marker) {
-        logger.warn('Marker ref not available yet')
-        return
-      }
+    if (!isNew || !canEdit) return
 
-      // Use nested timeouts for proper sequencing
-      setTimeout(() => {
-        try {
-          marker.openPopup()
-
-          // Set edit mode after popup is open (only when editing is allowed)
-          if (canEdit) {
-            setEditMode(true)
-            setShowColorOptions(false)
-
-            // Focus the input field
-            setTimeout(() => {
-              if (inputRef.current) {
-                inputRef.current.focus()
-                inputRef.current.select()
-              } else {
-                logger.warn('Input ref not available')
-              }
-            }, 100)
-          }
-        } catch (err) {
-          toast.error(`Error opening popup: ${(err as Error)?.message || err}`)
-        }
-      }, 100) // Slightly longer delay
+    // First ensure the marker is mounted
+    const marker = markerRef.current
+    if (!marker) {
+      logger.warn('Marker ref not available yet')
+      return
     }
+
+    // Use nested timeouts for proper sequencing
+    setTimeout(() => {
+      try {
+        marker.openPopup()
+        setEditMode(true)
+        setShowColorOptions(false)
+
+        // Focus the input field
+        setTimeout(() => {
+          if (inputRef.current) {
+            inputRef.current.focus()
+            inputRef.current.select()
+          } else {
+            logger.warn('Input ref not available')
+          }
+        }, 100)
+      } catch (err) {
+        toast.error(`Error opening popup: ${(err as Error)?.message || err}`)
+      }
+    }, 100) // Slightly longer delay
   }, [isNew, id, canEdit])
 
   // Keep the popup open when editing

--- a/apps/lrauv-dash2/components/DraggableMarker.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.tsx
@@ -212,11 +212,10 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
     // Remove the isSelected
   }, [isNew, editMode, canEdit])
 
-  // Notify parent when edit mode changes
+  // Single notification path for edit-mode changes (covers toggles and
+  // direct setEditMode calls such as logout / new-marker auto-edit).
   useEffect(() => {
-    if (onEditStateChange) {
-      onEditStateChange(editMode)
-    }
+    onEditStateChange?.(editMode)
   }, [editMode, onEditStateChange])
 
   // Update position when props change
@@ -244,14 +243,9 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
     }
   }, [editMode])
 
-  // Handle marker drag end
-  const handleEditModeToggle = useCallback(
-    (isEditing: boolean) => {
-      setEditMode(isEditing)
-      onEditStateChange?.(isEditing)
-    },
-    [onEditStateChange]
-  )
+  const handleEditModeToggle = useCallback((isEditing: boolean) => {
+    setEditMode(isEditing)
+  }, [])
 
   // Handle marker deletion
   const handleDelete = useCallback(

--- a/apps/lrauv-dash2/components/DraggableMarker.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.tsx
@@ -202,14 +202,12 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
     }
   }, [editMode])
 
-  // Keep the popup open when selected
+  // Newly added markers auto-enter edit mode when editing is allowed.
   useEffect(() => {
-    // Only new markers should automatically enter edit mode when allowed
     if (isNew && canEdit && !editMode) {
       setEditMode(true)
       setShowColorOptions(false)
     }
-    // Remove the isSelected
   }, [isNew, editMode, canEdit])
 
   // Single notification path for edit-mode changes (covers toggles and

--- a/apps/lrauv-dash2/components/DraggableMarker.tsx
+++ b/apps/lrauv-dash2/components/DraggableMarker.tsx
@@ -61,6 +61,7 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
   onColorChange,
   onSaveToLayer,
   onRemoveFromLayer,
+  onEditStateChange,
 }) => {
   const markerRef = useRef<L.Marker>(null)
   const [editMode, setEditMode] = useState(false)
@@ -144,13 +145,6 @@ const DraggableMarker: React.FC<DraggableMarkerProps> = ({
       tooltipAnchor: [-5, -25],
     })
   }
-
-  // Handle marker click
-  const onEditStateChange = useCallback((isEditing: boolean) => {
-    // logger.debug(
-    //   `Marker edit state changed: ${isEditing ? 'Editing' : 'Not Editing'}`
-    // )
-  }, [])
 
   const canEdit = !!onEdit
 

--- a/apps/lrauv-dash2/components/MarkerSection.tsx
+++ b/apps/lrauv-dash2/components/MarkerSection.tsx
@@ -1,16 +1,12 @@
 import React from 'react'
 import { useTethysApiContext } from '@mbari/api-client'
 import { useMarkers } from './MarkerContext'
-import { createLogger } from '@mbari/utils'
-
-const logger = createLogger('MarkerSection')
 
 export const MarkerSection: React.FC = () => {
   const {
     markers,
     toggleMarkerVisibility,
     updateMarker,
-    deleteMarker,
     removeMarkerFromLayer,
   } = useMarkers()
   const { authenticated } = useTethysApiContext()

--- a/apps/lrauv-dash2/components/MarkerSection.tsx
+++ b/apps/lrauv-dash2/components/MarkerSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useTethysApiContext } from '@mbari/api-client'
 import { useMarkers } from './MarkerContext'
 import { createLogger } from '@mbari/utils'
 
@@ -12,6 +13,8 @@ export const MarkerSection: React.FC = () => {
     deleteMarker,
     removeMarkerFromLayer,
   } = useMarkers()
+  const { authenticated } = useTethysApiContext()
+  const canEditMarkers = !!authenticated
 
   // Only show markers that are saved to layer
   const savedMarkers = markers.filter((marker) => marker.savedToLayer)
@@ -56,37 +59,39 @@ export const MarkerSection: React.FC = () => {
               </div>
             </label>
           </div>
-          <div className="flex">
-            <button
-              onClick={() => {
-                const newName = prompt('Rename marker:', marker.label)
-                if (newName) {
-                  updateMarker(marker.id.toString(), { label: newName })
-                }
-              }}
-              className="mr-2 text-blue-500 hover:text-blue-700"
-              aria-label={`Rename ${marker.label || 'Unnamed Marker'}`}
-            >
-              <span role="img" aria-label="Edit">
-                ✏️
-              </span>
-            </button>
-            <button
-              onClick={() => {
-                if (confirm('Remove this marker from map layers?')) {
-                  removeMarkerFromLayer(marker.id.toString())
-                }
-              }}
-              className="text-red-500 hover:text-red-700"
-              aria-label={`Remove ${
-                marker.label || 'Unnamed Marker'
-              } from layers`}
-            >
-              <span role="img" aria-label="Remove">
-                🗑️
-              </span>
-            </button>
-          </div>
+          {canEditMarkers && (
+            <div className="flex">
+              <button
+                onClick={() => {
+                  const newName = prompt('Rename marker:', marker.label)
+                  if (newName) {
+                    updateMarker(marker.id.toString(), { label: newName })
+                  }
+                }}
+                className="mr-2 text-blue-500 hover:text-blue-700"
+                aria-label={`Rename ${marker.label || 'Unnamed Marker'}`}
+              >
+                <span role="img" aria-label="Edit">
+                  ✏️
+                </span>
+              </button>
+              <button
+                onClick={() => {
+                  if (confirm('Remove this marker from map layers?')) {
+                    removeMarkerFromLayer(marker.id.toString())
+                  }
+                }}
+                className="text-red-500 hover:text-red-700"
+                aria-label={`Remove ${
+                  marker.label || 'Unnamed Marker'
+                } from layers`}
+              >
+                <span role="img" aria-label="Remove">
+                  🗑️
+                </span>
+              </button>
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/apps/lrauv-dash2/lib/getDraggableMarkerEditProps.test.ts
+++ b/apps/lrauv-dash2/lib/getDraggableMarkerEditProps.test.ts
@@ -1,0 +1,33 @@
+import { getDraggableMarkerEditProps } from './getDraggableMarkerEditProps'
+
+const handlers = {
+  onDragEnd: jest.fn(),
+  onEditStateChange: jest.fn(),
+  onEdit: jest.fn(),
+  onDelete: jest.fn(),
+  onColorChange: jest.fn(),
+  onSaveToLayer: jest.fn(),
+  onRemoveFromLayer: jest.fn(),
+}
+
+describe('getDraggableMarkerEditProps', () => {
+  it('returns write handlers and draggable when canEditMarkers is true', () => {
+    expect(getDraggableMarkerEditProps(true, handlers)).toEqual({
+      draggable: true,
+      ...handlers,
+    })
+  })
+
+  it('strips write handlers when canEditMarkers is false', () => {
+    expect(getDraggableMarkerEditProps(false, handlers)).toEqual({
+      draggable: false,
+      onDragEnd: undefined,
+      onEditStateChange: undefined,
+      onEdit: undefined,
+      onDelete: undefined,
+      onColorChange: undefined,
+      onSaveToLayer: undefined,
+      onRemoveFromLayer: undefined,
+    })
+  })
+})

--- a/apps/lrauv-dash2/lib/getDraggableMarkerEditProps.ts
+++ b/apps/lrauv-dash2/lib/getDraggableMarkerEditProps.ts
@@ -1,0 +1,35 @@
+type LatLng = [number, number]
+
+export type DraggableMarkerEditHandlers = {
+  onDragEnd: (pos: LatLng) => void
+  onEditStateChange: (isEditing: boolean) => void
+  onEdit: (newLabel: string) => void
+  onDelete: () => void
+  onColorChange: (color: string) => void
+  onSaveToLayer: (id: string) => void
+  onRemoveFromLayer: (id: string) => void
+}
+
+/** Gate DraggableMarker write props behind canEditMarkers (overview + vehicle maps). */
+export const getDraggableMarkerEditProps = (
+  canEditMarkers: boolean,
+  handlers: DraggableMarkerEditHandlers
+) => {
+  if (!canEditMarkers) {
+    return {
+      draggable: false as const,
+      onDragEnd: undefined,
+      onEditStateChange: undefined,
+      onEdit: undefined,
+      onDelete: undefined,
+      onColorChange: undefined,
+      onSaveToLayer: undefined,
+      onRemoveFromLayer: undefined,
+    }
+  }
+
+  return {
+    draggable: true as const,
+    ...handlers,
+  }
+}

--- a/apps/lrauv-dash2/lib/useClearMarkerEditModeWhenLoggedOut.test.ts
+++ b/apps/lrauv-dash2/lib/useClearMarkerEditModeWhenLoggedOut.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react'
+import { useClearMarkerEditModeWhenLoggedOut } from './useClearMarkerEditModeWhenLoggedOut'
+
+describe('useClearMarkerEditModeWhenLoggedOut', () => {
+  it('clears add and edit mode when canEditMarkers becomes false', () => {
+    const setIsAddingMarkers = jest.fn()
+    const setActiveEditMarkerId = jest.fn()
+
+    const { rerender } = renderHook(
+      ({ canEditMarkers }) =>
+        useClearMarkerEditModeWhenLoggedOut({
+          canEditMarkers,
+          isAddingMarkers: true,
+          activeEditMarkerId: '42',
+          setIsAddingMarkers,
+          setActiveEditMarkerId,
+        }),
+      { initialProps: { canEditMarkers: true } }
+    )
+
+    expect(setIsAddingMarkers).not.toHaveBeenCalled()
+    expect(setActiveEditMarkerId).not.toHaveBeenCalled()
+
+    rerender({ canEditMarkers: false })
+
+    expect(setIsAddingMarkers).toHaveBeenCalledWith(false)
+    expect(setActiveEditMarkerId).toHaveBeenCalledWith(null)
+  })
+
+  it('does not clear when already idle and canEditMarkers is false', () => {
+    const setIsAddingMarkers = jest.fn()
+    const setActiveEditMarkerId = jest.fn()
+
+    renderHook(() =>
+      useClearMarkerEditModeWhenLoggedOut({
+        canEditMarkers: false,
+        isAddingMarkers: false,
+        activeEditMarkerId: null,
+        setIsAddingMarkers,
+        setActiveEditMarkerId,
+      })
+    )
+
+    expect(setIsAddingMarkers).not.toHaveBeenCalled()
+    expect(setActiveEditMarkerId).not.toHaveBeenCalled()
+  })
+
+  it('does not clear while canEditMarkers stays true', () => {
+    const setIsAddingMarkers = jest.fn()
+    const setActiveEditMarkerId = jest.fn()
+
+    renderHook(() =>
+      useClearMarkerEditModeWhenLoggedOut({
+        canEditMarkers: true,
+        isAddingMarkers: true,
+        activeEditMarkerId: '7',
+        setIsAddingMarkers,
+        setActiveEditMarkerId,
+      })
+    )
+
+    expect(setIsAddingMarkers).not.toHaveBeenCalled()
+    expect(setActiveEditMarkerId).not.toHaveBeenCalled()
+  })
+})

--- a/apps/lrauv-dash2/lib/useClearMarkerEditModeWhenLoggedOut.test.ts
+++ b/apps/lrauv-dash2/lib/useClearMarkerEditModeWhenLoggedOut.test.ts
@@ -62,4 +62,27 @@ describe('useClearMarkerEditModeWhenLoggedOut', () => {
     expect(setIsAddingMarkers).not.toHaveBeenCalled()
     expect(setActiveEditMarkerId).not.toHaveBeenCalled()
   })
+
+  it('clears add and edit mode when the map view unmounts', () => {
+    const setIsAddingMarkers = jest.fn()
+    const setActiveEditMarkerId = jest.fn()
+
+    const { unmount } = renderHook(() =>
+      useClearMarkerEditModeWhenLoggedOut({
+        canEditMarkers: true,
+        isAddingMarkers: true,
+        activeEditMarkerId: '42',
+        setIsAddingMarkers,
+        setActiveEditMarkerId,
+      })
+    )
+
+    expect(setIsAddingMarkers).not.toHaveBeenCalled()
+    expect(setActiveEditMarkerId).not.toHaveBeenCalled()
+
+    unmount()
+
+    expect(setIsAddingMarkers).toHaveBeenCalledWith(false)
+    expect(setActiveEditMarkerId).toHaveBeenCalledWith(null)
+  })
 })

--- a/apps/lrauv-dash2/lib/useClearMarkerEditModeWhenLoggedOut.ts
+++ b/apps/lrauv-dash2/lib/useClearMarkerEditModeWhenLoggedOut.ts
@@ -1,6 +1,9 @@
 import { useEffect } from 'react'
 
-/** Clears add/edit marker mode when the user can no longer edit (e.g. logout). */
+/**
+ * Clears add/edit marker mode on logout and when the map view unmounts.
+ * MarkerProvider is app-wide, so edit state must not persist across routes.
+ */
 export const useClearMarkerEditModeWhenLoggedOut = (params: {
   canEditMarkers: boolean
   isAddingMarkers: boolean
@@ -28,4 +31,11 @@ export const useClearMarkerEditModeWhenLoggedOut = (params: {
     setIsAddingMarkers,
     setActiveEditMarkerId,
   ])
+
+  useEffect(() => {
+    return () => {
+      setIsAddingMarkers(false)
+      setActiveEditMarkerId(null)
+    }
+  }, [setIsAddingMarkers, setActiveEditMarkerId])
 }

--- a/apps/lrauv-dash2/lib/useClearMarkerEditModeWhenLoggedOut.ts
+++ b/apps/lrauv-dash2/lib/useClearMarkerEditModeWhenLoggedOut.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+
+/** Clears add/edit marker mode when the user can no longer edit (e.g. logout). */
+export const useClearMarkerEditModeWhenLoggedOut = (params: {
+  canEditMarkers: boolean
+  isAddingMarkers: boolean
+  activeEditMarkerId: string | null
+  setIsAddingMarkers: (value: boolean) => void
+  setActiveEditMarkerId: (id: string | null) => void
+}) => {
+  const {
+    canEditMarkers,
+    isAddingMarkers,
+    activeEditMarkerId,
+    setIsAddingMarkers,
+    setActiveEditMarkerId,
+  } = params
+
+  useEffect(() => {
+    if (!canEditMarkers) {
+      if (isAddingMarkers) setIsAddingMarkers(false)
+      if (activeEditMarkerId) setActiveEditMarkerId(null)
+    }
+  }, [
+    canEditMarkers,
+    isAddingMarkers,
+    activeEditMarkerId,
+    setIsAddingMarkers,
+    setActiveEditMarkerId,
+  ])
+}

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -29,6 +29,8 @@ import toast from 'react-hot-toast'
 import { createLogger, useResizeObserver } from '@mbari/utils'
 import { PlatformsListModal } from '../components/PlatformsListModal'
 import { useRefreshPositions } from '../lib/useRefreshPositions'
+import { useClearMarkerEditModeWhenLoggedOut } from '../lib/useClearMarkerEditModeWhenLoggedOut'
+import { getDraggableMarkerEditProps } from '../lib/getDraggableMarkerEditProps'
 import VehicleColorsModal from '../components/VehicleColorsModal'
 import { MapRefreshButton } from '../components/MapRefreshButton'
 
@@ -230,19 +232,13 @@ const OverViewMap: React.FC<{
   const { authenticated } = useTethysApiContext()
   const canEditMarkers = !!authenticated
 
-  // Prevent add/edit marker mode from sticking after logout.
-  useEffect(() => {
-    if (!canEditMarkers) {
-      if (isAddingMarkers) setIsAddingMarkers(false)
-      if (activeEditMarkerId) setActiveEditMarkerId(null)
-    }
-  }, [
+  useClearMarkerEditModeWhenLoggedOut({
     canEditMarkers,
     isAddingMarkers,
     activeEditMarkerId,
     setIsAddingMarkers,
     setActiveEditMarkerId,
-  ])
+  })
 
   const uniqueTrackedVehicles = Array.from(new Set(trackedVehicles))
   // Store all vehicle positions for bounds calculation
@@ -789,54 +785,30 @@ const OverViewMap: React.FC<{
                     position={[marker.lat, marker.lng]}
                     index={marker.index}
                     label={marker.label}
-                    draggable={canEditMarkers}
                     isSelected={selectedMarkerId === marker.id.toString()}
                     isNew={marker.isNew}
                     savedToLayer={marker.savedToLayer}
                     iconColor={marker.iconColor || defaultMarkerColor}
                     onClick={() => handleMarkerClick(marker.id.toString())}
-                    onDragEnd={
-                      canEditMarkers
-                        ? (newPos) =>
-                            handleMarkerPositionChange(
-                              marker.id.toString(),
-                              newPos
-                            )
-                        : undefined
-                    }
-                    onEditStateChange={
-                      canEditMarkers
-                        ? (isEditing) => {
-                            setActiveEditMarkerId(
-                              isEditing ? marker.id.toString() : null
-                            )
-                          }
-                        : undefined
-                    }
-                    onEdit={
-                      canEditMarkers
-                        ? () => handleEditMarker(marker.id.toString())
-                        : undefined
-                    }
-                    onDelete={
-                      canEditMarkers
-                        ? () => handleDeleteMarker(marker.id.toString())
-                        : undefined
-                    }
-                    onColorChange={
-                      canEditMarkers
-                        ? (color) =>
-                            handleMarkerColorChange(marker.id.toString(), color)
-                        : undefined
-                    }
-                    onSaveToLayer={
-                      canEditMarkers ? handleSaveMarkerToLayer : undefined
-                    }
-                    onRemoveFromLayer={
-                      canEditMarkers
-                        ? (id) => handleSaveMarkerToLayer(id, false)
-                        : undefined
-                    }
+                    {...getDraggableMarkerEditProps(canEditMarkers, {
+                      onDragEnd: (newPos) =>
+                        handleMarkerPositionChange(
+                          marker.id.toString(),
+                          newPos
+                        ),
+                      onEditStateChange: (isEditing) => {
+                        setActiveEditMarkerId(
+                          isEditing ? marker.id.toString() : null
+                        )
+                      },
+                      onEdit: () => handleEditMarker(marker.id.toString()),
+                      onDelete: () => handleDeleteMarker(marker.id.toString()),
+                      onColorChange: (color) =>
+                        handleMarkerColorChange(marker.id.toString(), color),
+                      onSaveToLayer: handleSaveMarkerToLayer,
+                      onRemoveFromLayer: (id) =>
+                        handleSaveMarkerToLayer(id, false),
+                    })}
                   />
                 )
             )

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -230,12 +230,19 @@ const OverViewMap: React.FC<{
   const { authenticated } = useTethysApiContext()
   const canEditMarkers = !!authenticated
 
-  // Prevent add-marker mode from sticking after logout.
+  // Prevent add/edit marker mode from sticking after logout.
   useEffect(() => {
-    if (!canEditMarkers && isAddingMarkers) {
-      setIsAddingMarkers(false)
+    if (!canEditMarkers) {
+      if (isAddingMarkers) setIsAddingMarkers(false)
+      if (activeEditMarkerId) setActiveEditMarkerId(null)
     }
-  }, [canEditMarkers, isAddingMarkers, setIsAddingMarkers])
+  }, [
+    canEditMarkers,
+    isAddingMarkers,
+    activeEditMarkerId,
+    setIsAddingMarkers,
+    setActiveEditMarkerId,
+  ])
 
   const uniqueTrackedVehicles = Array.from(new Set(trackedVehicles))
   // Store all vehicle positions for bounds calculation

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -19,7 +19,7 @@ import useGoogleElevator from '../lib/useGoogleElevator'
 import { Allotment, LayoutPriority } from 'allotment'
 import { useGoogleMaps } from '../lib/useGoogleMaps'
 import { useSidebarSizes } from '../lib/useSidebarSizes'
-import { VPosDetail, useStations } from '@mbari/api-client'
+import { VPosDetail, useStations, useTethysApiContext } from '@mbari/api-client'
 import 'allotment/dist/style.css'
 import { StationsListModal } from '../components/StationsListModal'
 import { MapLayersListModal } from '../components/MapLayersListModal'
@@ -227,6 +227,15 @@ const OverViewMap: React.FC<{
     setActiveEditMarkerId,
     setMarkers,
   } = useMarkers()
+  const { authenticated } = useTethysApiContext()
+  const canEditMarkers = !!authenticated
+
+  // Prevent add-marker mode from sticking after logout.
+  useEffect(() => {
+    if (!canEditMarkers && isAddingMarkers) {
+      setIsAddingMarkers(false)
+    }
+  }, [canEditMarkers, isAddingMarkers, setIsAddingMarkers])
 
   const uniqueTrackedVehicles = Array.from(new Set(trackedVehicles))
   // Store all vehicle positions for bounds calculation
@@ -745,18 +754,20 @@ const OverViewMap: React.FC<{
           onRequestStations={handleLayersRequest}
           onRequestVehicleColors={handleVehicleColorRequest}
           onRequestMarkers={handleMarkersRequest}
-          isAddingMarkers={isAddingMarkers}
-          onToggleMarkerMode={handleToggleMarkerMode}
+          isAddingMarkers={canEditMarkers && isAddingMarkers}
+          onToggleMarkerMode={
+            canEditMarkers ? handleToggleMarkerMode : undefined
+          }
           renderMapClickHandler={() => (
             <MapClickHandler
-              isAddingMarkers={isAddingMarkers}
+              isAddingMarkers={canEditMarkers && isAddingMarkers}
               isEditingMarker={false}
               onAddMarker={handleAddMarker}
             />
           )}
           renderCustomMarkerSet={() => (
             <CustomMarkerSet
-              isAddingMarkers={isAddingMarkers}
+              isAddingMarkers={canEditMarkers && isAddingMarkers}
               setIsAddingMarkers={(value) => setIsAddingMarkers(value)}
             />
           )}
@@ -771,28 +782,53 @@ const OverViewMap: React.FC<{
                     position={[marker.lat, marker.lng]}
                     index={marker.index}
                     label={marker.label}
-                    draggable={true}
+                    draggable={canEditMarkers}
                     isSelected={selectedMarkerId === marker.id.toString()}
                     isNew={marker.isNew}
                     savedToLayer={marker.savedToLayer}
                     iconColor={marker.iconColor || defaultMarkerColor}
                     onClick={() => handleMarkerClick(marker.id.toString())}
-                    onDragEnd={(newPos) =>
-                      handleMarkerPositionChange(marker.id.toString(), newPos)
+                    onDragEnd={
+                      canEditMarkers
+                        ? (newPos) =>
+                            handleMarkerPositionChange(
+                              marker.id.toString(),
+                              newPos
+                            )
+                        : undefined
                     }
-                    onEditStateChange={(isEditing) => {
-                      setActiveEditMarkerId(
-                        isEditing ? marker.id.toString() : null
-                      )
-                    }}
-                    onEdit={() => handleEditMarker(marker.id.toString())}
-                    onDelete={() => handleDeleteMarker(marker.id.toString())}
-                    onColorChange={(color) =>
-                      handleMarkerColorChange(marker.id.toString(), color)
+                    onEditStateChange={
+                      canEditMarkers
+                        ? (isEditing) => {
+                            setActiveEditMarkerId(
+                              isEditing ? marker.id.toString() : null
+                            )
+                          }
+                        : undefined
                     }
-                    onSaveToLayer={handleSaveMarkerToLayer}
-                    onRemoveFromLayer={(id) =>
-                      handleSaveMarkerToLayer(id, false)
+                    onEdit={
+                      canEditMarkers
+                        ? () => handleEditMarker(marker.id.toString())
+                        : undefined
+                    }
+                    onDelete={
+                      canEditMarkers
+                        ? () => handleDeleteMarker(marker.id.toString())
+                        : undefined
+                    }
+                    onColorChange={
+                      canEditMarkers
+                        ? (color) =>
+                            handleMarkerColorChange(marker.id.toString(), color)
+                        : undefined
+                    }
+                    onSaveToLayer={
+                      canEditMarkers ? handleSaveMarkerToLayer : undefined
+                    }
+                    onRemoveFromLayer={
+                      canEditMarkers
+                        ? (id) => handleSaveMarkerToLayer(id, false)
+                        : undefined
                     }
                   />
                 )

--- a/apps/lrauv-dash2/pages/index.tsx
+++ b/apps/lrauv-dash2/pages/index.tsx
@@ -761,7 +761,7 @@ const OverViewMap: React.FC<{
           renderMapClickHandler={() => (
             <MapClickHandler
               isAddingMarkers={canEditMarkers && isAddingMarkers}
-              isEditingMarker={false}
+              isEditingMarker={!!activeEditMarkerId}
               onAddMarker={handleAddMarker}
             />
           )}


### PR DESCRIPTION
## Summary
- Keep overview/vehicle map markers visible when logged out; gate add/edit/delete/drag/recolor/save-to-layer behind authentication (same views-open / writes-gated rule as #786)
- Hide Add-markers control and MarkerSection rename/remove when logged out; `DraggableMarker` shows view-only popup without write handlers
- Add focused `DraggableMarker` tests for read-only vs editable popup controls

Closes #788

Related: #786, #789

## Test plan
- [ ] Logged out on Overview: markers remain visible; no Add-markers control; marker popup is view-only (label/position/Close only)
- [ ] Logged out: cannot drag markers; layers list keeps visibility checkbox but hides rename/remove
- [ ] Logged in: Add-markers, edit, delete, drag, recolor, save-to-layer work as before
- [ ] Logout while in add-marker mode clears add mode
- [ ] `yarn workspace @mbari/lrauv-dash2 test:ci components/DraggableMarker.test.tsx` passes