### PR TITLE
fix: reload mission list so newly added missions appear in pickers

### DIFF
--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -149,7 +149,7 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   const { data: alternativeAddresses } = useSbdOutgoingAlternativeAddresses({})
   const { data: moduleInfoData } = useModuleInfo()
   const { data: universalData } = useUniversals({})
-  const { data: missionData } = useMissionList()
+  const { data: missionData } = useMissionList({ reload: 'y' })
   // Mission tier now stores the full path (e.g. 'Science/sci2_circle_hotspot.tl')
   const missionPath = variable.Mission ?? ''
   const { data: selectedMissionData } = useScript(

--- a/apps/lrauv-dash2/lib/useMissionData.ts
+++ b/apps/lrauv-dash2/lib/useMissionData.ts
@@ -29,8 +29,9 @@ export const useMissionData = (params: {
 }) => {
   const { vehicleName, selectedMission, showAllVehicleMissions } = params
 
-  const { data: missionData, isLoading: isMissionListLoading } =
-    useMissionList()
+  const { data: missionData, isLoading: isMissionListLoading } = useMissionList(
+    { reload: 'y' }
+  )
   const { data: siteInfo } = useSiteConfig()
 
   const frequentVehicles = useMemo(() => {

--- a/packages/api-client/src/react-query/Git/useMissionList.test.tsx
+++ b/packages/api-client/src/react-query/Git/useMissionList.test.tsx
@@ -61,4 +61,50 @@ describe('useMissionList', () => {
       firstMissionPath
     )
   })
+
+  it('keys cache by gitRef only and refetches on mount when reload=y', async () => {
+    const reloads: Array<string | null> = []
+    server.use(
+      rest.get('/git/missionList', (req, res, ctx) => {
+        reloads.push(req.url.searchParams.get('reload'))
+        return res(ctx.status(200), ctx.json(mockResponse))
+      })
+    )
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    const Probe: React.FC<{ reload?: 'y' }> = ({ reload }) => {
+      const { data } = useMissionList(reload ? { reload } : {})
+      return <div>{data?.list[0]?.path ?? 'loading'}</div>
+    }
+
+    const { unmount } = render(
+      <MockProviders queryClient={queryClient}>
+        <Probe />
+      </MockProviders>
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Default.xml')).toBeInTheDocument()
+    })
+    expect(reloads).toEqual([null])
+    expect(
+      queryClient.getQueryCache().findAll({ queryKey: ['git', 'missionList'] })
+    ).toHaveLength(1)
+
+    unmount()
+
+    render(
+      <MockProviders queryClient={queryClient}>
+        <Probe reload="y" />
+      </MockProviders>
+    )
+    await waitFor(() => {
+      expect(reloads).toEqual([null, 'y'])
+    })
+    expect(
+      queryClient.getQueryCache().findAll({ queryKey: ['git', 'missionList'] })
+    ).toHaveLength(1)
+  })
 })

