### PR TITLE
fix(#792): reload mission list so newly added scripts appear in pickers

### DIFF
--- a/apps/lrauv-dash2/components/CommandModal.tsx
+++ b/apps/lrauv-dash2/components/CommandModal.tsx
@@ -149,7 +149,7 @@ export const CommandModal: React.FC<CommandModalProps> = ({
   const { data: alternativeAddresses } = useSbdOutgoingAlternativeAddresses({})
   const { data: moduleInfoData } = useModuleInfo()
   const { data: universalData } = useUniversals({})
-  const { data: missionData } = useMissionList()
+  const { data: missionData } = useMissionList({ reload: 'y' })
   // Mission tier now stores the full path (e.g. 'Science/sci2_circle_hotspot.tl')
   const missionPath = variable.Mission ?? ''
   const { data: selectedMissionData } = useScript(

--- a/apps/lrauv-dash2/lib/useMissionData.ts
+++ b/apps/lrauv-dash2/lib/useMissionData.ts
@@ -29,8 +29,9 @@ export const useMissionData = (params: {
 }) => {
   const { vehicleName, selectedMission, showAllVehicleMissions } = params
 
-  const { data: missionData, isLoading: isMissionListLoading } =
-    useMissionList()
+  const { data: missionData, isLoading: isMissionListLoading } = useMissionList(
+    { reload: 'y' }
+  )
   const { data: siteInfo } = useSiteConfig()
 
   const frequentVehicles = useMemo(() => {

--- a/packages/api-client/src/react-query/Git/useMissionList.test.tsx
+++ b/packages/api-client/src/react-query/Git/useMissionList.test.tsx
@@ -61,4 +61,50 @@ describe('useMissionList', () => {
       firstMissionPath
     )
   })
+
+  it('keys cache by gitRef only and refetches on mount when reload=y', async () => {
+    const reloads: Array<string | null> = []
+    server.use(
+      rest.get('/git/missionList', (req, res, ctx) => {
+        reloads.push(req.url.searchParams.get('reload'))
+        return res(ctx.status(200), ctx.json(mockResponse))
+      })
+    )
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    const Probe: React.FC<{ reload?: 'y' }> = ({ reload }) => {
+      const { data } = useMissionList(reload ? { reload } : {})
+      return <div>{data?.list[0]?.path ?? 'loading'}</div>
+    }
+
+    const { unmount } = render(
+      <MockProviders queryClient={queryClient}>
+        <Probe />
+      </MockProviders>
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Default.xml')).toBeInTheDocument()
+    })
+    expect(reloads).toEqual([null])
+    expect(
+      queryClient.getQueryCache().findAll({ queryKey: ['git', 'missionList'] })
+    ).toHaveLength(1)
+
+    unmount()
+
+    render(
+      <MockProviders queryClient={queryClient}>
+        <Probe reload="y" />
+      </MockProviders>
+    )
+    await waitFor(() => {
+      expect(reloads).toEqual([null, 'y'])
+    })
+    expect(
+      queryClient.getQueryCache().findAll({ queryKey: ['git', 'missionList'] })
+    ).toHaveLength(1)
+  })
 })

--- a/packages/api-client/src/react-query/Git/useMissionList.ts
+++ b/packages/api-client/src/react-query/Git/useMissionList.ts
@@ -9,7 +9,7 @@ export const useMissionList = (
 ) => {
   const { axiosInstance, token } = useTethysApiContext()
   const { gitRef, reload } = params
-  // #792: keep reload out of the query key so all callers share one cache;
+  // #792: Keep reload out of the query key so all callers share one cache;
   // refetchOnMount when reload=y so that shared entry is not left stale.
   const query = useQuery(
     ['git', 'missionList', gitRef ?? null],

--- a/packages/api-client/src/react-query/Git/useMissionList.ts
+++ b/packages/api-client/src/react-query/Git/useMissionList.ts
@@ -8,16 +8,23 @@ export const useMissionList = (
   options?: SupportedQueryOptions
 ) => {
   const { axiosInstance, token } = useTethysApiContext()
+  const { gitRef, reload } = params
   const query = useQuery(
-    ['git', 'missionList', params],
+    // Keep reload out of the key so all consumers share one cache entry.
+    ['git', 'missionList', gitRef ?? null],
     () => {
-      return getMissionList(params, {
-        instance: axiosInstance,
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      return getMissionList(
+        { gitRef, reload },
+        {
+          instance: axiosInstance,
+          headers: { Authorization: `Bearer ${token}` },
+        }
+      )
     },
     {
-      staleTime: 60 * 1000 * 5, // 1 hour
+      staleTime: 60 * 1000 * 5, // 5 minutes
+      // Callers that request reload must hit the network even if cache is fresh.
+      refetchOnMount: reload === 'y' ? 'always' : undefined,
       ...options,
     }
   )

--- a/packages/api-client/src/react-query/Git/useMissionList.ts
+++ b/packages/api-client/src/react-query/Git/useMissionList.ts
@@ -9,13 +9,8 @@ export const useMissionList = (
 ) => {
   const { axiosInstance, token } = useTethysApiContext()
   const { gitRef, reload } = params
-  // Required with picker call sites that pass reload: 'y' (#792).
-  // If reload were part of the query key, { reload: 'y' } and {} would be
-  // separate cache entries — callers without reload could keep serving a
-  // stale mission list for up to staleTime. Key on gitRef only, and when
-  // reload is requested force a network refetch on mount so the shared
-  // entry is refreshed (TethysDash caches missionList server-side unless
-  // reload=y).
+  // #792: keep reload out of the query key so all callers share one cache;
+  // refetchOnMount when reload=y so that shared entry is not left stale.
   const query = useQuery(
     ['git', 'missionList', gitRef ?? null],
     () => {

--- a/packages/api-client/src/react-query/Git/useMissionList.ts
+++ b/packages/api-client/src/react-query/Git/useMissionList.ts
@@ -9,8 +9,14 @@ export const useMissionList = (
 ) => {
   const { axiosInstance, token } = useTethysApiContext()
   const { gitRef, reload } = params
+  // Required with picker call sites that pass reload: 'y' (#792).
+  // If reload were part of the query key, { reload: 'y' } and {} would be
+  // separate cache entries — callers without reload could keep serving a
+  // stale mission list for up to staleTime. Key on gitRef only, and when
+  // reload is requested force a network refetch on mount so the shared
+  // entry is refreshed (TethysDash caches missionList server-side unless
+  // reload=y).
   const query = useQuery(
-    // Keep reload out of the key so all consumers share one cache entry.
     ['git', 'missionList', gitRef ?? null],
     () => {
       return getMissionList(
@@ -23,7 +29,6 @@ export const useMissionList = (
     },
     {
       staleTime: 60 * 1000 * 5, // 5 minutes
-      // Callers that request reload must hit the network even if cache is fresh.
       refetchOnMount: reload === 'y' ? 'always' : undefined,
       ...options,
     }

--- a/packages/api-client/src/react-query/Git/useMissionList.ts
+++ b/packages/api-client/src/react-query/Git/useMissionList.ts
@@ -9,7 +9,7 @@ export const useMissionList = (
 ) => {
   const { axiosInstance, token } = useTethysApiContext()
   const { gitRef, reload } = params
-  // #792: Keep reload out of the query key so all callers share one cache;
+  // Keep reload out of the query key so all callers share one cache;
   // refetchOnMount when reload=y so that shared entry is not left stale.
   const query = useQuery(
     ['git', 'missionList', gitRef ?? null],


### PR DESCRIPTION
> **Review Order:** Copilot review by author first, then human review will be requested.

## Problem
When a new mission script is added to the repository, the mission picker in Build a Command showed a stale cached list — operators had to do a full page reload to see newly added missions.

## Solution
Updated `useMissionList` to key its React Query cache by `gitRef` only (not by a reload flag), and added a `reload` trigger that forces a refetch on mount when needed. This ensures the mission list stays fresh without requiring a page reload.

## Files Changed
- `packages/api-client/src/react-query/Git/useMissionList.ts` — cache key and reload logic
- `packages/api-client/src/react-query/Git/useMissionList.test.tsx` — tests covering cache key behavior and remount refetch
- `apps/lrauv-dash2/lib/useMissionData.ts` — pass reload trigger through
- `apps/lrauv-dash2/components/CommandModal.tsx` — minor update

## Testing
Unit tests pass covering the cache key and remount refetch behavior. Live testing not possible (no active deployment), but the fix is a React Query cache key change with targeted unit test coverage.

## References
- Closes #792