### PR TITLE
fix(#796): use script mission ID for set commands

### DIFF
--- a/apps/lrauv-dash2/components/MissionModal.tsx
+++ b/apps/lrauv-dash2/components/MissionModal.tsx
@@ -284,6 +284,7 @@ const MissionModal: React.FC<MissionModalProps> = ({
       previewSbd,
     } = makeMissionCommand({
       mission: missionPathForCommand,
+      missionId: selectedMissionData?.id,
       parameterOverrides,
       scheduleMethod,
       specifiedLocalTime: specifiedTime ?? undefined,

--- a/apps/lrauv-dash2/lib/makeCommand.test.ts
+++ b/apps/lrauv-dash2/lib/makeCommand.test.ts
@@ -40,6 +40,27 @@ describe('makeMissionCommand', () => {
     )
     expect(schedDate).toBe('asap')
   })
+
+  // #796: filename stem ≠ script mission ID (e.g. tritoncam_expanding_donut.tl → expanding_donut)
+  it('uses script missionId for set when it differs from the filename', () => {
+    const { commandText } = makeMissionCommand({
+      mission: 'Engineering/tritoncam_expanding_donut.tl',
+      missionId: 'expanding_donut',
+      parameterOverrides: [
+        {
+          name: 'Lat1',
+          overrideValue: '36.8',
+          unit: 'degree',
+          value: 'NaN',
+        },
+      ],
+      scheduleMethod: 'ASAP',
+    })
+    expect(commandText).toBe(
+      'load Engineering/tritoncam_expanding_donut.tl;set expanding_donut.Lat1 36.8 degree;run'
+    )
+  })
+
   it('should return a command to load a mission with parameters and insert', () => {
     const { commandText, previewSbd, schedDate } = makeMissionCommand({
       mission: 'Science/profile_station.xml',

--- a/apps/lrauv-dash2/lib/makeCommand.ts
+++ b/apps/lrauv-dash2/lib/makeCommand.ts
@@ -60,9 +60,13 @@ export const makeCommand = ({
   }
 }
 
-// Accepts a local time string and returns a formatted UTC time string
+// Accepts a local time string and returns a formatted UTC time string.
+// `mission` is the file path for `load`. `missionId` is the script's mission
+// ID from GET /commands/script (used for `set`); falls back to the filename
+// stem when omitted (e.g. path and ID match).
 export const makeMissionCommand = ({
   mission,
+  missionId,
   parameterOverrides,
   scheduleMethod,
   specifiedLocalTime,
@@ -70,11 +74,14 @@ export const makeMissionCommand = ({
 }: {
   parameterOverrides: ParameterProps[]
   mission: string
+  /** Script mission ID for `set` (may differ from the .tl filename). */
+  missionId?: string
   scheduleMethod: ScheduleMethod
   specifiedLocalTime?: string
   units?: { name: string; abbreviation: string }[]
 }) => {
-  const missionName = mission.split('/').pop()?.split('.')[0]
+  const missionName =
+    missionId?.trim() || mission.split('/').pop()?.split('.')[0]
   const commands: string[] = [`load ${mission}`]
   parameterOverrides.forEach((p) => {
     commands.push(


### PR DESCRIPTION
> **Review order:** Copilot review by author first, then human review will be requested.

`makeMissionCommand` used the `.tl` filename stem for both `load` and `set`. For missions where the script ID differs from the filename (e.g. `tritoncam_expanding_donut.tl` → ID `expanding_donut`), the `set` command was wrong.

`set` now prefers the `missionId` from `GET /commands/script`; `load` keeps the full file path. Falls back to filename stem when they match.

Verified on staging: `set profile_station.*` emitted correctly.