--- a/packages/api-client/src/react-query/Git/useMissionList.ts
+++ b/packages/api-client/src/react-query/Git/useMissionList.ts
@@ -9,7 +9,7 @@ export const useMissionList = (
 ) => {
   const { axiosInstance, token } = useTethysApiContext()
   const { gitRef, reload } = params
-  // #792: keep reload out of the query key so all callers share one cache;
+  // #792: Keep reload out of the query key so all callers share one cache;
   // refetchOnMount when reload=y so that shared entry is not left stale.
   const query = useQuery(
     ['git', 'missionList', gitRef ?? null],

--- a/packages/api-client/src/react-query/Git/useMissionList.ts
+++ b/packages/api-client/src/react-query/Git/useMissionList.ts
@@ -8,16 +8,23 @@ export const useMissionList = (
   options?: SupportedQueryOptions
 ) => {
   const { axiosInstance, token } = useTethysApiContext()
+  const { gitRef, reload } = params
   const query = useQuery(
-    ['git', 'missionList', params],
+    // Keep reload out of the key so all consumers share one cache entry.
+    ['git', 'missionList', gitRef ?? null],
     () => {
-      return getMissionList(params, {
-        instance: axiosInstance,
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      return getMissionList(
+        { gitRef, reload },
+        {
+          instance: axiosInstance,
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      )
     },
     {
-      staleTime: 60 * 1000 * 5, // 1 hour
+      staleTime: 60 * 1000 * 5, // 5 minutes
+      // Callers that request reload must hit the network even if cache is fresh.
+      refetchOnMount: reload === 'y' ? 'always' : undefined,
       ...options,
     }
   )

--- a/packages/api-client/src/react-query/Git/useMissionList.ts
+++ b/packages/api-client/src/react-query/Git/useMissionList.ts
@@ -9,13 +9,8 @@ export const useMissionList = (
 ) => {
   const { axiosInstance, token } = useTethysApiContext()
   const { gitRef, reload } = params
-  // Required with picker call sites that pass reload: 'y' (#792).
-  // If reload were part of the query key, { reload: 'y' } and {} would be
-  // separate cache entries — callers without reload could keep serving a
-  // stale mission list for up to staleTime. Key on gitRef only, and when
-  // reload is requested force a network refetch on mount so the shared
-  // entry is refreshed (TethysDash caches missionList server-side unless
-  // reload=y).
+  // #792: keep reload out of the query key so all callers share one cache;
+  // refetchOnMount when reload=y so that shared entry is not left stale.
   const query = useQuery(
     ['git', 'missionList', gitRef ?? null],
     () => {

--- a/packages/api-client/src/react-query/Git/useMissionList.ts
+++ b/packages/api-client/src/react-query/Git/useMissionList.ts
@@ -9,8 +9,14 @@ export const useMissionList = (
 ) => {
   const { axiosInstance, token } = useTethysApiContext()
   const { gitRef, reload } = params
+  // Required with picker call sites that pass reload: 'y' (#792).
+  // If reload were part of the query key, { reload: 'y' } and {} would be
+  // separate cache entries — callers without reload could keep serving a
+  // stale mission list for up to staleTime. Key on gitRef only, and when
+  // reload is requested force a network refetch on mount so the shared
+  // entry is refreshed (TethysDash caches missionList server-side unless
+  // reload=y).
   const query = useQuery(
-    // Keep reload out of the key so all consumers share one cache entry.
     ['git', 'missionList', gitRef ?? null],
     () => {
       return getMissionList(
@@ -23,7 +29,6 @@ export const useMissionList = (
     },
     {
       staleTime: 60 * 1000 * 5, // 5 minutes
-      // Callers that request reload must hit the network even if cache is fresh.
       refetchOnMount: reload === 'y' ? 'always' : undefined,
       ...options,
     }

--- a/packages/api-client/src/react-query/Git/useMissionList.ts
+++ b/packages/api-client/src/react-query/Git/useMissionList.ts
@@ -9,7 +9,7 @@ export const useMissionList = (
 ) => {
   const { axiosInstance, token } = useTethysApiContext()
   const { gitRef, reload } = params
-  // #792: Keep reload out of the query key so all callers share one cache;
+  // Keep reload out of the query key so all callers share one cache;
   // refetchOnMount when reload=y so that shared entry is not left stale.
   const query = useQuery(
     ['git', 'missionList', gitRef ?? null],


### PR DESCRIPTION
## Summary
- Fixes [#792](https://github.com/mbari-org/dash5/issues/792): Mission/Command pickers call `GET /git/missionList` with `reload=y` so TethysDash does not serve a stale cached mission index (Dash4 could show newly added missions that Dash5 omitted).
- Updates `useMissionList` cache keying so `reload` is not part of the React Query key (shared cache) and `refetchOnMount: 'always'` runs when `reload=y`.
- Auth header behavior is unchanged (pre-existing since #195).

## Test plan
- [ ] Local: open Schedule → Mission; DevTools Network shows `.../git/missionList?reload=y` with 200
- [ ] Engineering + search `triton` shows the full `tritoncam_*` set (not only the older 3)
- [ ] Command modal mission dropdown also requests `reload=y`
- [ ] Works for any vehicle (list is not vehicle-scoped)