### PR TITLE
fix(#801): restore depth sparkline for vehicles submerged longer than 8 hours

### DIFF
--- a/packages/api-client/src/react-query/Data/useDepthSparkline.test.tsx
+++ b/packages/api-client/src/react-query/Data/useDepthSparkline.test.tsx
@@ -216,4 +216,82 @@ describe('useDepthSparkline', () => {
     )
     expect(screen.getByTestId('gpsTimes')).toHaveTextContent('1')
   })
+
+  it('falls back to the long-dive query and pads forward when 8-hour window returns no depth data', async () => {
+    // Primary (8-hour) returns empty — vehicle has been submerged > 8 h.
+    // Fallback (7-day window) returns the last known depth point 10 h ago.
+    const TEN_HOURS_AGO_MS = NOW_MS - 10 * 60 * 60 * 1000
+    server.use(
+      rest.get('/data/depth', (req, res, ctx) => {
+        const fromMs = Number(req.url.searchParams.get('from') ?? 0)
+        const isLongDive = NOW_MS - fromMs > EIGHT_HOURS_MS + 60_000
+        if (!isLongDive) {
+          return res(ctx.status(200), ctx.json({ times: [], values: [] }))
+        }
+        return res(
+          ctx.status(200),
+          ctx.json({ times: [TEN_HOURS_AGO_MS], values: [80] })
+        )
+      })
+    )
+
+    render(
+      <MockProviders queryClient={makeClient()}>
+        <SparklineConsumer vehicle="brizo" />
+      </MockProviders>
+    )
+
+    await waitFor(() =>
+      expect(screen.queryByText('loading')).not.toBeInTheDocument()
+    )
+    // Should have exactly 4 points (1 real fallback point + 3 pad points) and be marked padded.
+    expect(screen.getByTestId('depthLen')).toHaveTextContent('4')
+    expect(screen.getByTestId('padded')).toHaveTextContent('true')
+  })
+
+  it('trims fallback data to the current dive segment when vehicle surfaced then re-dived', async () => {
+    // Fallback returns: a prior deep dive (100 m), then a surface event (0.5 m),
+    // then the start of the current dive (20 m). Primary is empty (long-dive mode).
+    // After trim, only the surface + current dive points remain → scale stays at
+    // 40 m instead of being inflated by the prior dive's 100 m peak.
+    const TEN_HOURS_AGO_MS = NOW_MS - 10 * 60 * 60 * 1000
+    const NINE_HOURS_AGO_MS = NOW_MS - 9 * 60 * 60 * 1000
+    const ONE_HOUR_AGO_MS = NOW_MS - 1 * 60 * 60 * 1000
+    const THIRTY_MIN_AGO_MS = NOW_MS - 30 * 60 * 1000
+    server.use(
+      rest.get('/data/depth', (req, res, ctx) => {
+        const fromMs = Number(req.url.searchParams.get('from') ?? 0)
+        const isLongDive = NOW_MS - fromMs > EIGHT_HOURS_MS + 60_000
+        if (!isLongDive) {
+          return res(ctx.status(200), ctx.json({ times: [], values: [] }))
+        }
+        return res(
+          ctx.status(200),
+          ctx.json({
+            times: [
+              TEN_HOURS_AGO_MS, // prior dive — deep
+              NINE_HOURS_AGO_MS, // prior dive — deep
+              ONE_HOUR_AGO_MS, // surfaced
+              THIRTY_MIN_AGO_MS, // current dive — shallow
+            ],
+            values: [80, 100, 0.5, 20],
+          })
+        )
+      })
+    )
+
+    render(
+      <MockProviders queryClient={makeClient()}>
+        <SparklineConsumer vehicle="brizo" />
+      </MockProviders>
+    )
+
+    await waitFor(() =>
+      expect(screen.queryByText('loading')).not.toBeInTheDocument()
+    )
+    // Surface point (0.5 m) + current dive point (20 m) + 3 pad points = 5 total.
+    // Prior deep dive points (80 m, 100 m) must be trimmed off.
+    expect(screen.getByTestId('depthLen')).toHaveTextContent('5')
+    expect(screen.getByTestId('padded')).toHaveTextContent('true')
+  })
 })

--- a/packages/api-client/src/react-query/Data/useDepthSparkline.ts
+++ b/packages/api-client/src/react-query/Data/useDepthSparkline.ts
@@ -6,6 +6,16 @@ import { useTethysApiContext } from '../TethysApiProvider'
 import { SupportedQueryOptions } from '../types'
 
 const EIGHT_HOURS_MS = 8 * 60 * 60 * 1000
