### PR TITLE
fix(#779): display mission ID in pending Schedule rows via getScript at queue time

### DIFF
--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -29,6 +29,7 @@ import {
   useCreateNote,
   timeoutExpiredRegEx,
   useTethysApiContext,
+  getScript,
 } from '@mbari/api-client'
 import { useQueryClient, useQueries } from 'react-query'
 import useGlobalModalId from '../lib/useGlobalModalId'
@@ -40,7 +41,6 @@ import {
   normalizeMissionName,
   normalizeMissionPath,
 } from '../lib/missionUtils'
-import { getScript } from '@mbari/api-client'
 import { toast } from 'react-hot-toast'
 
 export interface ScheduleSectionProps {

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -28,8 +28,9 @@ import {
   useDeleteCommandQueue,
   useCreateNote,
   timeoutExpiredRegEx,
+  useTethysApiContext,
 } from '@mbari/api-client'
-import { useQueryClient } from 'react-query'
+import { useQueryClient, useQueries } from 'react-query'
 import useGlobalModalId from '../lib/useGlobalModalId'
 import {
   missionNameFromStartedText,
@@ -39,6 +40,7 @@ import {
   normalizeMissionName,
   normalizeMissionPath,
 } from '../lib/missionUtils'
+import { getScript } from '@mbari/api-client'
 import { toast } from 'react-hot-toast'
 
 export interface ScheduleSectionProps {
@@ -185,6 +187,7 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
   isRecovered,
 }) => {
   const { setGlobalModalId } = useGlobalModalId()
+  const { axiosInstance } = useTethysApiContext()
   const [scheduleFilter, setScheduleFilter] = useState<string>('')
   const [scheduleSearch, setScheduleSearch] = useState<string>('')
   const [deploymentLogsOnly, setDeploymentLogsOnly] = useState(false)
@@ -784,6 +787,40 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
   const staticFilterCellOffset = hasPastSchedule ? 1 : 0
 
   const results = [scheduledCells, historicCells].flat()
+
+  // Pre-fetch mission IDs for pending rows (no vehicle-reported missionId yet).
+  // useQueries runs all lookups in parallel and caches aggressively — mission
+  // definitions don't change during a deployment.
+  const pendingScriptPaths = useMemo(() => {
+    const paths = new Set<string>()
+    for (const m of results) {
+      if (!m.missionId) {
+        const p = rawMissionPathFromEventData(m.event.data ?? m.event.text)
+        if (p) paths.add(p)
+      }
+    }
+    return Array.from(paths)
+  }, [results])
+
+  const scriptIdQueries = useQueries(
+    pendingScriptPaths.map((path) => ({
+      queryKey: ['commands', 'script', path],
+      queryFn: () => getScript({ path }, { instance: axiosInstance }),
+      staleTime: Infinity, // mission definitions don't change mid-deployment
+      enabled: !!axiosInstance && !!path,
+    }))
+  )
+
+  // Build a path → mission ID lookup for use in cellAtIndex.
+  const scriptIdByPath = useMemo(() => {
+    const map = new Map<string, string>()
+    pendingScriptPaths.forEach((path, i) => {
+      const id = scriptIdQueries[i]?.data?.id
+      if (id) map.set(path, id)
+    })
+    return map
+  }, [pendingScriptPaths, scriptIdQueries])
+
   // Show the "Previous Vehicle Directives" separator whenever there are
   // historic items, even if no commands are currently active above it.
   // Operators require a complete audit trail — timed-out or completed
@@ -993,15 +1030,18 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
     const { name: parsedMissionName, parameters: missionParams } =
       parseMissionCommand(commandData)
     // Display name priority (|| so empty strings fall through to the next level):
-    // 1. missionId — vehicle-reported mission ID from missionStarted telemetry
-    //    (e.g. "keepstation", "follow_that_car"). Most accurate: it's what the
-    //    vehicle actually calls the mission, regardless of filename or _vt suffix.
-    // 2. missionNameFromEventData — filename without path/extension. Checked
-    //    against both data and text since commands can arrive in either field.
-    // 3. parsedMissionName from parseMissionCommand — last resort for edge cases
-    //    not covered by missionNameFromEventData (e.g. non-load command formats).
+    // 1. missionId — vehicle-reported ID from missionStarted telemetry. Most accurate.
+    // 2. scriptId — ID from getScriptDescription, resolved at queue time before the
+    //    vehicle reports back. Handles cases where filename ≠ mission ID (e.g. _vt files).
+    // 3. missionNameFromEventData — filename without path/extension. Fallback when
+    //    the script lookup is still loading or returns no result.
+    // 4. parsedMissionName — last resort for edge cases.
+    const scriptPath = rawMissionPathFromEventData(
+      mission?.event.data ?? mission?.event.text
+    )
     const missionName =
       mission?.missionId ||
+      (scriptPath ? scriptIdByPath.get(scriptPath) : undefined) ||
       missionNameFromEventData(mission?.event.data) ||
       missionNameFromEventData(mission?.event.text) ||
       parsedMissionName

--- a/apps/lrauv-dash2/components/ScheduleSection.tsx
+++ b/apps/lrauv-dash2/components/ScheduleSection.tsx
@@ -789,18 +789,20 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
   const results = [scheduledCells, historicCells].flat()
 
   // Pre-fetch mission IDs for pending rows (no vehicle-reported missionId yet).
+  // Scoped to scheduledCells only — historic rows either already have a
+  // missionId from telemetry or are no longer actionable.
   // useQueries runs all lookups in parallel and caches aggressively — mission
   // definitions don't change during a deployment.
   const pendingScriptPaths = useMemo(() => {
     const paths = new Set<string>()
-    for (const m of results) {
+    for (const m of scheduledCells ?? []) {
       if (!m.missionId) {
         const p = rawMissionPathFromEventData(m.event.data ?? m.event.text)
         if (p) paths.add(p)
       }
     }
     return Array.from(paths)
-  }, [results])
+  }, [scheduledCells])
 
   const scriptIdQueries = useQueries(
     pendingScriptPaths.map((path) => ({
@@ -1031,8 +1033,8 @@ export const ScheduleSection: React.FC<ScheduleSectionProps> = ({
       parseMissionCommand(commandData)
     // Display name priority (|| so empty strings fall through to the next level):
     // 1. missionId — vehicle-reported ID from missionStarted telemetry. Most accurate.
-    // 2. scriptId — ID from getScriptDescription, resolved at queue time before the
-    //    vehicle reports back. Handles cases where filename ≠ mission ID (e.g. _vt files).
+    // 2. scriptId — ID from getScript (GET /commands/script), resolved at queue time before
+    //    the vehicle reports back. Handles cases where filename ≠ mission ID (e.g. _vt files).
     // 3. missionNameFromEventData — filename without path/extension. Fallback when
     //    the script lookup is still loading or returns no result.
     // 4. parsedMissionName — last resort for edge cases.

--- a/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
+++ b/apps/lrauv-dash2/jest/ScheduleSection.test.tsx
@@ -1573,3 +1573,49 @@ test('parses legacy sched YYYYMMDD}T timestamp for backwards compatibility', asy
     expect(screen.getByText(/Sent and Queued for .+ UTC/)).toBeInTheDocument()
   })
 })
+
+test('pending row shows mission ID from getScript before vehicle telemetry arrives', async () => {
+  // profile_station_vt.tl declares mission ID "profile_station". The pending
+  // row should display "profile_station" immediately — not the filename-derived
+  // "profile_station_vt" — because getScript resolves the ID at queue time.
+  server.use(
+    rest.get('/events', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({
+          result: [
+            {
+              data: 'load Science/profile_station_vt.tl;set profile_station.MissionTimeout 12 h;run',
+              unixTime: Date.now() - 30 * 1000,
+              eventId: 501,
+              eventType: 'run',
+              text: null,
+              note: null,
+              user: 'test-operator',
+            },
+          ],
+        })
+      )
+    ),
+    rest.get('/events/mission-started', (_req, res, ctx) =>
+      res(ctx.status(200), ctx.json({ result: [] }))
+    ),
+    rest.get('/commands/script', (_req, res, ctx) =>
+      res(
+        ctx.status(200),
+        ctx.json({ result: { id: 'profile_station', scriptArgs: [] } })
+      )
+    )
+  )
+
+  render(
+    <MockProviders queryClient={new QueryClient()}>
+      <ScheduleSection {...props} currentDeploymentId={1} />
+    </MockProviders>
+  )
+
+  await waitFor(() => {
+    expect(screen.getByText('profile_station')).toBeInTheDocument()
+  })
+  expect(screen.queryByText('profile_station_vt')).not.toBeInTheDocument()
+})

--- a/packages/api-client/src/axios/Command/getScript.ts
+++ b/packages/api-client/src/axios/Command/getScript.ts
@@ -3,7 +3,7 @@ import { getInstance } from '../getInstance'
 import { RequestConfig } from '../types'
 
 export interface GetScriptParams {
-  gitRef: string
+  gitRef?: string
   path: string
 }
 


### PR DESCRIPTION
> **Review Order:** Copilot review by author first, then human review will be requested.

## Problem
Pending Schedule rows showed the raw filename (e.g., `Transport/keepstation.tl` or `Science/profile_station_vt.tl`) instead of the mission ID (`keepstation`, `profile_station`). The correct ID was only visible after the vehicle started the mission and reported back via telemetry — causing a confusing mid-execution name change.

## Solution
At queue time, `ScheduleSection` now calls `GET /commands/script` for each pending mission (in parallel, with `staleTime: Infinity`) to resolve the mission ID immediately. Pending rows display the correct ID from the moment they enter the queue.

## Supersedes
This replaces the `_vt` regex approach from PR #774, which was merged and then reverted. That approach stripped `_vt` from filenames in the UI — an incorrect assumption. Quinn and Emme confirmed the right fix is to use the actual mission ID from `getScriptDescription`, not manipulate filenames. Carlos confirmed `GET /commands/script` is the correct and only available path (TethysDash #93 — POST /commands returning the ID is won't-fix).

## Testing
Verified locally on `sim` — `keepstation` and `profile_station` both show correct mission IDs as Pending before vehicle confirmation.

## References
- Closes #779
- Reverts #774