+// Fallback window when the 8-hour query returns no depth data (vehicle submerged
+// longer than 8 h). 7 days covers any realistic long-dive / no-comms scenario.
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
+// Cap the fallback at 480 points (~1/min × 8 h) to avoid an oversized payload.
+const LONG_DIVE_MAXLEN = 480
+// Default refetch interval — 2 minutes keeps the rolling window current.
+const REFETCH_INTERVAL = 2 * 60 * 1000
+// Depth threshold (meters) below which a point is considered a surface event.
+// Used to trim fallback data to the current dive cycle for correct scale.
+const SURFACE_DEPTH_M = 2
 
 export interface DepthSparklineData {
   depthTimes: number[] // minutes since epoch
@@ -26,9 +36,6 @@ export const useDepthSparkline = (
   // Keep a stable query key per vehicle so React Query re-uses the cache entry
   // across re-renders. The rolling 8-hour window is computed fresh inside each
   // queryFn so the chart stays current as long as refetchInterval triggers.
-  // Default interval is 2 minutes; callers can override via options.
-  const REFETCH_INTERVAL = 2 * 60 * 1000
-
   const depthQuery = useQuery(
     ['depthSparkline', 'depth', vehicle],
     () =>
@@ -39,6 +46,33 @@ export const useDepthSparkline = (
     {
       staleTime: REFETCH_INTERVAL,
       refetchInterval: REFETCH_INTERVAL,
+      ...options,
+      enabled: !!vehicle && options?.enabled !== false,
+    }
+  )
+
+  // Fallback: runs in parallel with the primary query. Fetches the most recent
+  // LONG_DIVE_MAXLEN points from a 7-day window so that if the 8-hour window
+  // returns no data (vehicle submerged > 8 h), the sparkline can immediately
+  // show the last known dive profile padded forward to now — no extra round-trip.
+  // Only refetches when the primary query has already succeeded with zero points
+  // (i.e. the vehicle is actually in a long-dive scenario) to avoid unnecessary
+  // 7-day API calls in the common case where the primary has data.
+  const primarySucceededEmpty =
+    depthQuery.isSuccess && (depthQuery.data?.times.length ?? 0) === 0
+  const longDiveQuery = useQuery(
+    ['depthSparkline', 'depth', vehicle, 'longDive'],
+    () =>
+      getDepthData(
+        { vehicle, from: Date.now() - SEVEN_DAYS_MS, maxlen: LONG_DIVE_MAXLEN },
+        { instance: axiosInstance }
+      ),
+    {
+      staleTime: REFETCH_INTERVAL,
+      refetchInterval: primarySucceededEmpty ? REFETCH_INTERVAL : false,
+      // Only refetch on focus/reconnect in long-dive mode — avoids spurious 7-day requests in the common case.
+      refetchOnWindowFocus: primarySucceededEmpty,
+      refetchOnReconnect: primarySucceededEmpty,
       ...options,
       enabled: !!vehicle && options?.enabled !== false,
     }
@@ -90,19 +124,48 @@ export const useDepthSparkline = (
     const windowStart = (nowMin - 8 * 60) * 60000 // ms epoch for windowStart
     const windowStartMin = nowMin - 8 * 60
 
-    // Clamp depth data to the rolling 8-hour window and keep times/values aligned.
-    // The API is asked for the same window on each refetch, but cached data can lag
-    // by up to staleTime (2 min) so we trim defensively here as well.
-    const rawTimes = depthQuery.data?.times ?? []
-    const rawValues = depthQuery.data?.values ?? []
+    // Prefer the 8-hour window query; use the long-dive fallback only when the
+    // primary query has *completed* with zero points (vehicle submerged > 8 h).
+    // Gating on isSuccess prevents the fallback from activating during initial
+    // load (when data is still undefined) and causing a premature wide-window plot.
+    const usingFallback =
+      depthQuery.isSuccess && (depthQuery.data?.times ?? []).length === 0
+    const rawTimes = usingFallback
+      ? longDiveQuery.data?.times ?? []
+      : depthQuery.data?.times ?? []
+    const rawValues = usingFallback
+      ? longDiveQuery.data?.values ?? []
+      : depthQuery.data?.values ?? []
+
+    // Clamp depth data to the rolling 8-hour window. For the long-dive fallback,
+    // skip the time clamp — all returned points are older than 8 h by definition,
+    // and we need them to reconstruct the dive profile before padding forward.
     const safeLen = Math.min(rawTimes.length, rawValues.length)
-    const depthTimesMin: number[] = []
-    const clampedValues: number[] = []
+    let depthTimesMin: number[] = []
+    let clampedValues: number[] = []
     for (let i = 0; i < safeLen; i++) {
       const tMin = Math.floor(rawTimes[i] / 60000)
-      if (tMin >= windowStartMin) {
+      if (usingFallback || tMin >= windowStartMin) {
         depthTimesMin.push(tMin)
         clampedValues.push(rawValues[i])
+      }
+    }
+
+    // In fallback mode the payload can span multiple dive cycles. Trim to the
+    // current dive by finding the last surface event (depth < 2 m) and keeping
+    // only points from there onward. This ensures the depth scale reflects the
+    // current dive rather than a historical maximum from a previous mission.
+    if (usingFallback && clampedValues.length > 0) {
+      let lastSurfaceIdx = -1
+      for (let i = clampedValues.length - 1; i >= 0; i--) {
+        if (clampedValues[i] < SURFACE_DEPTH_M) {
+          lastSurfaceIdx = i
+          break
+        }
+      }
+      if (lastSurfaceIdx >= 0) {
+        depthTimesMin = depthTimesMin.slice(lastSurfaceIdx)
+        clampedValues = clampedValues.slice(lastSurfaceIdx)
       }
     }
 
@@ -112,11 +175,13 @@ export const useDepthSparkline = (
     let depthTimes = depthTimesMin
     let depthValues = clampedValues
     let padded = false
-    if (depthTimesMin.length > 0 && nowMin - Math.max(...depthTimesMin) > 4) {
+    if (depthTimesMin.length > 0) {
       const lastT = Math.max(...depthTimesMin)
-      depthTimes = [...depthTimesMin, lastT, lastT + 2, nowMin]
-      depthValues = [...clampedValues, 1, 10, 10]
-      padded = true
+      if (nowMin - lastT > 4) {
+        depthTimes = [...depthTimesMin, lastT, lastT + 2, nowMin]
+        depthValues = [...clampedValues, 1, 10, 10]
+        padded = true
+      }
     }
 
     // Separate comms events by type and state (matching auvstatus.py extractCommHistory).
@@ -150,11 +215,17 @@ export const useDepthSparkline = (
       argoTimes,
       padded,
     }
-  }, [depthQuery.data, commsQuery.data, nowMinBucket])
+  }, [depthQuery.data, longDiveQuery.data, commsQuery.data, nowMinBucket])
 
   return {
     data,
-    isLoading: depthQuery.isLoading || commsQuery.isLoading,
-    isError: depthQuery.isError || commsQuery.isError,
+    isLoading:
+      depthQuery.isLoading ||
+      commsQuery.isLoading ||
+      (primarySucceededEmpty && longDiveQuery.isLoading),
+    isError:
+      depthQuery.isError ||
+      commsQuery.isError ||
+      (primarySucceededEmpty && longDiveQuery.isError),
   }
 }


### PR DESCRIPTION
> **Review Order:** Copilot review by author first, then human review will be requested.

## Problem
When a vehicle has been continuously underwater without comms for more than 8 hours, the primary 8-hour depth window returns zero points, causing the sparkline to disappear entirely from the Vehicle State diagram. This was discovered last week when Triton's `needComms` was accidentally set to an unusually high value, leaving the vehicle submerged for ~20 hours — at which point the sparkline vanished from Dash5 while Dash4 continued to show the last known depth profile correctly.

Additionally, for very long dives spanning multiple prior dive cycles, Dash5 was computing the depth scale from the historical maximum across all prior dives (e.g. 120m) rather than the current dive (e.g. 40m). Dash4 displays 40m in these cases, which provides a better, more accurate view for pilots — Dash5 now displays the same.

## Solution
- Added a parallel **7-day fallback query** (`maxlen: 480`) that runs alongside the primary 8-hour query. When the primary returns empty, the fallback activates.
- Trimmed fallback data to the most recent dive cycle (points from the last surface event onward) so the depth scale reflects only the current dive — matching Dash4 behaviour.
- The existing pad-forward logic extrapolates the last known depth to "now", keeping the sparkline current.

## Testing
- 8 unit tests pass covering: normal window, padded/unpadded states, fallback activation, and surface-trim for correct depth scale.
- Validated live on staging when Triton was submerged for ~20 hours last week.

## References
- Closes #801